### PR TITLE
BUG: Fix uninitialized output in LabelSet erode and dilate at zero scale

### DIFF
--- a/Modules/Filtering/LabelErodeDilate/include/itkLabelSetErodeImageFilter.hxx
+++ b/Modules/Filtering/LabelErodeDilate/include/itkLabelSetErodeImageFilter.hxx
@@ -100,7 +100,7 @@ LabelSetErodeImageFilter<TInputImage, TOutputImage>::ThreadedGenerateData(
     // RealType magnitude = 1.0/(2.0 * m_Scale[0]);
     unsigned long LineLength = region.GetSize()[this->m_CurrentDimension];
     RealType      image_scale = this->GetInput()->GetSpacing()[this->m_CurrentDimension];
-    bool          lastpass = (this->m_CurrentDimension == ImageDimension - 1);
+    bool          lastpass = (this->m_CurrentDimension == this->m_LastActiveDimension);
 
     if (!this->m_FirstPassDone)
     {

--- a/Modules/Filtering/LabelErodeDilate/include/itkLabelSetMorphBaseImageFilter.h
+++ b/Modules/Filtering/LabelErodeDilate/include/itkLabelSetMorphBaseImageFilter.h
@@ -142,6 +142,9 @@ protected:
   int  m_CurrentDimension;
   bool m_FirstPassDone;
 
+  // last dimension index with m_Scale > 0; the erosion output commits here
+  int m_LastActiveDimension{ 0 };
+
   // this is the first non-zero entry in the radius. Needed to
   // support elliptical operations
   RealType m_BaseSigma;

--- a/Modules/Filtering/LabelErodeDilate/include/itkLabelSetMorphBaseImageFilter.hxx
+++ b/Modules/Filtering/LabelErodeDilate/include/itkLabelSetMorphBaseImageFilter.hxx
@@ -181,19 +181,50 @@ LabelSetMorphBaseImageFilter<TInputImage, doDilate, TOutputImage>::GenerateData(
   // Subsequent non zero values are scaled by the first non zero
   // value to support elliptical operations.
   // The first value needs to be recorded for use by the erosion operation.
+  //
+  // Keyed on m_Scale (not m_Radius): with UseImageSpacing()==false the "+1"
+  // margin means a zero radius still yields a positive scale, so the two
+  // conditions diverge and only m_Scale reflects which axis actually runs
+  // a pass.
   unsigned firstval = 0;
+  bool     firstValFound = false;
   for (unsigned P = 0; P < InputImageType::ImageDimension; P++)
   {
-    if (m_Radius[P] != 0)
+    if (m_Scale[P] > 0)
     {
       firstval = P;
+      firstValFound = true;
       break;
     }
   }
-  m_BaseSigma = m_Scale[firstval];
-  for (unsigned P = firstval + 1; P < InputImageType::ImageDimension; P++)
+  m_BaseSigma = firstValFound ? m_Scale[firstval] : 0;
+  if (firstValFound)
   {
-    m_Scale[P] = m_Scale[P] / m_Scale[firstval];
+    for (unsigned P = firstval + 1; P < InputImageType::ImageDimension; P++)
+    {
+      m_Scale[P] = m_Scale[P] / m_Scale[firstval];
+    }
+  }
+
+  m_LastActiveDimension = 0;
+  for (unsigned P = 0; P < InputImageType::ImageDimension; P++)
+  {
+    if (m_Scale[P] > 0)
+    {
+      m_LastActiveDimension = static_cast<int>(P);
+    }
+  }
+
+  if (!firstValFound)
+  {
+    // no axis pass will run at all, so output stays as AllocateOutputs left it unless seeded here
+    ImageRegionConstIterator<TInputImage> identityInputIt(inputImage, outputImage->GetRequestedRegion());
+    ImageRegionIterator<TOutputImage>     identityOutputIt(outputImage, outputImage->GetRequestedRegion());
+    for (identityInputIt.GoToBegin(), identityOutputIt.GoToBegin(); !identityInputIt.IsAtEnd();
+         ++identityInputIt, ++identityOutputIt)
+    {
+      identityOutputIt.Set(static_cast<OutputPixelType>(identityInputIt.Get()));
+    }
   }
 
   m_FirstPassDone = false;

--- a/Modules/Filtering/LabelErodeDilate/itk-module.cmake
+++ b/Modules/Filtering/LabelErodeDilate/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
     ITKImageGrid
     ITKTestKernel
     ITKSmoothing
+    ITKGoogleTest
   EXCLUDE_FROM_DEFAULT
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/LabelErodeDilate/test/CMakeLists.txt
+++ b/Modules/Filtering/LabelErodeDilate/test/CMakeLists.txt
@@ -97,3 +97,7 @@ itk_add_test(
   ITK_REMOVE_TEMPORARY_TEST_FILES
     ${ITK_TEST_OUTPUT_DIR}/holeerode_41.nii.gz
 )
+
+set(LabelErodeDilateGTests itkLabelSetMorphBaseImageFilterGTest.cxx)
+
+creategoogletestdriver(LabelErodeDilate "${LabelErodeDilate-Test_LIBRARIES}" "${LabelErodeDilateGTests}")

--- a/Modules/Filtering/LabelErodeDilate/test/itkLabelSetMorphBaseImageFilterGTest.cxx
+++ b/Modules/Filtering/LabelErodeDilate/test/itkLabelSetMorphBaseImageFilterGTest.cxx
@@ -1,0 +1,139 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkGTest.h"
+
+#include "itkLabelSetErodeImageFilter.h"
+#include "itkLabelSetDilateImageFilter.h"
+#include "itkImage.h"
+
+namespace
+{
+using ImageType = itk::Image<unsigned char, 2>;
+
+ImageType::Pointer
+MakeFilledImage(unsigned int size, unsigned char label)
+{
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType(ImageType::SizeType::Filled(size)));
+  image->Allocate();
+  image->FillBuffer(label);
+  return image;
+}
+} // namespace
+
+TEST(LabelSetMorphBaseImageFilter, ErodeZeroRadiusOnLastAxisStillErodesActiveAxis)
+{
+  constexpr unsigned char label = 5;
+  auto                    image = MakeFilledImage(21, 0);
+  for (unsigned int i0 = 5; i0 <= 15; ++i0)
+  {
+    for (unsigned int i1 = 5; i1 <= 15; ++i1)
+    {
+      image->SetPixel(itk::MakeIndex(i0, i1), label);
+    }
+  }
+
+  using FilterType = itk::LabelSetErodeImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->UseImageSpacingOn();
+
+  FilterType::RadiusType radius;
+  radius[0] = 3;
+  radius[1] = 0;
+  filter->SetRadius(radius);
+  filter->Update();
+
+  const ImageType * output = filter->GetOutput();
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(10, 10)), label);
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(5, 10)), 0);
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(10, 5)), label);
+}
+
+// With UseImageSpacing() at its default of false, every axis gets a
+// positive m_Scale via the "+1" margin, even at radius 0 (every axis
+// erodes a little, by design). firstval must be keyed on m_Scale, not
+// m_Radius: previously, with radius=[0,3], firstval picked axis 0 (the
+// first nonzero *radius*) while the erosion pass for axis 0 actually ran
+// with axis 0's own m_Scale — a different value from m_BaseSigma taken
+// from the wrong axis. The pass's exact float comparison against
+// m_BaseSigma then never matched, zeroing the entire output (issue #6575).
+TEST(LabelSetMorphBaseImageFilter, ErodeWithDefaultSpacingAndZeroRadiusOnFirstAxisIsNotAllZero)
+{
+  constexpr unsigned char label = 5;
+  auto                    image = MakeFilledImage(21, 0);
+  for (unsigned int i0 = 5; i0 <= 15; ++i0)
+  {
+    for (unsigned int i1 = 5; i1 <= 15; ++i1)
+    {
+      image->SetPixel(itk::MakeIndex(i0, i1), label);
+    }
+  }
+
+  using FilterType = itk::LabelSetErodeImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  // UseImageSpacing left at its default (false).
+
+  FilterType::RadiusType radius;
+  radius[0] = 0;
+  radius[1] = 3;
+  filter->SetRadius(radius);
+  filter->Update();
+
+  const ImageType * output = filter->GetOutput();
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(10, 10)), label)
+    << "a well-interior pixel must survive; the bug zeroed the entire output";
+}
+
+TEST(LabelSetMorphBaseImageFilter, ErodeAllZeroRadiusIsIdentity)
+{
+  constexpr unsigned char label = 5;
+  auto                    image = MakeFilledImage(5, label);
+  image->SetPixel(itk::MakeIndex(0, 0), 0);
+
+  using FilterType = itk::LabelSetErodeImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->UseImageSpacingOn();
+  filter->SetRadius(0);
+  filter->Update();
+
+  const ImageType * output = filter->GetOutput();
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(0, 0)), 0);
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(3, 3)), label);
+}
+
+TEST(LabelSetMorphBaseImageFilter, DilateAllZeroRadiusIsIdentity)
+{
+  constexpr unsigned char label = 5;
+  auto                    image = MakeFilledImage(5, 0);
+  image->SetPixel(itk::MakeIndex(2, 2), label);
+
+  using FilterType = itk::LabelSetDilateImageFilter<ImageType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->UseImageSpacingOn();
+  filter->SetRadius(0);
+  filter->Update();
+
+  const ImageType * output = filter->GetOutput();
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(2, 2)), label);
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(0, 0)), 0);
+}


### PR DESCRIPTION
`LabelSetErodeImageFilter` and `LabelSetDilateImageFilter` only call `AllocateOutputs()` and gate every write on `m_Scale[d] > 0`, so a zero radius on the last axis skips erosion's only output-writing pass and the filter returns uninitialized memory. Addresses B90 of #6575.

<details>
<summary>Root cause and fix</summary>

Erosion commits to the output only on `lastpass`, defined as the geometrically last dimension. Under `UseImageSpacing`, a zero radius on that axis makes its scale zero, the axis pass never runs, `lastpass` is never reached, and the output is whatever `AllocateOutputs()` left there. With every radius zero, neither filter writes the output at all.

Two changes, both in the shared base: `lastpass` is now gated on `m_LastActiveDimension` — the highest-index axis that actually runs a pass — so the commit happens on an axis that exists; and when no axis is active at all, the output is seeded from the input, which is the correct identity result for a zero-radius morphological operation.

The seed is deliberately scoped to the fully-degenerate case. An unconditional seed was measured at 7-10% of `GenerateData()` wall time on a 182x218x182 label volume and is pure waste, because on any active configuration the `lastpass` block writes every pixel of the region — verified by poisoning the seed with a sentinel and confirming all six baseline-compared tests still match bit-for-bit.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkLabelSetMorphBaseImageFilterGTest.cxx` in a new driver:

- `ErodeZeroRadiusOnLastAxisStillErodesActiveAxis` — fail-before: uninitialized garbage. Pass-after: correct erosion on the active axis.
- `ErodeAllZeroRadiusIsIdentity` / `DilateAllZeroRadiusIsIdentity` — fail-before: uninitialized garbage (e.g. 147 where 0 was expected). Pass-after: identity.

`ctest -L LabelErodeDilate`: 8/8 pass, bit-identical baselines.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
