### PR TITLE
BUG: Fix null metadata cast and unchecked geometry lengths in HDF5ImageIO

### DIFF
--- a/Modules/IO/HDF5/itk-module.cmake
+++ b/Modules/IO/HDF5/itk-module.cmake
@@ -13,6 +13,7 @@ itk_module(
   PRIVATE_DEPENDS
     ITKHDF5
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageSources
   FACTORY_NAMES

--- a/Modules/IO/HDF5/itk-module.cmake
+++ b/Modules/IO/HDF5/itk-module.cmake
@@ -16,6 +16,7 @@ itk_module(
     ITKGoogleTest
     ITKTestKernel
     ITKImageSources
+    ITKHDF5
   FACTORY_NAMES
     ImageIO::HDF5
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -1325,15 +1325,15 @@ HDF5ImageIO::WriteImageInformation()
       // C String Arrays
       {
         auto * cstringObj = dynamic_cast<MetaDataObject<char *> *>(metaObj);
-        auto * constCstringObj = dynamic_cast<MetaDataObject<const char *> *>(metaObj);
-        if (cstringObj != nullptr || constCstringObj != nullptr)
+        if (cstringObj != nullptr)
         {
-          const char * val = constCstringObj->GetMetaDataObjectValue();
-          if (cstringObj != nullptr)
-          {
-            val = cstringObj->GetMetaDataObjectValue();
-          }
-          this->WriteString(objName, val);
+          this->WriteString(objName, cstringObj->GetMetaDataObjectValue());
+          continue;
+        }
+        auto * constCstringObj = dynamic_cast<MetaDataObject<const char *> *>(metaObj);
+        if (constCstringObj != nullptr)
+        {
+          this->WriteString(objName, constCstringObj->GetMetaDataObjectValue());
           continue;
         }
       }

--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -709,13 +709,32 @@ HDF5ImageIO::ReadImageInformation()
 
     std::vector<std::vector<double>> directions = this->ReadDirections(DirectionsName);
 
-    auto numDims = static_cast<int>(directions.size());
+    const auto numDims = static_cast<int>(directions.size());
+    if (numDims < 1)
+    {
+      itkExceptionMacro("Directions has no rows in HDF5 File, expected at least 1");
+    }
+    for (const std::vector<double> & direction : directions)
+    {
+      if (direction.size() != static_cast<size_t>(numDims))
+      {
+        itkExceptionMacro("Directions row has " << direction.size() << " entries in HDF5 File, expected " << numDims);
+      }
+    }
     this->SetNumberOfDimensions(numDims);
 
     // H5::Group instanceGroup(m_H5File->openGroup(groupName));
     std::string OriginName(groupName);
     OriginName += Origin;
-    this->m_Origin = this->ReadVector<double>(OriginName);
+    const std::vector<double> origin = this->ReadVector<double>(OriginName);
+    if (origin.size() != static_cast<size_t>(numDims))
+    {
+      itkExceptionMacro("Origin has " << origin.size() << " entries in HDF5 File, expected " << numDims);
+    }
+    for (int i = 0; i < numDims; ++i)
+    {
+      this->SetOrigin(i, origin[i]);
+    }
 
     for (int i = 0; i < numDims; ++i)
     {
@@ -724,7 +743,11 @@ HDF5ImageIO::ReadImageInformation()
 
     std::string SpacingName(groupName);
     SpacingName += Spacing;
-    std::vector<double> spacing = this->ReadVector<double>(SpacingName);
+    const std::vector<double> spacing = this->ReadVector<double>(SpacingName);
+    if (spacing.size() != static_cast<size_t>(numDims))
+    {
+      itkExceptionMacro("Spacing has " << spacing.size() << " entries in HDF5 File, expected " << numDims);
+    }
     for (int i = 0; i < numDims; ++i)
     {
       this->SetSpacing(i, spacing[i]);
@@ -735,6 +758,10 @@ HDF5ImageIO::ReadImageInformation()
 
     {
       std::vector<ImageIOBase::SizeValueType> Dims = this->ReadVector<ImageIOBase::SizeValueType>(DimensionsName);
+      if (Dims.size() != static_cast<size_t>(numDims))
+      {
+        itkExceptionMacro("Dimension has " << Dims.size() << " entries in HDF5 File, expected " << numDims);
+      }
       for (int i = 0; i < numDims; ++i)
       {
         this->SetDimensions(i, Dims[i]);
@@ -921,6 +948,11 @@ HDF5ImageIO::ReadImageInformation()
       }
     }
     imageSet.close();
+  }
+  // Preserve the description of exceptions thrown by ITK itself.
+  catch (const ExceptionObject &)
+  {
+    throw;
   }
   // catch failure caused by the H5File operations
   catch (const H5::AttributeIException & error)

--- a/Modules/IO/HDF5/test/CMakeLists.txt
+++ b/Modules/IO/HDF5/test/CMakeLists.txt
@@ -7,6 +7,12 @@ set(
 
 createtestdriver(ITKIOHDF5 "${ITKIOHDF5-Test_LIBRARIES}" "${ITKIOHDF5Tests}")
 
+set(
+  ITKIOHDF5GTests
+  itkHDF5ImageIOGTest.cxx
+)
+creategoogletestdriver(ITKIOHDF5 "${ITKIOHDF5-Test_LIBRARIES}" "${ITKIOHDF5GTests}")
+
 itk_add_test(
   NAME itkHDF5ImageIOTest
   COMMAND

--- a/Modules/IO/HDF5/test/CMakeLists.txt
+++ b/Modules/IO/HDF5/test/CMakeLists.txt
@@ -7,11 +7,13 @@ set(
 
 createtestdriver(ITKIOHDF5 "${ITKIOHDF5-Test_LIBRARIES}" "${ITKIOHDF5Tests}")
 
-set(
-  ITKIOHDF5GTests
-  itkHDF5ImageIOGTest.cxx
-)
+set(ITKIOHDF5GTests itkHDF5ImageIOGTest.cxx)
 creategoogletestdriver(ITKIOHDF5 "${ITKIOHDF5-Test_LIBRARIES}" "${ITKIOHDF5GTests}")
+target_compile_definitions(
+  ITKIOHDF5GTestDriver
+  PRIVATE
+    "ITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
+)
 
 itk_add_test(
   NAME itkHDF5ImageIOTest

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOGTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOGTest.cxx
@@ -17,34 +17,156 @@
  *=========================================================================*/
 #include "itkHDF5ImageIO.h"
 #include "itkMetaDataObject.h"
+#include "itk_H5Cpp.h"
 #include "itkGTest.h"
 
+#include <algorithm>
+#include <cstdint>
 #include <string>
+#include <vector>
 
-TEST(HDF5ImageIO, WriteImageInformationNonConstCStringMetaDataRoundTrips)
+#define _STRING(s) #s
+#define TOSTRING(s) _STRING(s)
+
+namespace
 {
-  const std::string path = std::string(::testing::TempDir()) + "/itkHDF5ImageIOGTest_cstring_meta.hdf5";
+std::string
+TestFilePath(const std::string & name)
+{
+  return std::string(TOSTRING(ITK_TEST_OUTPUT_DIR)) + "/itkHDF5ImageIOGTest_" + name + ".hdf5";
+}
+
+// Writes the geometry datasets of an ITK HDF5 image directly, so that a dataset
+// length can disagree with the dimension count the Directions dataset implies.
+void
+WriteGeometryFixture(const std::string &                path,
+                     const std::vector<double> &        origin,
+                     const std::vector<double> &        spacing,
+                     const std::vector<std::uint64_t> & dimensions,
+                     const hsize_t                      directionRows = 2,
+                     const hsize_t                      directionColumns = 2)
+{
+  H5::H5File file(path, H5F_ACC_TRUNC);
+  file.createGroup("/ITKImage");
+  file.createGroup("/ITKImage/0");
+
+  const auto writeVector = [&file](const std::string & name, const auto & values, const H5::PredType & type) {
+    const hsize_t       count = values.size();
+    const H5::DataSpace space(1, &count);
+    H5::DataSet         dataSet = file.createDataSet(name, type, space);
+    if (count > 0)
+    {
+      dataSet.write(values.data(), type);
+    }
+  };
+
+  writeVector("/ITKImage/0/Origin", origin, H5::PredType::NATIVE_DOUBLE);
+  writeVector("/ITKImage/0/Spacing", spacing, H5::PredType::NATIVE_DOUBLE);
+  writeVector("/ITKImage/0/Dimension", dimensions, H5::PredType::NATIVE_UINT64);
+
+  std::vector<double> directions(directionRows * directionColumns, 0.0);
+  for (hsize_t i = 0; i < std::min(directionRows, directionColumns); ++i)
+  {
+    directions[i * directionRows + i] = 1.0;
+  }
+  const hsize_t       directionDims[2] = { directionColumns, directionRows };
+  const H5::DataSpace directionSpace(2, directionDims);
+  H5::DataSet directionSet = file.createDataSet("/ITKImage/0/Directions", H5::PredType::NATIVE_DOUBLE, directionSpace);
+  directionSet.write(directions.data(), H5::PredType::NATIVE_DOUBLE);
+
+  file.createGroup("/ITKImage/0/MetaData");
+
+  const unsigned char voxels[4] = { 0, 0, 0, 0 };
+  const hsize_t       voxelDims[2] = { 2, 2 };
+  const H5::DataSpace voxelSpace(2, voxelDims);
+  H5::DataSet         voxelSet = file.createDataSet("/ITKImage/0/VoxelData", H5::PredType::NATIVE_UCHAR, voxelSpace);
+  voxelSet.write(voxels, H5::PredType::NATIVE_UCHAR);
+}
+
+// Returns the description of the exception thrown by ReadImageInformation, or an empty string when it does not throw.
+std::string
+ReadImageInformationDescription(const std::string & path)
+{
+  auto io = itk::HDF5ImageIO::New();
+  io->SetFileName(path);
+  try
+  {
+    io->ReadImageInformation();
+  }
+  catch (const itk::ExceptionObject & error)
+  {
+    return error.GetDescription();
+  }
+  return {};
+}
+} // namespace
+
+TEST(HDF5ImageIO, ReadImageInformationAcceptsConsistentGeometry)
+{
+  const std::string path = TestFilePath("consistent");
+  ASSERT_NO_THROW(WriteGeometryFixture(path, { 0.0, 0.0 }, { 1.0, 1.0 }, { 2, 2 }));
 
   auto io = itk::HDF5ImageIO::New();
   io->SetFileName(path);
-  io->SetNumberOfDimensions(2);
-  io->SetDimensions(0, 2);
-  io->SetDimensions(1, 2);
-  io->SetSpacing(0, 1.0);
-  io->SetSpacing(1, 1.0);
-  io->SetOrigin(0, 0.0);
-  io->SetOrigin(1, 0.0);
-  io->SetDirection(0, std::vector<double>{ 1.0, 0.0 });
-  io->SetDirection(1, std::vector<double>{ 0.0, 1.0 });
-  io->SetNumberOfComponents(1);
-  io->SetPixelType(itk::IOPixelEnum::SCALAR);
-  io->SetComponentType(itk::IOComponentEnum::UCHAR);
+  ASSERT_NO_THROW(io->ReadImageInformation());
+  EXPECT_EQ(io->GetNumberOfDimensions(), 2);
+}
 
-  char   value[] = "payload";
-  char * cstr = value;
-  itk::EncapsulateMetaData<char *>(io->GetMetaDataDictionary(), "CStringMeta", cstr);
+TEST(HDF5ImageIO, ReadImageInformationRejectsTruncatedOrigin)
+{
+  const std::string path = TestFilePath("short_origin");
+  ASSERT_NO_THROW(WriteGeometryFixture(path, { 0.0 }, { 1.0, 1.0 }, { 2, 2 }));
 
-  ASSERT_NO_THROW(io->WriteImageInformation());
+  EXPECT_NE(ReadImageInformationDescription(path).find("Origin has 1 entries"), std::string::npos);
+}
+
+TEST(HDF5ImageIO, ReadImageInformationRejectsTruncatedSpacing)
+{
+  const std::string path = TestFilePath("short_spacing");
+  ASSERT_NO_THROW(WriteGeometryFixture(path, { 0.0, 0.0 }, { 1.0 }, { 2, 2 }));
+
+  EXPECT_NE(ReadImageInformationDescription(path).find("Spacing has 1 entries"), std::string::npos);
+}
+
+TEST(HDF5ImageIO, ReadImageInformationRejectsTruncatedDimension)
+{
+  const std::string path = TestFilePath("short_dimension");
+  ASSERT_NO_THROW(WriteGeometryFixture(path, { 0.0, 0.0 }, { 1.0, 1.0 }, { 2 }));
+
+  EXPECT_NE(ReadImageInformationDescription(path).find("Dimension has 1 entries"), std::string::npos);
+}
+
+TEST(HDF5ImageIO, ReadImageInformationRejectsNonSquareDirections)
+{
+  const std::string path = TestFilePath("short_directions");
+  ASSERT_NO_THROW(WriteGeometryFixture(path, { 0.0, 0.0 }, { 1.0, 1.0 }, { 2, 2 }, 2, 1));
+
+  EXPECT_NE(ReadImageInformationDescription(path).find("Directions row has 1 entries"), std::string::npos);
+}
+
+TEST(HDF5ImageIO, WriteImageInformationCStringMetaDataRoundTrips)
+{
+  const std::string path = TestFilePath("cstring_meta");
+
+  char         value[] = "payload";
+  char * const cstr = value;
+  const char * constCstr = "const payload";
+
+  {
+    auto io = itk::HDF5ImageIO::New();
+    io->SetFileName(path);
+    io->SetNumberOfDimensions(2);
+    io->SetDimensions(0, 2);
+    io->SetDimensions(1, 2);
+    io->SetNumberOfComponents(1);
+    io->SetPixelType(itk::IOPixelEnum::SCALAR);
+    io->SetComponentType(itk::IOComponentEnum::UCHAR);
+
+    itk::EncapsulateMetaData<char *>(io->GetMetaDataDictionary(), "CStringMeta", cstr);
+    itk::EncapsulateMetaData<const char *>(io->GetMetaDataDictionary(), "ConstCStringMeta", constCstr);
+
+    ASSERT_NO_THROW(io->WriteImageInformation());
+  } // io goes out of scope, closing the file it holds open.
 
   auto readIO = itk::HDF5ImageIO::New();
   readIO->SetFileName(path);
@@ -53,4 +175,8 @@ TEST(HDF5ImageIO, WriteImageInformationNonConstCStringMetaDataRoundTrips)
   std::string readValue;
   ASSERT_TRUE(itk::ExposeMetaData<std::string>(readIO->GetMetaDataDictionary(), "CStringMeta", readValue));
   EXPECT_EQ(readValue, "payload");
+
+  std::string readConstValue;
+  ASSERT_TRUE(itk::ExposeMetaData<std::string>(readIO->GetMetaDataDictionary(), "ConstCStringMeta", readConstValue));
+  EXPECT_EQ(readConstValue, "const payload");
 }

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOGTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOGTest.cxx
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkHDF5ImageIO.h"
+#include "itkMetaDataObject.h"
+#include "itkGTest.h"
+
+#include <string>
+
+TEST(HDF5ImageIO, WriteImageInformationNonConstCStringMetaDataRoundTrips)
+{
+  const std::string path = std::string(::testing::TempDir()) + "/itkHDF5ImageIOGTest_cstring_meta.hdf5";
+
+  auto io = itk::HDF5ImageIO::New();
+  io->SetFileName(path);
+  io->SetNumberOfDimensions(2);
+  io->SetDimensions(0, 2);
+  io->SetDimensions(1, 2);
+  io->SetSpacing(0, 1.0);
+  io->SetSpacing(1, 1.0);
+  io->SetOrigin(0, 0.0);
+  io->SetOrigin(1, 0.0);
+  io->SetDirection(0, std::vector<double>{ 1.0, 0.0 });
+  io->SetDirection(1, std::vector<double>{ 0.0, 1.0 });
+  io->SetNumberOfComponents(1);
+  io->SetPixelType(itk::IOPixelEnum::SCALAR);
+  io->SetComponentType(itk::IOComponentEnum::UCHAR);
+
+  char   value[] = "payload";
+  char * cstr = value;
+  itk::EncapsulateMetaData<char *>(io->GetMetaDataDictionary(), "CStringMeta", cstr);
+
+  ASSERT_NO_THROW(io->WriteImageInformation());
+
+  auto readIO = itk::HDF5ImageIO::New();
+  readIO->SetFileName(path);
+  ASSERT_NO_THROW(readIO->ReadImageInformation());
+
+  std::string readValue;
+  ASSERT_TRUE(itk::ExposeMetaData<std::string>(readIO->GetMetaDataDictionary(), "CStringMeta", readValue));
+  EXPECT_EQ(readValue, "payload");
+}


### PR DESCRIPTION
`HDF5ImageIO::WriteImageInformation()` dereferences a null `dynamic_cast` result for a `MetaDataObject<char *>`, and `ReadImageInformation()` indexes the geometry vectors to `numDims` without checking the datasets are actually that long. Addresses B73 and B74 of #6575.

<details>
<summary>Root cause</summary>

**B73:** the C-string branch guards with `cstringObj != nullptr || constCstringObj != nullptr` and then unconditionally dereferences `constCstringObj`. `MetaDataObject<char *>` and `MetaDataObject<const char *>` are unrelated instantiations, so only one cast can succeed — a `char *` entry makes the other null, and it is the one that gets dereferenced.

**B74:** `numDims` comes from the Directions dataset, but Origin, Spacing and Dimension are read with `ReadVector` and then indexed to `numDims` regardless of their own length. A file whose geometry datasets disagree over-reads a heap vector before any pixel is touched.

`Directions` itself — the dataset `numDims` is *derived from* — was equally unchecked: `ReadDirections()` returns `dim[1]` rows of `dim[0]` entries and never compares the two, so a non-square matrix yields direction rows shorter than `numDims`. All four geometry datasets are now validated for an exact length match.

Exception descriptions only reach the caller because `ExceptionObject` is now rethrown unchanged: every throw inside `ReadImageInformation()` was previously caught by the trailing `catch (...)` and replaced with `"Unspecified error occurred during ReadImageInformation"`.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkHDF5ImageIOGTest.cxx`, fixtures written in the test body, no ExternalData. Assertions match on the exception description, so they cannot pass on an unrelated failure.

| Test | Fail-before | Pass-after |
|---|---|---|
| `ReadImageInformationAcceptsConsistentGeometry` | positive control | passes |
| `ReadImageInformationRejectsTruncatedOrigin` / `...Spacing` / `...Dimension` | silent out-of-bounds read, or generic `"Unspecified error"` description | throws, description names the dataset |
| `ReadImageInformationRejectsNonSquareDirections` | loads with silently wrong direction cosines | throws |
| `WriteImageInformationCStringMetaDataRoundTrips` | SIGSEGV at `-O0`; also covers the `const char *` branch | passes |

`ctest -R HDF5`: 8/8 pass, no result changes.

Note: the `char *` metadata test is a `-O0`/sanitizer canary. At `-O1`+ the optimizer sinks the dead load of the null cast into the not-taken branch, so the unfixed code does not fault in an optimized build.

</details>

<details>
<summary>B75 investigated and withdrawn</summary>

The ledger also listed B75 (`Read()` passes the file datatype as `H5Dread`'s memory type, so a `STD_I16BE` dataset should read back byte-swapped). The code is as described, but the path is unreachable: `ReadImageInformation()` runs `PredTypeToComponentType()`, which requires an exact `H5Tequal` match against a `NATIVE_*` predtype and throws otherwise — and it populates `m_VoxelDataSet`, so `Read()` cannot run before it succeeds. Writing a `STD_I16BE` VoxelData and reading it back throws during `ReadImageInformation()`; with `STD_I16LE` on this host the file type is bit-identical to `NATIVE_SHORT` and the line is a no-op. There is no reachable failure to fix, so no change was made.

</details>

<details>
<summary>Known limitations left for follow-up</summary>

- `WriteString(const std::string &, const char * s)` does `std::string _s(s)` with no null check, so a `MetaDataObject<char *>` holding `nullptr` is still UB. Out of scope for B73, which concerns the null *cast* rather than the null *value*.
- `WriteImageInformation()` silently drops metadata whose type is outside the hardcoded cast list (e.g. `Array<long long>`, which the reader can itself produce).
- No catch handler calls `ResetToInitialState()`, so a rejected file leaves the ImageIO holding an open HDF5 handle.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
