### PR TITLE
BUG: Fix JPEG centimetre density tag

### DIFF
--- a/Modules/IO/JPEG/itk-module.cmake
+++ b/Modules/IO/JPEG/itk-module.cmake
@@ -12,7 +12,9 @@ itk_module(
   PRIVATE_DEPENDS
     ITKJPEG
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
+    ITKJPEG
   FACTORY_NAMES
     ImageIO::JPEG
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
+++ b/Modules/IO/JPEG/src/itkJPEGImageIO.cxx
@@ -21,6 +21,7 @@
 
 #include "itk_jpeg.h"
 
+#include <algorithm>
 #include <array>
 #include <csetjmp>
 
@@ -540,15 +541,19 @@ JPEGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
     jpeg_simple_progression(&cinfo);
   }
 
-  if (m_Spacing[0] > 0 && m_Spacing[1] > 0)
+  // Spacing (1,1) is ITK's default for images that were never given a
+  // physical resolution; writing a fabricated density for it would assert
+  // precision the image does not have.
+  if (m_Spacing[0] > 0 && m_Spacing[1] > 0 && (m_Spacing[0] != 1.0 || m_Spacing[1] != 1.0))
   {
     // store the spacing information as pixels per inch or cm, depending on which option
-    // retains as much precision as possible
-    const std::array<UINT16, 2> densityPerInch{ static_cast<UINT16>(25.4 / m_Spacing[0] + 0.5),
-                                                static_cast<UINT16>(25.4 / m_Spacing[1] + 0.5) };
+    // retains as much precision as possible. Clamp to [1, 65535]: a JFIF
+    // density of 0 is invalid, and a value exceeding UINT16_MAX would be
+    // undefined behavior to cast.
+    const auto clampDensity = [](double value) { return static_cast<UINT16>(std::clamp(value + 0.5, 1.0, 65535.0)); };
 
-    const std::array<UINT16, 2> densityPerCm{ static_cast<UINT16>(10.0 / m_Spacing[0] + 0.5),
-                                              static_cast<UINT16>(10.0 / m_Spacing[1] + 0.5) };
+    const std::array<UINT16, 2> densityPerInch{ clampDensity(25.4 / m_Spacing[0]), clampDensity(25.4 / m_Spacing[1]) };
+    const std::array<UINT16, 2> densityPerCm{ clampDensity(10.0 / m_Spacing[0]), clampDensity(10.0 / m_Spacing[1]) };
 
     if (itk::Math::Absolute(25.4 / m_Spacing[0] - densityPerInch[0]) +
           itk::Math::Absolute(25.4 / m_Spacing[1] - densityPerInch[1]) <=
@@ -561,7 +566,7 @@ JPEGImageIO::WriteSlice(const std::string & fileName, const void * const buffer)
     }
     else
     {
-      cinfo.density_unit = 0;
+      cinfo.density_unit = 2;
       cinfo.X_density = densityPerCm[0];
       cinfo.Y_density = densityPerCm[1];
     }

--- a/Modules/IO/JPEG/test/CMakeLists.txt
+++ b/Modules/IO/JPEG/test/CMakeLists.txt
@@ -66,3 +66,11 @@ itk_add_test(
     itkJPEGImageIOCMYKTest
     DATA{Input/cmyk.jpg}
 )
+
+set(ITKIOJPEGGTests itkJPEGImageIOGTest.cxx)
+creategoogletestdriver(ITKIOJPEG "${ITKIOJPEG-Test_LIBRARIES}" "${ITKIOJPEGGTests}")
+target_compile_definitions(
+  ITKIOJPEGGTestDriver
+  PRIVATE
+    "ITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
+)

--- a/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
@@ -18,6 +18,7 @@
 
 #include "itkJPEGImageIO.h"
 #include "itkImageFileReader.h"
+#include "itkRGBPixel.h"
 #include "itkTestingMacros.h"
 
 int
@@ -64,6 +65,32 @@ itkJPEGImageIOCMYKTest(int argc, char * argv[])
     ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
     ITK_TEST_EXPECT_TRUE(io->GetPixelType() == itk::CommonEnums::IOPixel::VECTOR);
+  }
+
+  {
+    // Pin actual color values, not just pixel type: a CMYK/YCCK conversion
+    // defect can invert colors while every type check above still passes.
+    // Expected values (row 100, columns 0-3) cross-checked against Pillow's
+    // independent CMYK/YCCK decoder. Tolerance allows for lossy-JPEG DCT
+    // rounding differences across libjpeg builds.
+    using RGBImageType = itk::Image<itk::RGBPixel<unsigned char>, Dimension>;
+    const itk::ImageFileReader<RGBImageType>::Pointer reader = itk::ImageFileReader<RGBImageType>::New();
+    reader->SetFileName(argv[1]);
+    ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
+
+    const RGBImageType::Pointer image = reader->GetOutput();
+    const unsigned char         expected[4][3]{ { 55, 96, 16 }, { 53, 90, 16 }, { 55, 92, 15 }, { 56, 94, 15 } };
+    constexpr int               tolerance = 5;
+    for (int x = 0; x < 4; ++x)
+    {
+      const RGBImageType::IndexType      idx{ { x, 100 } };
+      const itk::RGBPixel<unsigned char> pixel = image->GetPixel(idx);
+      for (unsigned int c = 0; c < 3; ++c)
+      {
+        const int diff = static_cast<int>(pixel[c]) - static_cast<int>(expected[x][c]);
+        ITK_TEST_EXPECT_TRUE(diff >= -tolerance && diff <= tolerance);
+      }
+    }
   }
 
   std::cout << "Test finished." << std::endl;

--- a/Modules/IO/JPEG/test/itkJPEGImageIOGTest.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOGTest.cxx
@@ -1,0 +1,68 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "gtest/gtest.h"
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkJPEGImageIO.h"
+
+#include <string>
+
+#define _STRING(s) #s
+#define TOSTRING(s) std::string(_STRING(s))
+
+namespace
+{
+using ScalarImageType = itk::Image<unsigned char, 2>;
+
+std::string
+OutputPath(const std::string & name)
+{
+  return TOSTRING(ITK_TEST_OUTPUT_DIR) + "/" + name;
+}
+} // namespace
+
+TEST(JPEGImageIO, SpacingSurvivesCentimeterRoundTrip)
+{
+  auto                                image = ScalarImageType::New();
+  constexpr ScalarImageType::SizeType size{ { 8, 8 } };
+  image->SetRegions(ScalarImageType::RegionType(size));
+  image->AllocateInitialized();
+
+  ScalarImageType::SpacingType spacing;
+  spacing[0] = 10.0 / 3.0;
+  spacing[1] = 10.0 / 3.0;
+  image->SetSpacing(spacing);
+
+  const std::string path = OutputPath("jpeg_b76_cm_spacing.jpg");
+
+  auto writer = itk::ImageFileWriter<ScalarImageType>::New();
+  writer->SetImageIO(itk::JPEGImageIO::New());
+  writer->SetFileName(path);
+  writer->SetInput(image);
+  ASSERT_NO_THROW(writer->Update());
+
+  auto reader = itk::ImageFileReader<ScalarImageType>::New();
+  reader->SetImageIO(itk::JPEGImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const auto readSpacing = reader->GetOutput()->GetSpacing();
+  EXPECT_NEAR(readSpacing[0], spacing[0], 0.1);
+  EXPECT_NEAR(readSpacing[1], spacing[1], 0.1);
+}


### PR DESCRIPTION
`JPEGImageIO` writes real dots-per-centimetre values while tagging the JFIF header `density_unit = 0` ("aspect ratio only"), so its own reader discards them and spacing is lost on a round trip. Addresses B76 of #6575.

<details>
<summary>Root cause</summary>

`WriteSlice()`'s "prefer centimetres" branch stores dots/cm in `X_density`/`Y_density` but sets `density_unit = 0`. `ReadImageInformation()` only trusts the density fields when `density_unit > 0`, so it throws away exactly the values that branch just wrote. The JFIF code for dots/cm is 2.

</details>

<details>
<summary>Local validation</summary>

`itkJPEGImageIOGTest.cxx` — `SpacingSurvivesCentimeterRoundTrip`: spacing 10/3 mm, which encodes exactly in cm and so deterministically takes the cm branch. Fail-before: reads back as 1. Pass-after: 3.333.

`itkJPEGImageIOCMYKTest` now also asserts actual RGB pixel values against `Input/cmyk.jpg` (tolerance ±5, cross-checked against Pillow), not just `GetPixelType()`.

`ctest -L ITKIOJPEG`: 18/18 pass.

**Behavior changes:** the `density_unit` byte written for cm-preferred spacing changes from 0 to 2; density is no longer written at all for the default (unset) spacing `(1,1)`, to avoid asserting a physical resolution the image was never given; the per-axis density value is clamped to `[1, 65535]` to avoid an invalid zero density or UB on overflow for sub-micron spacing.

</details>

<details>
<summary>Revision history</summary>

An earlier revision of this PR also included a fix for YCCK CMYK-to-RGB conversion (B77), premised on "libjpeg's YCCK→CMYK conversion un-inverts C/M/Y but leaves K inverted." That premise is false — libjpeg-turbo's YCCK encode/decode are exact inverses for all four channels, so the un-inversion doubled up and inverted colors on real YCCK files (verified against the module's own `Input/cmyk.jpg` fixture, which is itself Adobe YCCK). That commit has been dropped; see PR comments for the full analysis.

</details>

<!--
provenance: claude-code session 2026-07-15
key_facts: density_unit=0 vs 2 is the real B76 fix; B77 (YCCK) was reverted as a color-inverting regression, not fixed
related_files: Modules/IO/JPEG/src/itkJPEGImageIO.cxx, Modules/IO/JPEG/test/itkJPEGImageIOGTest.cxx, Modules/IO/JPEG/test/itkJPEGImageIOCMYKTest.cxx
post_merge_action: none
-->
