### PR TITLE
BUG: Validate TileImageFilter Layout has no zero before the last axis

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.h
@@ -132,6 +132,9 @@ protected:
   PrintSelf(std::ostream & os, Indent indent) const override;
 
   void
+  VerifyPreconditions() const override;
+
+  void
   GenerateInputRequestedRegion() override;
 
   void

--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -131,6 +131,21 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateData()
 
 template <typename TInputImage, typename TOutputImage>
 void
+TileImageFilter<TInputImage, TOutputImage>::VerifyPreconditions() const
+{
+  Superclass::VerifyPreconditions();
+
+  for (unsigned int d = 0; d < OutputImageDimension - 1; ++d)
+  {
+    if (m_Layout[d] == 0)
+    {
+      itkExceptionMacro("Layout[" << d << "] is 0; only the last dimension may be 0.");
+    }
+  }
+}
+
+template <typename TInputImage, typename TOutputImage>
+void
 TileImageFilter<TInputImage, TOutputImage>::GenerateInputRequestedRegion()
 {
   for (unsigned int i = 0; i < this->GetNumberOfIndexedInputs(); ++i)

--- a/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkTileImageFilterGTest.cxx
@@ -191,3 +191,30 @@ TEST_F(TileImageFixture, VectorImage)
 
   EXPECT_ANY_THROW(filter->Update());
 }
+
+
+TEST_F(TileImageFixture, RejectsZeroInNonLastLayoutAxis)
+{
+  using Utils = FixtureUtilities<itk::Image<unsigned char, 2>>;
+
+  auto filter = Utils::FilterType::New();
+  filter->SetInput(0, Utils::CreateImage(4));
+
+  Utils::FilterType::LayoutArrayType layout{};
+  layout[0] = 0;
+  layout[1] = 3;
+  filter->SetLayout(layout);
+
+  EXPECT_THROW(filter->UpdateOutputInformation(), itk::ExceptionObject);
+}
+
+
+TEST_F(TileImageFixture, RejectsDefaultZeroLayout)
+{
+  using Utils = FixtureUtilities<itk::Image<unsigned char, 2>>;
+
+  auto filter = Utils::FilterType::New();
+  filter->SetInput(0, Utils::CreateImage(4));
+
+  EXPECT_THROW(filter->UpdateOutputInformation(), itk::ExceptionObject);
+}


### PR DESCRIPTION
`TileImageFilter` never validates `Layout`: a 0 in any axis but the last indexes an empty `std::vector` and runs a loop of about 2^32 iterations, and the constructor's own all-zero default divides by zero. Addresses B87 of #6575.

<details>
<summary>Root cause and fix</summary>

Only the last axis of `Layout` may be 0 (meaning "as many tiles as needed"); a 0 anywhere else is meaningless, and the tile-index arithmetic in `GenerateData()` has no defense against it. Rather than guarding each use site, `VerifyPreconditions()` now rejects a zero in any non-last axis, so `GenerateData()` cannot be reached with an unusable layout.

</details>

<details>
<summary>Local validation</summary>

Two cases added to `itkTileImageFilterGTest.cxx`:

- `RejectsZeroInNonLastLayoutAxis` — fail-before: no exception (then UB). Pass-after: throws.
- `RejectsDefaultZeroLayout` — same, for the constructor default.

`ctest -L ImageGrid`: 69/69 pass, unchanged.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
