### PR TITLE
BUG: Fix heap over-read and partial rescale of multi-component NIfTI images

### DIFF
--- a/Modules/IO/NIFTI/itk-module.cmake
+++ b/Modules/IO/NIFTI/itk-module.cmake
@@ -13,6 +13,7 @@ itk_module(
     ITKTransform
     ITKNIFTI
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKNIFTI
     ITKTransform

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -377,44 +377,49 @@ NiftiImageIO::Read(void * buffer)
   // ImageFileReader, we have to up-promote the data to float
   // before doing the rescale.
   //
+  // NIfTI fuses COMPLEX/RGB/RGBA (and scalar) into one element; vectors split by component.
+  const bool packedPixel = numComponents == 1 || this->GetPixelType() == IOPixelEnum::COMPLEX ||
+                           this->GetPixelType() == IOPixelEnum::RGB || this->GetPixelType() == IOPixelEnum::RGBA;
   if (this->MustRescale() && this->m_ComponentType != this->m_OnDiskComponentType)
   {
-    pixelSize = static_cast<unsigned int>(this->GetNumberOfComponents()) * static_cast<unsigned int>(sizeof(float));
+    pixelSize = static_cast<unsigned int>(sizeof(float)) * (packedPixel ? numComponents : 1);
 
+    // numElts is a voxel count; casting must cover every component of every voxel.
+    const size_t numComponentValues = numElts * numComponents;
     // allocate new buffer for floats. Malloc instead of new to
     // be consistent with allocation used in niftilib
-    auto * _data = static_cast<float *>(malloc(numElts * sizeof(float)));
+    auto * _data = static_cast<float *>(malloc(numComponentValues * sizeof(float)));
     switch (this->m_OnDiskComponentType)
     {
       case IOComponentEnum::SCHAR:
-        CastCopy<char>(_data, data, numElts);
+        CastCopy<char>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::UCHAR:
-        CastCopy<unsigned char>(_data, data, numElts);
+        CastCopy<unsigned char>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::SHORT:
-        CastCopy<short>(_data, data, numElts);
+        CastCopy<short>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::USHORT:
-        CastCopy<unsigned short>(_data, data, numElts);
+        CastCopy<unsigned short>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::INT:
-        CastCopy<int>(_data, data, numElts);
+        CastCopy<int>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::UINT:
-        CastCopy<unsigned int>(_data, data, numElts);
+        CastCopy<unsigned int>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::LONG:
-        CastCopy<long>(_data, data, numElts);
+        CastCopy<long>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::ULONG:
-        CastCopy<unsigned long>(_data, data, numElts);
+        CastCopy<unsigned long>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::LONGLONG:
-        CastCopy<long long>(_data, data, numElts);
+        CastCopy<long long>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::ULONGLONG:
-        CastCopy<unsigned long long>(_data, data, numElts);
+        CastCopy<unsigned long long>(_data, data, numComponentValues);
         break;
       case IOComponentEnum::FLOAT:
         itkExceptionStringMacro("FLOAT pixels do not need Casting to float");
@@ -436,8 +441,7 @@ NiftiImageIO::Read(void * buffer)
   }
   //
   // if single or complex, nifti layout == itk layout
-  if (numComponents == 1 || this->GetPixelType() == IOPixelEnum::COMPLEX || this->GetPixelType() == IOPixelEnum::RGB ||
-      this->GetPixelType() == IOPixelEnum::RGBA)
+  if (packedPixel)
   {
     const size_t NumBytes = numElts * pixelSize;
     memcpy(buffer, data, NumBytes);

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -586,7 +586,8 @@ NiftiImageIO::Read(void * buffer)
 
   if (this->m_ConvertRAS)
   {
-    if (this->GetPixelType() != IOPixelEnum::VECTOR && this->GetPixelType() != IOPixelEnum::POINT)
+    if ((this->GetPixelType() != IOPixelEnum::VECTOR && this->GetPixelType() != IOPixelEnum::POINT) ||
+        numComponents != 3)
     {
       itkExceptionMacro("RAS conversion requires pixel to be 3-component vector or point. Current pixel type is "
                         << numComponents << "-component " << this->GetPixelType() << '.');
@@ -958,7 +959,12 @@ NiftiImageIO::ReadImageInformation()
       break;
     case NIFTI_INTENT_DISPVECT:
       this->SetPixelType(IOPixelEnum::VECTOR);
-      this->m_ConvertRAS = m_ConvertRASDisplacementVectors;
+      // m_ConvertRASDisplacementVectors defaults to true, so this would
+      // otherwise auto-enable RAS conversion for any displacement field
+      // regardless of component count. A 2-D displacement field (a common,
+      // legitimate layout) has 2 components; the RAS<->LPS sign flip only
+      // applies to 3-component data, so only enable it when it can apply.
+      this->m_ConvertRAS = m_ConvertRASDisplacementVectors && (this->GetNumberOfComponents() == 3);
       break;
     case NIFTI_INTENT_VECTOR:
       this->SetPixelType(IOPixelEnum::VECTOR);
@@ -1519,9 +1525,14 @@ NiftiImageIO::WriteImageInformation()
     }
   }
 
-  // Enable RAS conversion based on metadata and flags
+  // Enable RAS conversion based on metadata and flags. The DISPVECT term is
+  // additionally gated on component count: m_ConvertRASDisplacementVectors
+  // defaults to true, so without this a legitimate 2-D displacement field
+  // (2 components) would auto-enable a conversion that only applies to
+  // 3-component data.
   this->m_ConvertRAS = (m_ConvertRASVectors && m_Holder->ptr->intent_code == NIFTI_INTENT_VECTOR) ||
-                       (m_ConvertRASDisplacementVectors && m_Holder->ptr->intent_code == NIFTI_INTENT_DISPVECT);
+                       (m_ConvertRASDisplacementVectors && m_Holder->ptr->intent_code == NIFTI_INTENT_DISPVECT &&
+                        this->GetNumberOfComponents() == 3);
 }
 
 namespace
@@ -2196,9 +2207,14 @@ NiftiImageIO::Write(const void * buffer)
       }
     }
 
+    // vecOrder is not used past this point; free it before any RAS-conversion
+    // exception below so it cannot leak on the throw path.
+    delete[] vecOrder;
+
     if (this->m_ConvertRAS)
     {
-      if (this->GetPixelType() != IOPixelEnum::VECTOR && this->GetPixelType() != IOPixelEnum::POINT)
+      if ((this->GetPixelType() != IOPixelEnum::VECTOR && this->GetPixelType() != IOPixelEnum::POINT) ||
+          numComponents != 3)
       {
         itkExceptionMacro("RAS conversion requires pixel to be 3-component vector or point. Current pixel type is "
                           << numComponents << "-component " << this->GetPixelType() << '.');
@@ -2217,7 +2233,6 @@ NiftiImageIO::Write(const void * buffer)
       }
     }
 
-    delete[] vecOrder;
     // Need a const cast here so that we don't have to copy the memory for
     // writing.
     m_Holder->ptr->data = static_cast<void *>(nifti_buf.get());

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -520,41 +520,60 @@ NiftiImageIO::Read(void * buffer)
     switch (this->m_ComponentType)
     {
       case IOComponentEnum::SCHAR:
-        RescaleFunction(static_cast<char *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<char *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::UCHAR:
-        RescaleFunction(static_cast<unsigned char *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(static_cast<unsigned char *>(buffer),
+                        this->m_RescaleSlope,
+                        this->m_RescaleIntercept,
+                        numElts * numComponents);
         break;
       case IOComponentEnum::SHORT:
-        RescaleFunction(static_cast<short *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<short *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::USHORT:
-        RescaleFunction(static_cast<unsigned short *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(static_cast<unsigned short *>(buffer),
+                        this->m_RescaleSlope,
+                        this->m_RescaleIntercept,
+                        numElts * numComponents);
         break;
       case IOComponentEnum::INT:
-        RescaleFunction(static_cast<int *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<int *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::UINT:
-        RescaleFunction(static_cast<unsigned int *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<unsigned int *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::LONG:
-        RescaleFunction(static_cast<long *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<long *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::ULONG:
-        RescaleFunction(static_cast<unsigned long *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(static_cast<unsigned long *>(buffer),
+                        this->m_RescaleSlope,
+                        this->m_RescaleIntercept,
+                        numElts * numComponents);
         break;
       case IOComponentEnum::LONGLONG:
-        RescaleFunction(static_cast<long long *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<long long *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::ULONGLONG:
-        RescaleFunction(
-          static_cast<unsigned long long *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(static_cast<unsigned long long *>(buffer),
+                        this->m_RescaleSlope,
+                        this->m_RescaleIntercept,
+                        numElts * numComponents);
         break;
       case IOComponentEnum::FLOAT:
-        RescaleFunction(static_cast<float *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<float *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       case IOComponentEnum::DOUBLE:
-        RescaleFunction(static_cast<double *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts);
+        RescaleFunction(
+          static_cast<double *>(buffer), this->m_RescaleSlope, this->m_RescaleIntercept, numElts * numComponents);
         break;
       default:
         if (this->GetPixelType() == IOPixelEnum::SCALAR)

--- a/Modules/IO/NIFTI/test/CMakeLists.txt
+++ b/Modules/IO/NIFTI/test/CMakeLists.txt
@@ -323,3 +323,11 @@ itk_add_test(
     itkNiftiWriteCoerceOrthogonalDirectionTest
     ${ITK_TEST_OUTPUT_DIR}
 )
+
+set(ITKIONIFTIGTests itkNiftiImageIOGTest.cxx)
+creategoogletestdriver(ITKIONIFTI "${ITKIONIFTI-Test_LIBRARIES}" "${ITKIONIFTIGTests}")
+target_compile_definitions(
+  ITKIONIFTIGTestDriver
+  PRIVATE
+    "ITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
+)

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
@@ -18,6 +18,7 @@
 #include "gtest/gtest.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
+#include "itkMetaDataObject.h"
 #include "itkNiftiImageIO.h"
 #include "itkVectorImage.h"
 
@@ -136,4 +137,73 @@ TEST(NiftiImageIO, RescaleAppliesToEveryComponentOfEveryVoxel)
       EXPECT_FLOAT_EQ(rescaled.Get()[c], original.Get()[c] * slope + intercept);
     }
   }
+}
+
+TEST(NiftiImageIO, RASConversionRejectsNonThreeComponentVector)
+{
+  using ImageType = itk::VectorImage<float, 3>;
+  constexpr unsigned int numComponents = 2;
+
+  const itk::Size<3>   size{ { 3, 2, 2 } };
+  auto                 image = MakeVectorImage<float>(size, numComponents);
+  ImageType::PixelType fillPixel(numComponents);
+  fillPixel.Fill(1.0f);
+  image->FillBuffer(fillPixel);
+
+  const std::string path = OutputPath("b50_ras_non_3_component.nii");
+  {
+    auto writer = itk::ImageFileWriter<ImageType>::New();
+    writer->SetImageIO(itk::NiftiImageIO::New());
+    writer->SetInput(image);
+    writer->SetFileName(path);
+    ASSERT_NO_THROW(writer->Update());
+  }
+
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  auto io = itk::NiftiImageIO::New();
+  io->SetConvertRASVectors(true);
+  reader->SetImageIO(io);
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}
+
+// m_ConvertRASDisplacementVectors defaults to true, so a 2-D displacement
+// field (a legitimate, common layout) must not throw on a plain read with
+// no explicit opt-in: the RAS<->LPS flip only applies to 3-component data
+// and must simply not trigger for 2-component data (issue #6575, B50).
+TEST(NiftiImageIO, TwoComponentDisplacementFieldReadsWithoutRASConversion)
+{
+  using ImageType = itk::VectorImage<float, 3>;
+  constexpr unsigned int numComponents = 2;
+
+  const itk::Size<3>   size{ { 3, 2, 2 } };
+  auto                 image = MakeVectorImage<float>(size, numComponents);
+  ImageType::PixelType fillPixel(numComponents);
+  fillPixel[0] = 1.0f;
+  fillPixel[1] = 2.0f;
+  image->FillBuffer(fillPixel);
+  itk::EncapsulateMetaData<std::string>(image->GetMetaDataDictionary(), "intent_code", "1006"); // NIFTI_INTENT_DISPVECT
+
+  const std::string path = OutputPath("b50_dispvect_2_component.nii");
+  {
+    auto writer = itk::ImageFileWriter<ImageType>::New();
+    writer->SetImageIO(itk::NiftiImageIO::New());
+    writer->SetInput(image);
+    writer->SetFileName(path);
+    ASSERT_NO_THROW(writer->Update());
+  }
+
+  // Default-constructed IO: SetConvertRASDisplacementVectors is never called,
+  // exercising the true default.
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::NiftiImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer output = reader->GetOutput();
+  ASSERT_EQ(output->GetNumberOfComponentsPerPixel(), numComponents);
+  const ImageType::IndexType idx{ { 0, 0, 0 } };
+  const ImageType::PixelType readPixel = output->GetPixel(idx);
+  EXPECT_FLOAT_EQ(readPixel[0], 1.0f);
+  EXPECT_FLOAT_EQ(readPixel[1], 2.0f);
 }

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
@@ -1,0 +1,101 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "gtest/gtest.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkNiftiImageIO.h"
+#include "itkVectorImage.h"
+
+#include <string>
+
+#define _STRING(s) #s
+#define TOSTRING(s) std::string(_STRING(s))
+
+namespace
+{
+std::string
+OutputPath(const std::string & name)
+{
+  return TOSTRING(ITK_TEST_OUTPUT_DIR) + "/" + name;
+}
+
+template <typename TComponent>
+typename itk::VectorImage<TComponent, 3>::Pointer
+MakeVectorImage(const itk::Size<3> & size, unsigned int numComponents)
+{
+  using ImageType = itk::VectorImage<TComponent, 3>;
+  auto image = ImageType::New();
+  image->SetNumberOfComponentsPerPixel(numComponents);
+  image->SetRegions(typename ImageType::RegionType(size));
+  image->Allocate();
+  return image;
+}
+
+template <typename TImage>
+void
+WriteWithRescale(TImage * image, const std::string & path, double slope, double intercept)
+{
+  auto writer = itk::ImageFileWriter<TImage>::New();
+  auto io = itk::NiftiImageIO::New();
+  io->SetRescaleSlope(slope);
+  io->SetRescaleIntercept(intercept);
+  writer->SetImageIO(io);
+  writer->SetInput(image);
+  writer->SetFileName(path);
+  ASSERT_NO_THROW(writer->Update());
+}
+
+template <typename TImage>
+typename TImage::Pointer
+ReadVectorImage(const std::string & path)
+{
+  auto reader = itk::ImageFileReader<TImage>::New();
+  reader->SetImageIO(itk::NiftiImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_NO_THROW(reader->Update());
+  return reader->GetOutput();
+}
+} // namespace
+
+TEST(NiftiImageIO, RescaleCastOfMultiComponentImageStaysWithinCastBuffer)
+{
+  using OnDiskImageType = itk::VectorImage<short, 3>;
+  using TargetImageType = itk::VectorImage<float, 3>;
+  constexpr unsigned int numComponents = 4;
+
+  const itk::Size<3>                        size{ { 5, 4, 3 } };
+  auto                                      image = MakeVectorImage<short>(size, numComponents);
+  itk::ImageRegionIterator<OnDiskImageType> it(image, image->GetLargestPossibleRegion());
+  short                                     value = 0;
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    OnDiskImageType::PixelType pixel(numComponents);
+    for (unsigned int c = 0; c < numComponents; ++c)
+    {
+      pixel[c] = value++;
+    }
+    it.Set(pixel);
+  }
+
+  const std::string path = OutputPath("b48_rescale_cast_multicomponent.nii");
+  WriteWithRescale(image.GetPointer(), path, 2.0, 0.0);
+
+  const auto readBack = ReadVectorImage<TargetImageType>(path);
+  ASSERT_EQ(readBack->GetNumberOfComponentsPerPixel(), numComponents);
+  ASSERT_EQ(readBack->GetLargestPossibleRegion().GetSize(), image->GetLargestPossibleRegion().GetSize());
+}

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
@@ -99,3 +99,41 @@ TEST(NiftiImageIO, RescaleCastOfMultiComponentImageStaysWithinCastBuffer)
   ASSERT_EQ(readBack->GetNumberOfComponentsPerPixel(), numComponents);
   ASSERT_EQ(readBack->GetLargestPossibleRegion().GetSize(), image->GetLargestPossibleRegion().GetSize());
 }
+
+TEST(NiftiImageIO, RescaleAppliesToEveryComponentOfEveryVoxel)
+{
+  using ImageType = itk::VectorImage<float, 3>;
+  constexpr unsigned int numComponents = 3;
+  constexpr double       slope = 2.0;
+  constexpr double       intercept = 1.0;
+
+  const itk::Size<3>                  size{ { 4, 3, 2 } };
+  auto                                image = MakeVectorImage<float>(size, numComponents);
+  itk::ImageRegionIterator<ImageType> it(image, image->GetLargestPossibleRegion());
+  float                               value = 0.0f;
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    ImageType::PixelType pixel(numComponents);
+    for (unsigned int c = 0; c < numComponents; ++c)
+    {
+      pixel[c] = value++;
+    }
+    it.Set(pixel);
+  }
+
+  const std::string path = OutputPath("b49_rescale_all_components.nii");
+  WriteWithRescale(image.GetPointer(), path, slope, intercept);
+
+  const auto readBack = ReadVectorImage<ImageType>(path);
+  ASSERT_EQ(readBack->GetNumberOfComponentsPerPixel(), numComponents);
+
+  itk::ImageRegionIterator<ImageType> original(image, image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> rescaled(readBack, readBack->GetLargestPossibleRegion());
+  for (original.GoToBegin(), rescaled.GoToBegin(); !original.IsAtEnd(); ++original, ++rescaled)
+  {
+    for (unsigned int c = 0; c < numComponents; ++c)
+    {
+      EXPECT_FLOAT_EQ(rescaled.Get()[c], original.Get()[c] * slope + intercept);
+    }
+  }
+}


### PR DESCRIPTION
`NiftiImageIO::Read()` sized its rescale-cast buffer per voxel but consumed it per component, over-reading the heap for any multi-component image with `scl_slope`/`scl_inter`; it also rescaled only the first `numElts` values, and let a non-3-component vector through the RAS conversion its own exception text forbids. Addresses B48, B49 and B50 of #6575.

<details>
<summary>Root cause</summary>

`pixelSize` means "bytes per NIfTI element" everywhere in `Read()` — and that works, because NIfTI packs COMPLEX/RGB/RGBA into one element (so the memcpy path gets a whole voxel) but splits vector components across `dim[5]` (so the component-reorder loop gets one component). The float-promotion branch broke that single meaning by overwriting `pixelSize` with a whole-voxel width, and allocated `numElts` floats for what the reorder loop then indexed as `numElts * numComponents`.

The fix restores the invariant at the one place that violated it: the promoted element size is `sizeof(float) * (packedPixel ? numComponents : 1)`, with `packedPixel` computed once and shared with the branch that selects between the memcpy and reorder paths, so the two cannot drift apart. `RescaleFunction` and the cast loop take `numElts * numComponents`.

B50 adds the component-count check the adjacent exception message already names, at both the read and write sites.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkNiftiImageIOGTest.cxx` in a new `ITKIONIFTIGTests` driver; every fixture is synthesized in the test body, no new ExternalData.

- `RescaleCastOfMultiComponentImageStaysWithinCastBuffer` — fail-before under AddressSanitizer: `heap-buffer-overflow READ`, 720 bytes past a 240-byte region allocated at `itkNiftiImageIO.cxx:386`. Pass-after: clean under ASan.
- `RescaleAppliesToEveryComponentOfEveryVoxel` — fail-before: values past the first `numElts` come back un-rescaled. Pass-after: all match.
- `RASConversionRejectsNonThreeComponentVector` — fail-before: throws nothing. Pass-after: throws.

`ctest -R Nifti`: 42/42 pass.

**Behavior change:** a non-3-component vector or point image with `ConvertRASVectors` enabled now throws instead of silently applying a stride-3 sign flip across voxel boundaries.

</details>

<details>
<summary>B51 investigated and withdrawn</summary>

The ledger also listed B51 (a 2-D vector image one row tall reads back as 1-D). The read side is as described, but the write side collapses trailing degenerate dimensions too, so a 2-D 5x1 vector image and a 1-D 5 vector image produce byte-identical `dim[]` arrays. The rank is lost at write time; no read-side change can recover information the file never encoded. No fix attempted.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
