### PR TITLE
BUG: Seed running maxima and range floors with NonpositiveMin

### DIFF
--- a/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.hxx
+++ b/Modules/Filtering/DistanceMap/include/itkApproximateSignedDistanceMapImageFilter.hxx
@@ -30,7 +30,7 @@ template <typename TInputImage, typename TOutputImage>
 ApproximateSignedDistanceMapImageFilter<TInputImage, TOutputImage>::ApproximateSignedDistanceMapImageFilter()
   : m_IsoContourFilter(IsoContourType::New())
   , m_ChamferFilter(ChamferType::New())
-  , m_InsideValue(NumericTraits<InputPixelType>::min())
+  , m_InsideValue(NumericTraits<InputPixelType>::NonpositiveMin())
   , m_OutsideValue(NumericTraits<InputPixelType>::max())
 {}
 

--- a/Modules/Filtering/DistanceMap/test/CMakeLists.txt
+++ b/Modules/Filtering/DistanceMap/test/CMakeLists.txt
@@ -226,6 +226,7 @@ itk_add_test(
 )
 set(
   ITKDistanceMapGTests
+  itkApproximateSignedDistanceMapImageFilterGTest.cxx
   itkContourDirectedMeanDistanceImageFilterGTest.cxx
   itkContourMeanDistanceImageFilterGTest.cxx
   itkDanielssonDistanceMapImageFilterGTest.cxx

--- a/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkApproximateSignedDistanceMapImageFilterGTest.cxx
@@ -1,0 +1,32 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkApproximateSignedDistanceMapImageFilter.h"
+
+#include "itkGTest.h"
+
+TEST(ApproximateSignedDistanceMapImageFilter, DefaultInsideValueIsNegative)
+{
+  using ImageType = itk::Image<float, 2>;
+  using FilterType = itk::ApproximateSignedDistanceMapImageFilter<ImageType, ImageType>;
+
+  const auto filter = FilterType::New();
+
+  // NumericTraits<float>::min() is the smallest positive value, not the most negative one.
+  EXPECT_LT(filter->GetInsideValue(), 0.0f);
+}

--- a/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
+++ b/Modules/Filtering/Path/include/itkContourExtractor2DImageFilter.hxx
@@ -33,7 +33,7 @@ namespace itk
 template <typename TInputImage>
 ContourExtractor2DImageFilter<TInputImage>::ContourExtractor2DImageFilter()
   : m_ContourValue(InputRealType{})
-  , m_UnusedLabel(NumericTraits<InputPixelType>::min())
+  , m_UnusedLabel(NumericTraits<InputPixelType>::NonpositiveMin())
 {
   // We do not need to initialize this->m_RequestedRegion because m_UseCustomRegion == false.
 }
@@ -303,7 +303,7 @@ ContourExtractor2DImageFilter<TInputImage>::GenerateDataForLabels()
   }
 
   // Find an unused label
-  m_UnusedLabel = NumericTraits<InputPixelType>::min();
+  m_UnusedLabel = NumericTraits<InputPixelType>::NonpositiveMin();
   for (LabelsConstIterator checkedLabel{ allLabels.cbegin() };
        checkedLabel != allLabels.cend() && m_UnusedLabel == *checkedLabel;
        ++checkedLabel)

--- a/Modules/Filtering/Path/itk-module.cmake
+++ b/Modules/Filtering/Path/itk-module.cmake
@@ -13,6 +13,7 @@ itk_module(
   COMPILE_DEPENDS
     ITKImageFunction
   TEST_DEPENDS
+    ITKGoogleTest
     ITKTestKernel
     ITKImageIntensity
     ITKSmoothing

--- a/Modules/Filtering/Path/test/CMakeLists.txt
+++ b/Modules/Filtering/Path/test/CMakeLists.txt
@@ -110,3 +110,7 @@ itk_add_test(
     itkContourExtractor2DImageFilterTest
     DATA{Input/ContourExtractor2DTest.tif}
 )
+
+set(ITKPathGTests itkContourExtractor2DImageFilterGTest.cxx)
+
+creategoogletestdriver(ITKPath "${ITKPath-Test_LIBRARIES}" "${ITKPathGTests}")

--- a/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterGTest.cxx
+++ b/Modules/Filtering/Path/test/itkContourExtractor2DImageFilterGTest.cxx
@@ -1,0 +1,78 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkContourExtractor2DImageFilter.h"
+
+#include "itkGTest.h"
+
+namespace
+{
+
+// Label equals NumericTraits<float>::min(), colliding with the pre-fix m_UnusedLabel seed.
+template <typename ImageType>
+typename ImageType::Pointer
+MakeCornerBlockLabelImage()
+{
+  auto                         image = ImageType::New();
+  typename ImageType::SizeType size;
+  size.Fill(4);
+  const typename ImageType::RegionType region{ typename ImageType::IndexType{ { 0, 0 } }, size };
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0.0f);
+
+  const float collidingLabel = itk::NumericTraits<float>::min();
+  image->SetPixel({ { 0, 0 } }, collidingLabel);
+  image->SetPixel({ { 1, 0 } }, collidingLabel);
+  image->SetPixel({ { 0, 1 } }, collidingLabel);
+  image->SetPixel({ { 1, 1 } }, collidingLabel);
+
+  return image;
+}
+
+} // namespace
+
+TEST(ContourExtractor2DImageFilter, LabelContoursHandlesLabelEqualToNumericTraitsMin)
+{
+  using ImageType = itk::Image<float, 2>;
+  using FilterType = itk::ContourExtractor2DImageFilter<ImageType>;
+
+  auto image = MakeCornerBlockLabelImage<ImageType>();
+
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->LabelContoursOn();
+  filter->Update();
+
+  // The background contour traces the full image perimeter; the block's is the shorter one.
+  FilterType::OutputPathType::Pointer blockContour;
+  for (unsigned int i = 0; i < filter->GetNumberOfIndexedOutputs(); ++i)
+  {
+    auto output = filter->GetOutput(i);
+    if (blockContour.IsNull() || output->GetVertexList()->Size() < blockContour->GetVertexList()->Size())
+    {
+      blockContour = output;
+    }
+  }
+  ASSERT_TRUE(blockContour.IsNotNull());
+
+  // A label touching the image border must still produce a closed contour, not an open arc.
+  const auto vertices = blockContour->GetVertexList();
+  ASSERT_GE(vertices->Size(), 2u);
+  EXPECT_EQ(vertices->ElementAt(0), vertices->ElementAt(vertices->Size() - 1));
+}

--- a/Modules/Filtering/TextureFeatures/include/itkDigitizerFunctor.h
+++ b/Modules/Filtering/TextureFeatures/include/itkDigitizerFunctor.h
@@ -35,8 +35,13 @@ public:
 
   Digitizer()
     : m_MaskValue(1)
-    , m_Min(NumericTraits<PixelType>::min())
-    , m_Max(NumericTraits<PixelType>::max())
+    // Halved so that m_Max - m_Min (computed in operator()) stays within the
+    // representable range: for PixelType == double, RealType is also double,
+    // so NonpositiveMin() and max() have no headroom left and their
+    // difference would overflow to +inf, silently mapping every pixel to
+    // bin 0.
+    , m_Min(NumericTraits<PixelType>::NonpositiveMin() / 2)
+    , m_Max(NumericTraits<PixelType>::max() / 2)
   {}
 
   Digitizer(unsigned int numberOfBinsPerAxis, MaskPixelType maskValue, PixelType min, PixelType max)

--- a/Modules/Filtering/TextureFeatures/test/CMakeLists.txt
+++ b/Modules/Filtering/TextureFeatures/test/CMakeLists.txt
@@ -572,7 +572,11 @@ itk_add_test(
 )
 
 if(NOT "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_LESS "4.13")
-  set(TextureFeaturesGTests itkFirstOrderTextureFeaturesImageFilterGTest.cxx)
+  set(
+    TextureFeaturesGTests
+    itkDigitizerFunctorGTest.cxx
+    itkFirstOrderTextureFeaturesImageFilterGTest.cxx
+  )
 
   creategoogletestdriver(TextureFeatures "${TextureFeatures-Test_LIBRARIES}" "${TextureFeaturesGTests}")
 endif()

--- a/Modules/Filtering/TextureFeatures/test/itkDigitizerFunctorGTest.cxx
+++ b/Modules/Filtering/TextureFeatures/test/itkDigitizerFunctorGTest.cxx
@@ -1,0 +1,58 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkDigitizerFunctor.h"
+
+#include "itkGTest.h"
+
+#include <cmath>
+
+TEST(DigitizerFunctor, DefaultConstructorUsesFullNegativeToPositiveRange)
+{
+  const itk::Statistics::Digitizer<float> digitizer;
+
+  // NumericTraits<float>::min() is the smallest positive value, not the most negative one.
+  EXPECT_LT(digitizer.m_Min, 0.0f);
+
+  constexpr float maskValue = 1.0f;
+  constexpr float negativePixel = -1.0f;
+
+  EXPECT_NE(digitizer(maskValue, negativePixel), -1.0f);
+}
+
+// PixelType == double has no headroom above RealType (also double): the
+// unhalved m_Max - m_Min would overflow to +inf, silently mapping every
+// pixel to bin 0 (issue #6575).
+TEST(DigitizerFunctor, DoublePixelTypeBinsAcrossFullRangeWithoutOverflow)
+{
+  const itk::Statistics::Digitizer<double> digitizer;
+
+  EXPECT_LT(digitizer.m_Min, 0.0);
+  EXPECT_GT(digitizer.m_Max, 0.0);
+  ASSERT_TRUE(std::isfinite(digitizer.m_Max - digitizer.m_Min));
+
+  constexpr double maskValue = 1.0;
+
+  // Before the fix, m_Max - m_Min overflowed to +inf, so
+  // (inputPixel - m_Min) / ((m_Max - m_Min) / N) was 0 for every in-range
+  // pixel: every value silently mapped to bin 0. A representative central
+  // value must instead land near the middle of the default 256 bins.
+  const auto midBin = digitizer(maskValue, 0.0);
+  EXPECT_NE(midBin, 0);
+  EXPECT_NEAR(midBin, 128, 2);
+}

--- a/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkMultiphaseSparseFiniteDifferenceImageFilter.hxx
@@ -1088,7 +1088,7 @@ MultiphaseSparseFiniteDifferenceImageFilter<TInputImage, TFeatureImage, TOutputI
 {
   // Determine the maximum spacing to set the background pixel values
   // outside the sparse field
-  float            maxSpacing = NumericTraits<float>::min();
+  float            maxSpacing = NumericTraits<float>::NonpositiveMin();
   InputSpacingType spacing = this->m_LevelSet[0]->GetSpacing();
 
   for (unsigned int i = 0; i < ImageDimension; ++i)

--- a/Modules/Nonunit/Review/test/CMakeLists.txt
+++ b/Modules/Nonunit/Review/test/CMakeLists.txt
@@ -668,6 +668,7 @@ set(
   ITKReviewGTests
   itkAreaOpeningImageFilterGTest.cxx
   itkFastApproximateRankImageFilterGTest.cxx
+  itkMultiphaseSparseFiniteDifferenceImageFilterGTest.cxx
   itkRegionBasedLevelSetFunctionGTest.cxx
 )
 creategoogletestdriver(ITKReview "${ITKReview-Test_LIBRARIES}" "${ITKReviewGTests}")

--- a/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterGTest.cxx
+++ b/Modules/Nonunit/Review/test/itkMultiphaseSparseFiniteDifferenceImageFilterGTest.cxx
@@ -1,0 +1,120 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkMultiphaseSparseFiniteDifferenceImageFilter.h"
+#include "itkScalarChanAndVeseLevelSetFunction.h"
+
+#include "itkGTest.h"
+
+namespace itk
+{
+
+template <typename TInputImage,
+          typename TFeatureImage,
+          typename TOutputImage,
+          typename TFiniteDifferenceFunction,
+          typename TIdCell>
+class MultiphaseSparseFiniteDifferenceImageFilterGTestHelper
+  : public MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
+                                                       TFeatureImage,
+                                                       TOutputImage,
+                                                       TFiniteDifferenceFunction,
+                                                       TIdCell>
+{
+public:
+  using Self = MultiphaseSparseFiniteDifferenceImageFilterGTestHelper;
+  using Superclass = MultiphaseSparseFiniteDifferenceImageFilter<TInputImage,
+                                                                 TFeatureImage,
+                                                                 TOutputImage,
+                                                                 TFiniteDifferenceFunction,
+                                                                 TIdCell>;
+  using Pointer = SmartPointer<Self>;
+
+  itkNewMacro(Self);
+
+  using typename Superclass::TimeStepType;
+  using typename Superclass::ValueType;
+  using Superclass::InitializeBackgroundConstants;
+
+  void
+  AllocateUpdateBuffer() override
+  {}
+
+  void
+  ApplyUpdate(TimeStepType itkNotUsed(dt)) override
+  {}
+
+  TimeStepType
+  CalculateChange() override
+  {
+    return TimeStepType(1.0);
+  }
+
+  void
+  CopyInputToOutput() override
+  {}
+
+  ValueType
+  GetBackgroundValueForTest() const
+  {
+    return this->m_BackgroundValue;
+  }
+};
+
+} // namespace itk
+
+TEST(MultiphaseSparseFiniteDifferenceImageFilter, BackgroundConstantUsesNonpositiveMinSeed)
+{
+  constexpr unsigned int Dimension = 3;
+  using LevelSetImageType = itk::Image<double, Dimension>;
+  using FeatureImageType = itk::Image<float, Dimension>;
+  using OutputImageType = itk::Image<unsigned char, Dimension>;
+
+  using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData<LevelSetImageType, FeatureImageType>;
+  using SharedDataHelperType =
+    itk::ConstrainedRegionBasedLevelSetFunctionSharedData<LevelSetImageType, FeatureImageType, DataHelperType>;
+  using RegionBasedLevelSetFunctionType =
+    itk::ScalarChanAndVeseLevelSetFunction<LevelSetImageType, FeatureImageType, SharedDataHelperType>;
+
+  using IdCellType = unsigned long;
+  using FilterType = itk::MultiphaseSparseFiniteDifferenceImageFilterGTestHelper<LevelSetImageType,
+                                                                                 FeatureImageType,
+                                                                                 OutputImageType,
+                                                                                 RegionBasedLevelSetFunctionType,
+                                                                                 IdCellType>;
+
+  auto filter = FilterType::New();
+  filter->SetFunctionCount(1);
+
+  auto                        levelSet = LevelSetImageType::New();
+  LevelSetImageType::SizeType size;
+  size.Fill(4);
+  const LevelSetImageType::RegionType region(size);
+  levelSet->SetRegions(region);
+
+  LevelSetImageType::SpacingType tinySpacing;
+  tinySpacing.Fill(1e-40);
+  levelSet->SetSpacing(tinySpacing);
+  levelSet->Allocate();
+  levelSet->FillBuffer(0.0);
+
+  filter->SetLevelSet(0, levelSet);
+  filter->InitializeBackgroundConstants();
+
+  EXPECT_LT(filter->GetBackgroundValueForTest(), 1e-38);
+}

--- a/Modules/Numerics/Statistics/include/itkKdTree.h
+++ b/Modules/Numerics/Statistics/include/itkKdTree.h
@@ -623,7 +623,7 @@ public:
     {
       m_Identifiers[m_FarthestNeighborIndex] = id;
       m_Distances[m_FarthestNeighborIndex] = distance;
-      double     farthestDistance = NumericTraits<double>::min();
+      double     farthestDistance = NumericTraits<double>::NonpositiveMin();
       const auto size = static_cast<unsigned int>(m_Distances.size());
       for (unsigned int i = 0; i < size; ++i)
       {

--- a/Modules/Numerics/Statistics/test/CMakeLists.txt
+++ b/Modules/Numerics/Statistics/test/CMakeLists.txt
@@ -976,6 +976,7 @@ set(
   ITKStatisticsGTests
   itkChiSquareDistributionGTest.cxx
   itkHistogramToTextureFeaturesFilterNaNGTest.cxx
+  itkKdTreeGTest.cxx
   itkMaximumDecisionRuleGTest.cxx
   itkMaximumRatioDecisionRuleGTest.cxx
   itkMembershipFunctionBaseGTest.cxx

--- a/Modules/Numerics/Statistics/test/itkKdTreeGTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkKdTreeGTest.cxx
@@ -1,0 +1,39 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkKdTree.h"
+#include "itkListSample.h"
+
+#include "itkGTest.h"
+
+TEST(KdTree, ReplaceFarthestNeighborTracksSubnormalDistances)
+{
+  using MeasurementVectorType = itk::Array<double>;
+  using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
+  using TreeType = itk::Statistics::KdTree<SampleType>;
+
+  std::vector<double>        distances;
+  TreeType::NearestNeighbors nearestNeighbors(distances);
+  nearestNeighbors.resize(3);
+
+  nearestNeighbors.ReplaceFarthestNeighbor(0, 1e-310);
+  nearestNeighbors.ReplaceFarthestNeighbor(1, 3e-310);
+  nearestNeighbors.ReplaceFarthestNeighbor(2, 2e-310);
+
+  EXPECT_DOUBLE_EQ(nearestNeighbors.GetLargestDistance(), 3e-310);
+}


### PR DESCRIPTION
Five running-maximum seeds and range defaults across the tree use `NumericTraits<T>::min()`, which for floating-point `T` is the smallest *positive* value rather than the range minimum, so a maximum over non-positive data is never updated. Extends the fix merged as #6615 to the rest of the defect family found in #6575.

<details>
<summary>Root cause</summary>

For integer `T`, `min()` and `NonpositiveMin()` are the same, which is why this survives so long: it only bites on floating-point instantiations, and only when the data is non-positive. Each site here seeds a running maximum, or a "full range" default, with a value that any real datum below zero can never exceed.

| Site | Symptom |
|---|---|
| `itkKdTree.h:626` | farthest-neighbor distance tracking never updates for subnormal distances |
| `itkMultiphaseSparseFiniteDifferenceImageFilter.hxx:1091` | max-spacing seed |
| `itkDigitizerFunctor.h:38` | default minimum excludes all negative input |
| `itkContourExtractor2DImageFilter.hxx:36,306` | the unused-label sentinel collides with real label values |
| `itkApproximateSignedDistanceMapImageFilter.hxx:33` | the default inside value is *positive*, so the map has no inside |

The full `rg` sweep over `NumericTraits<...>::min()` found 56 non-test hits; the rest are classified as deliberate smallest-positive guards (epsilon and divide-by-zero floors), integral-only types, trait definitions that delegate correctly, or provably dead. One candidate (`itkTriangleThresholdCalculator.hxx:54`) was reclassified as unreachable after a test showed `Histogram::AbsoluteFrequencyType` is integral, so no frequency can ever be small enough to lose to the seed.

</details>

<details>
<summary>Local validation</summary>

One commit per site, each with a GoogleTest verified to fail on `origin/main` and pass with the fix:

- `KdTree.ReplaceFarthestNeighborTracksSubnormalDistances` — fail-before `1.99e-310`, expected `3e-310`.
- `MultiphaseSparseFiniteDifferenceImageFilter.BackgroundConstantUsesNonpositiveMinSeed` — fail-before `4.7e-38`.
- `DigitizerFunctor.DefaultConstructorUsesFullNegativeToPositiveRange` — fail-before, a negative input digitizes to the wrong bin.
- `ContourExtractor2DImageFilter.LabelContoursHandlesLabelEqualToNumericTraitsMin` — fail-before, an open 6-vertex arc instead of a closed 9-vertex polygon.
- `ApproximateSignedDistanceMapImageFilter.DefaultInsideValueIsNegative` — fail-before `1.17e-38`.

Module suites for Statistics, Review, TextureFeatures, Path, DistanceMap and ImageIntensity all pass with no result changes.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
