### PR TITLE
BUG: Fix GDCM single-bit row padding and single-valued PixelSpacing

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -357,21 +357,19 @@ GDCMImageIO::Read(void * pointer)
 
   if (m_SingleBit)
   {
-    const auto copy = make_unique_for_overwrite<unsigned char[]>(len);
-    auto *     t = reinterpret_cast<unsigned char *>(pointer);
-    size_t     j = 0;
-    for (size_t i = 0; i < len / 8; ++i)
+    const auto   copy = make_unique_for_overwrite<unsigned char[]>(len);
+    const auto * t = reinterpret_cast<const unsigned char *>(pointer);
+    const size_t width = m_Dimensions[0];
+    const size_t bytesPerRow = (width + 7) / 8;
+    const size_t rowCount = len / width;
+    size_t       outIndex = 0;
+    for (size_t row = 0; row < rowCount; ++row)
     {
-      const unsigned char c = t[i];
-      copy[j + 0] = (c & 0x01) ? 255 : 0;
-      copy[j + 1] = (c & 0x02) ? 255 : 0;
-      copy[j + 2] = (c & 0x04) ? 255 : 0;
-      copy[j + 3] = (c & 0x08) ? 255 : 0;
-      copy[j + 4] = (c & 0x10) ? 255 : 0;
-      copy[j + 5] = (c & 0x20) ? 255 : 0;
-      copy[j + 6] = (c & 0x40) ? 255 : 0;
-      copy[j + 7] = (c & 0x80) ? 255 : 0;
-      j += 8;
+      const unsigned char * rowBytes = t + (row * bytesPerRow);
+      for (size_t col = 0; col < width; ++col)
+      {
+        copy[outIndex++] = (rowBytes[col / 8] & (1 << (col % 8))) ? 255 : 0;
+      }
     }
     memcpy(static_cast<char *>(pointer), copy.get(), len);
   }

--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -671,12 +671,18 @@ GDCMImageIO::InternalReadImageInformation()
         // TODO throw an exception that VM is not compatible.
         m_El.SetLength(16);
         m_El.Read(m_Ss);
-        assert(m_El.GetLength() == 2);
-        for (unsigned long i = 0; i < m_El.GetLength(); ++i)
+        // GetValue(1) is uninitialized unless the tag carries a second backslash-separated value.
+        if (s.find('\\') != std::string::npos)
         {
-          sp.push_back(m_El.GetValue(i));
+          sp.push_back(m_El.GetValue(0));
+          sp.push_back(m_El.GetValue(1));
+          std::swap(sp[0], sp[1]);
         }
-        std::swap(sp[0], sp[1]);
+        else
+        {
+          sp.push_back(m_El.GetValue(0));
+          sp.push_back(m_El.GetValue(0));
+        }
         assert(sp.size() == 2);
         spacing[0] = sp[0];
         spacing[1] = sp[1];

--- a/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
@@ -18,12 +18,19 @@
 
 #include "itkImage.h"
 #include "itkImageFileWriter.h"
+#include "itkImageFileReader.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
 #include "itkMetaDataObject.h"
 #include "itkGTest.h"
 #include "itksys/SystemTools.hxx"
 #include "itkImageSeriesReader.h"
+#include "gdcmReader.h"
+#include "gdcmWriter.h"
+#include "gdcmAttribute.h"
+#include "gdcmDataSet.h"
+#include "gdcmDataElement.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -39,6 +46,10 @@ struct ITKGDCMImageIO : public ::testing::Test
   void
   SetUp() override
   {
+    // Concurrently-run tests must not share a scratch directory: one test's
+    // TearDown would remove the directory another test is still writing into.
+    const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
+    m_TempDir = TOSTRING(ITK_TEST_OUTPUT_DIR) + "/ITKGDCMImageIO_" + info->name();
     itksys::SystemTools::MakeDirectory(m_TempDir);
   }
 
@@ -48,7 +59,7 @@ struct ITKGDCMImageIO : public ::testing::Test
     itksys::SystemTools::RemoveADirectory(m_TempDir);
   }
 
-  const std::string m_TempDir{ TOSTRING(ITK_TEST_OUTPUT_DIR) + "/ITKGDCMImageIO" };
+  std::string       m_TempDir;
   const std::string m_DicomSeriesInput{ TOSTRING(DICOM_SERIES_INPUT) };
 };
 
@@ -151,6 +162,92 @@ private:
     }
   }
 };
+
+std::vector<uint8_t>
+PackRowPaddedBits(const std::vector<uint8_t> & pixels, size_t width, size_t height)
+{
+  const size_t         bytesPerRow = (width + 7) / 8;
+  std::vector<uint8_t> packed(bytesPerRow * height, 0);
+  for (size_t row = 0; row < height; ++row)
+  {
+    for (size_t col = 0; col < width; ++col)
+    {
+      if (pixels[(row * width) + col] != 0)
+      {
+        packed[(row * bytesPerRow) + (col / 8)] |= static_cast<uint8_t>(1u << (col % 8));
+      }
+    }
+  }
+  return packed;
+}
+
+std::string
+WriteSingleBitDicom(const std::string & dir, size_t width, size_t height, const std::vector<uint8_t> & pixels)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto                image = ImageType::New();
+  ImageType::SizeType size{ { static_cast<itk::SizeValueType>(width), static_cast<itk::SizeValueType>(height) } };
+  image->SetRegions(ImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(0);
+
+  auto & dict = image->GetMetaDataDictionary();
+  itk::EncapsulateMetaData<std::string>(dict, "0008|0060", "OT");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0010", "Test^Patient");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0020", "12345");
+
+  auto gdcmIO = itk::GDCMImageIO::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetImageIO(gdcmIO);
+  writer->SetInput(image);
+  const std::string basePath = dir + "/singlebit_base.dcm";
+  writer->SetFileName(basePath);
+  writer->Update();
+
+  gdcm::Reader reader;
+  reader.SetFileName(basePath.c_str());
+  if (!reader.Read())
+  {
+    return {};
+  }
+  gdcm::DataSet & ds = reader.GetFile().GetDataSet();
+
+  gdcm::Attribute<0x0028, 0x0002> samplesPerPixel;
+  samplesPerPixel.SetValue(1);
+  ds.Replace(samplesPerPixel.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0100> bitsAllocated;
+  bitsAllocated.SetValue(1);
+  ds.Replace(bitsAllocated.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0101> bitsStored;
+  bitsStored.SetValue(1);
+  ds.Replace(bitsStored.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0102> highBit;
+  highBit.SetValue(0);
+  ds.Replace(highBit.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0103> pixelRepresentation;
+  pixelRepresentation.SetValue(0);
+  ds.Replace(pixelRepresentation.GetAsDataElement());
+
+  const std::vector<uint8_t> packed = PackRowPaddedBits(pixels, width, height);
+  gdcm::DataElement          pixelData{ gdcm::Tag(0x7fe0, 0x0010) };
+  pixelData.SetVR(gdcm::VR::OB);
+  pixelData.SetByteValue(reinterpret_cast<const char *>(packed.data()), static_cast<uint32_t>(packed.size()));
+  ds.Replace(pixelData);
+
+  const std::string outPath = dir + "/singlebit.dcm";
+  gdcm::Writer      gdcmWriter;
+  gdcmWriter.SetFileName(outPath.c_str());
+  gdcmWriter.SetFile(reader.GetFile());
+  if (!gdcmWriter.Write())
+  {
+    return {};
+  }
+  return outPath;
+}
 
 } // namespace
 
@@ -336,4 +433,31 @@ TEST_F(ITKGDCMSeriesTestData, ReadSeriesBottomToTop)
   EXPECT_GT(image2->GetSpacing()[2], 0.0);
   // and the direction should have a positive Z component
   EXPECT_GT(image2->GetDirection()[2][2], 0.0);
+}
+
+TEST_F(ITKGDCMImageIO, SingleBitRowsRespectBytePadding)
+{
+  constexpr size_t           width = 10;
+  constexpr size_t           height = 4;
+  const std::vector<uint8_t> pixels(width * height, 1);
+
+  const std::string path = WriteSingleBitDicom(m_TempDir, width, height, pixels);
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  for (size_t row = 0; row < height; ++row)
+  {
+    for (size_t col = 0; col < width; ++col)
+    {
+      const ImageType::IndexType idx{ { static_cast<itk::IndexValueType>(col),
+                                        static_cast<itk::IndexValueType>(row) } };
+      EXPECT_EQ(image->GetPixel(idx), 255) << "row " << row << " col " << col;
+    }
+  }
 }

--- a/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
@@ -249,6 +249,60 @@ WriteSingleBitDicom(const std::string & dir, size_t width, size_t height, const 
   return outPath;
 }
 
+std::string
+WriteHardcopyDicomWithSingleValuePixelSpacing(const std::string & dir)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto                image = ImageType::New();
+  ImageType::SizeType size{ { 4, 4 } };
+  image->SetRegions(ImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(0);
+
+  auto & dict = image->GetMetaDataDictionary();
+  itk::EncapsulateMetaData<std::string>(dict, "0008|0060", "OT");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0010", "Test^Patient");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0020", "12345");
+
+  auto gdcmIO = itk::GDCMImageIO::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetImageIO(gdcmIO);
+  writer->SetInput(image);
+  const std::string basePath = dir + "/pixelspacing_base.dcm";
+  writer->SetFileName(basePath);
+  writer->Update();
+
+  gdcm::Reader reader;
+  reader.SetFileName(basePath.c_str());
+  if (!reader.Read())
+  {
+    return {};
+  }
+  gdcm::DataSet & ds = reader.GetFile().GetDataSet();
+
+  const std::string sopClassUIDValue = "1.2.840.10008.5.1.1.29"; // HardcopyGrayscaleImageStorage
+  gdcm::DataElement sopClassUID{ gdcm::Tag(0x0008, 0x0016) };
+  sopClassUID.SetVR(gdcm::VR::UI);
+  sopClassUID.SetByteValue(sopClassUIDValue.c_str(), static_cast<uint32_t>(sopClassUIDValue.size()));
+  ds.Replace(sopClassUID);
+
+  const std::string pixelSpacingValue = "0.5 "; // single value, no second component
+  gdcm::DataElement pixelSpacing{ gdcm::Tag(0x0028, 0x0030) };
+  pixelSpacing.SetVR(gdcm::VR::DS);
+  pixelSpacing.SetByteValue(pixelSpacingValue.c_str(), static_cast<uint32_t>(pixelSpacingValue.size()));
+  ds.Replace(pixelSpacing);
+
+  const std::string outPath = dir + "/pixelspacing.dcm";
+  gdcm::Writer      gdcmWriter;
+  gdcmWriter.SetFileName(outPath.c_str());
+  gdcmWriter.SetFile(reader.GetFile());
+  if (!gdcmWriter.Write())
+  {
+    return {};
+  }
+  return outPath;
+}
+
 } // namespace
 
 TEST_F(ITKGDCMSeriesTestData, ReadSlicesReverseOrder)
@@ -460,4 +514,20 @@ TEST_F(ITKGDCMImageIO, SingleBitRowsRespectBytePadding)
       EXPECT_EQ(image->GetPixel(idx), 255) << "row " << row << " col " << col;
     }
   }
+}
+
+TEST_F(ITKGDCMImageIO, SingleValuePixelSpacingIsIsotropic)
+{
+  const std::string path = WriteHardcopyDicomWithSingleValuePixelSpacing(m_TempDir);
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[0], 0.5);
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[1], 0.5);
 }


### PR DESCRIPTION
`GDCMImageIO` decodes 1-bit pixel data as an unpadded bitstream even though GDCM pads every row to a byte boundary, and reads axis-0 spacing from an uninitialized `Element` slot when `(0028,0030)` carries a single value. Addresses B88 and B89 of #6575.

<details>
<summary>Root cause</summary>

**B88:** the SINGLEBIT expansion walks the buffer flat over `len/8` bytes with no row boundary, but `gdcmBitmap.cxx::GetBufferLength()` pads each row to a byte. Whenever the width is not a multiple of 8, row N's padding bits bleed into row N+1's decode and every row after the first is wrong.

**B89:** in the ultrasound/hardcopy `MediaStorage` arm, `Element<VR::DS, VM::VM1_n>::SetLength(16)` fixes `GetLength()` at 2 by construction, so the `assert(GetLength() == 2)` next to it cannot fire even in a Debug build. When the PixelSpacing tag holds one DS value, `data[1]` is never written, and `GetValue(1)` — indeterminate — lands in `spacing[0]` after the axis swap. A single-valued PixelSpacing is now treated as isotropic.

</details>

<details>
<summary>Local validation</summary>

Two cases added to `itkGDCMImageIOGTest.cxx`, both fixtures synthesized in the test body, no ExternalData.

- `SingleBitRowsRespectBytePadding` — 10x4 single-bit image. Fail-before: 12 of 40 pixels wrong. Pass-after: 0.
- `SingleValuePixelSpacingIsIsotropic` — fail-before: the indeterminate slot read as 0 and tripped ITK's zero-spacing guard ("Refusing to change spacing from [1, 1] to [0, 0.5]"). Pass-after: spacing [0.5, 0.5].

`ctest -R GDCM` (97 tests): only the new test's status changed. `itkGDCMLoadImageSpacingTest`, `itkGDCMLoadImageNoSpacingTest`, `itkGDCMImageIOSecondaryCaptureSpacingTest` and `itkGDCM_ComplianceTest_singlebit` — the tests most sensitive to these two paths — pass unchanged. No baseline flipped.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
