### PR TITLE
BUG: Fix six read and write defects in TIFFImageIO

### DIFF
--- a/Modules/IO/TIFF/itk-module.cmake
+++ b/Modules/IO/TIFF/itk-module.cmake
@@ -14,6 +14,7 @@ itk_module(
   TEST_DEPENDS
     ITKGoogleTest
     ITKTestKernel
+    ITKTIFF
   FACTORY_NAMES
     ImageIO::TIFF
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -436,8 +436,11 @@ TIFFImageIO::ReadImageInformation()
   switch (this->GetFormat())
   {
     case TIFFImageIO::PALETTE_GRAYSCALE:
-    case TIFFImageIO::GRAYSCALE:
       this->SetNumberOfComponents(1);
+      this->SetPixelType(IOPixelEnum::SCALAR);
+      break;
+    case TIFFImageIO::GRAYSCALE:
+      this->SetNumberOfComponents(m_InternalImage->m_SamplesPerPixel);
       this->SetPixelType(IOPixelEnum::SCALAR);
       break;
     case TIFFImageIO::RGB_:
@@ -1371,9 +1374,11 @@ TIFFImageIO::ReadGenericImage(void * _out, unsigned int width, unsigned int heig
 
   switch (this->GetFormat())
   {
-    case TIFFImageIO::GRAYSCALE:
     case TIFFImageIO::PALETTE_GRAYSCALE:
       inc = 1;
+      break;
+    case TIFFImageIO::GRAYSCALE:
+      inc = m_InternalImage->m_SamplesPerPixel;
       break;
     case TIFFImageIO::RGB_:
       inc = m_InternalImage->m_SamplesPerPixel;
@@ -1488,6 +1493,9 @@ TIFFImageIO::PutGrayscale(TType *      to,
                           unsigned int toskew,
                           unsigned int fromskew)
 {
+  const size_t samplesPerPixel = m_InternalImage->m_SamplesPerPixel;
+  const size_t linesize = samplesPerPixel * xsize;
+
   // PHOTOMETRIC_MINISWHITE stores 0 as white; samples must be inverted to min-is-black.
   if constexpr (std::is_integral_v<TType>)
   {
@@ -1495,13 +1503,14 @@ TIFFImageIO::PutGrayscale(TType *      to,
     {
       for (unsigned int y = ysize; y-- > 0;)
       {
-        for (unsigned int x = 0; x < xsize; ++x)
+        for (size_t x = 0; x < linesize; x += samplesPerPixel)
         {
           to[x] = static_cast<TType>(~from[x]);
+          std::copy_n(from + x + 1, samplesPerPixel - 1, to + x + 1);
         }
-        to += xsize;
+        to += linesize;
         to += toskew;
-        from += xsize;
+        from += linesize;
         from += fromskew;
       }
       return;
@@ -1510,10 +1519,10 @@ TIFFImageIO::PutGrayscale(TType *      to,
 
   for (unsigned int y = ysize; y-- > 0;)
   {
-    std::copy_n(from, xsize, to);
-    to += xsize;
+    std::copy_n(from, linesize, to);
+    to += linesize;
     to += toskew;
-    from += xsize;
+    from += linesize;
     from += fromskew;
   }
 }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -24,6 +24,8 @@
 
 #include "itk_tiff.h"
 
+#include <type_traits>
+
 namespace itk
 {
 
@@ -1486,6 +1488,26 @@ TIFFImageIO::PutGrayscale(TType *      to,
                           unsigned int toskew,
                           unsigned int fromskew)
 {
+  // PHOTOMETRIC_MINISWHITE stores 0 as white; samples must be inverted to min-is-black.
+  if constexpr (std::is_integral_v<TType>)
+  {
+    if (m_InternalImage->m_Photometrics == PHOTOMETRIC_MINISWHITE)
+    {
+      for (unsigned int y = ysize; y-- > 0;)
+      {
+        for (unsigned int x = 0; x < xsize; ++x)
+        {
+          to[x] = static_cast<TType>(~from[x]);
+        }
+        to += xsize;
+        to += toskew;
+        from += xsize;
+        from += fromskew;
+      }
+      return;
+    }
+  }
+
   for (unsigned int y = ysize; y-- > 0;)
   {
     std::copy_n(from, xsize, to);

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -680,14 +680,14 @@ TIFFImageIO::InternalWrite(const void * buffer)
     }
     TIFFSetField(tif, TIFFTAG_SOFTWARE, "InsightToolkit");
 
-    if (scomponents > 3)
+    // MINISBLACK has 1 color channel, RGB has 3; samples beyond that need EXTRASAMPLES.
+    const uint16_t colorComponents = (scomponents <= 2) ? 1 : 3;
+    if (scomponents > colorComponents)
     {
-      // if number of scalar components is greater than 3, that means we assume
-      // there is alpha.
-      const uint16_t extra_samples = scomponents - 3;
-      const auto     sample_info = make_unique_for_overwrite<uint16_t[]>(scomponents - 3);
+      const uint16_t extra_samples = scomponents - colorComponents;
+      const auto     sample_info = make_unique_for_overwrite<uint16_t[]>(extra_samples);
       sample_info[0] = EXTRASAMPLE_ASSOCALPHA;
-      for (uint16_t cc = 1; cc < scomponents - 3; ++cc)
+      for (uint16_t cc = 1; cc < extra_samples; ++cc)
       {
         sample_info[cc] = EXTRASAMPLE_UNSPECIFIED;
       }
@@ -747,7 +747,7 @@ TIFFImageIO::InternalWrite(const void * buffer)
       {
         itkWarningMacro("Could not write this image as palette because pixel is not scalar");
       }
-      TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
+      TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, colorComponents == 1 ? PHOTOMETRIC_MINISBLACK : PHOTOMETRIC_RGB);
     }
     if (compression == COMPRESSION_JPEG)
     {

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -71,6 +71,14 @@ TIFFImageIO::ReadGenericImage(void * out, unsigned int width, unsigned int heigh
   {
     this->ReadGenericImage<short>(out, width, height);
   }
+  else if (m_ComponentType == IOComponentEnum::UINT)
+  {
+    this->ReadGenericImage<unsigned int>(out, width, height);
+  }
+  else if (m_ComponentType == IOComponentEnum::INT)
+  {
+    this->ReadGenericImage<int>(out, width, height);
+  }
   else if (m_ComponentType == IOComponentEnum::FLOAT)
   {
     this->ReadGenericImage<float>(out, width, height);
@@ -158,8 +166,11 @@ TIFFImageIO::ReadVolume(void * buffer)
   {
     int32_t    subfiletype = 6;
     const bool hasSubfiletype = TIFFGetField(m_InternalImage->m_Image, TIFFTAG_SUBFILETYPE, &subfiletype) != 0;
+    // An untagged page defaults to NewSubfileType==0 (TIFF 6.0) and must be
+    // treated as primary, matching the m_SubFiles count computed in
+    // TIFFReaderInternal::Initialize().
     const bool skipPage = onlyPrimarySubFiles
-                            ? !(hasSubfiletype && subfiletype == 0)
+                            ? !(!hasSubfiletype || subfiletype == 0)
                             : (hasSubfiletype && (subfiletype & FILETYPE_REDUCEDIMAGE || subfiletype & FILETYPE_MASK));
 
     if (skipPage)
@@ -1271,16 +1282,30 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
   uint32_t currentHeight = 0;
   uint16_t currentSamplesPerPixel = 0;
   uint16_t currentBitsPerSample = 0;
+  uint16_t currentPhotometrics = 0;
+  uint16_t currentSampleFormat = 1;
+  uint16_t currentPlanarConfig = 0;
+  uint16_t currentOrientation = ORIENTATION_TOPLEFT;
   TIFFGetField(m_InternalImage->m_Image, TIFFTAG_IMAGEWIDTH, &currentWidth);
   TIFFGetField(m_InternalImage->m_Image, TIFFTAG_IMAGELENGTH, &currentHeight);
   TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_SAMPLESPERPIXEL, &currentSamplesPerPixel);
   TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_BITSPERSAMPLE, &currentBitsPerSample);
+  TIFFGetField(m_InternalImage->m_Image, TIFFTAG_PHOTOMETRIC, &currentPhotometrics);
+  TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_SAMPLEFORMAT, &currentSampleFormat);
+  TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_PLANARCONFIG, &currentPlanarConfig);
+  TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_ORIENTATION, &currentOrientation);
+  // The first page's geometry and format fields are cached and reused for every
+  // page; reject any later page that differs rather than read it with stale values.
   if (currentWidth != width || currentHeight != height ||
       currentSamplesPerPixel != m_InternalImage->m_SamplesPerPixel ||
-      currentBitsPerSample != m_InternalImage->m_BitsPerSample)
+      currentBitsPerSample != m_InternalImage->m_BitsPerSample ||
+      currentPhotometrics != m_InternalImage->m_Photometrics ||
+      currentSampleFormat != m_InternalImage->m_SampleFormat ||
+      currentPlanarConfig != m_InternalImage->m_PlanarConfig || currentOrientation != m_InternalImage->m_Orientation)
   {
-    itkExceptionStringMacro(
-      "This reader requires every page to share the first page's width, height, SamplesPerPixel, and BitsPerSample.");
+    itkExceptionStringMacro("This reader requires every page to share the first page's width, height, "
+                            "SamplesPerPixel, BitsPerSample, Photometric, SampleFormat, PlanarConfig, and "
+                            "Orientation.");
   }
 
   if (!m_InternalImage->CanRead())
@@ -1331,6 +1356,18 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
     else if (m_ComponentType == IOComponentEnum::FLOAT)
     {
       auto * volume = static_cast<float *>(buffer);
+      volume += pixelOffset;
+      this->ReadGenericImage(volume, width, height);
+    }
+    else if (m_ComponentType == IOComponentEnum::UINT)
+    {
+      auto * volume = static_cast<unsigned int *>(buffer);
+      volume += pixelOffset;
+      this->ReadGenericImage(volume, width, height);
+    }
+    else if (m_ComponentType == IOComponentEnum::INT)
+    {
+      auto * volume = static_cast<int *>(buffer);
       volume += pixelOffset;
       this->ReadGenericImage(volume, width, height);
     }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -1260,6 +1260,21 @@ TIFFImageIO::ReadCurrentPage(void * buffer, size_t pixelOffset)
   const uint32_t width = m_InternalImage->m_Width;
   const uint32_t height = m_InternalImage->m_Height;
 
+  uint32_t currentWidth = 0;
+  uint32_t currentHeight = 0;
+  uint16_t currentSamplesPerPixel = 0;
+  uint16_t currentBitsPerSample = 0;
+  TIFFGetField(m_InternalImage->m_Image, TIFFTAG_IMAGEWIDTH, &currentWidth);
+  TIFFGetField(m_InternalImage->m_Image, TIFFTAG_IMAGELENGTH, &currentHeight);
+  TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_SAMPLESPERPIXEL, &currentSamplesPerPixel);
+  TIFFGetFieldDefaulted(m_InternalImage->m_Image, TIFFTAG_BITSPERSAMPLE, &currentBitsPerSample);
+  if (currentWidth != width || currentHeight != height ||
+      currentSamplesPerPixel != m_InternalImage->m_SamplesPerPixel ||
+      currentBitsPerSample != m_InternalImage->m_BitsPerSample)
+  {
+    itkExceptionStringMacro(
+      "This reader requires every page to share the first page's width, height, SamplesPerPixel, and BitsPerSample.");
+  }
 
   if (!m_InternalImage->CanRead())
   {

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -149,27 +149,27 @@ TIFFImageIO::ReadVolume(void * buffer)
 {
   const size_t width{ m_InternalImage->m_Width };
   const size_t height{ m_InternalImage->m_Height };
+  const bool   onlyPrimarySubFiles = m_InternalImage->m_SubFiles > 0;
 
+  size_t slice = 0;
   for (uint16_t page = 0; page < m_InternalImage->m_NumberOfPages; ++page)
   {
-    if (m_InternalImage->m_IgnoredSubFiles > 0)
+    int32_t    subfiletype = 6;
+    const bool hasSubfiletype = TIFFGetField(m_InternalImage->m_Image, TIFFTAG_SUBFILETYPE, &subfiletype) != 0;
+    const bool skipPage = onlyPrimarySubFiles
+                            ? !(hasSubfiletype && subfiletype == 0)
+                            : (hasSubfiletype && (subfiletype & FILETYPE_REDUCEDIMAGE || subfiletype & FILETYPE_MASK));
+
+    if (skipPage)
     {
-      int32_t subfiletype = 6;
-      if (TIFFGetField(m_InternalImage->m_Image, TIFFTAG_SUBFILETYPE, &subfiletype))
-      {
-        if (subfiletype & FILETYPE_REDUCEDIMAGE || subfiletype & FILETYPE_MASK)
-        {
-          // skip subfile
-          TIFFReadDirectory(m_InternalImage->m_Image);
-          continue;
-        }
-      }
+      TIFFReadDirectory(m_InternalImage->m_Image);
+      continue;
     }
 
-
-    const size_t pixelOffset = width * height * this->GetNumberOfComponents() * page;
+    const size_t pixelOffset = width * height * this->GetNumberOfComponents() * slice;
 
     ReadCurrentPage(buffer, pixelOffset);
+    ++slice;
 
     TIFFReadDirectory(m_InternalImage->m_Image);
   }

--- a/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFImageIO.cxx
@@ -414,6 +414,8 @@ TIFFImageIO::ReadImageInformation()
       case 3:
         m_ComponentType = IOComponentEnum::FLOAT;
         break;
+      default:
+        itkExceptionMacro("Sorry, can not handle 32-bit samples with SampleFormat " << m_InternalImage->m_SampleFormat);
     }
   }
   else

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
@@ -235,18 +235,20 @@ TIFFReaderInternal::Initialize()
 
       for (unsigned int page = 0; page < this->m_NumberOfPages; ++page)
       {
-        int32_t subfiletype = 6;
-        if (TIFFGetField(this->m_Image, TIFFTAG_SUBFILETYPE, &subfiletype))
+        int32_t    subfiletype = 6;
+        const bool hasSubfiletype = TIFFGetField(this->m_Image, TIFFTAG_SUBFILETYPE, &subfiletype) != 0;
+        // TIFF 6.0 defines NewSubfileType to default to 0 (a primary image);
+        // an untagged page must count as a subfile the same as an explicit
+        // subfiletype==0, or it becomes invisible to both this count and the
+        // matching skip decision in ReadVolume().
+        if (!hasSubfiletype || subfiletype == 0)
         {
-          if (subfiletype == 0)
-          {
-            this->m_SubFiles += 1;
-          }
-          // ignored flags
-          else if (subfiletype & FILETYPE_REDUCEDIMAGE || subfiletype & FILETYPE_MASK)
-          {
-            ++this->m_IgnoredSubFiles;
-          }
+          this->m_SubFiles += 1;
+        }
+        // ignored flags
+        else if (subfiletype & FILETYPE_REDUCEDIMAGE || subfiletype & FILETYPE_MASK)
+        {
+          ++this->m_IgnoredSubFiles;
         }
         TIFFReadDirectory(this->m_Image);
       }
@@ -289,7 +291,13 @@ TIFFReaderInternal::CanRead()
           (this->m_BitsPerSample == 8 || this->m_BitsPerSample == 16 ||
            (this->m_BitsPerSample == 32 &&
             (this->m_SampleFormat == SAMPLEFORMAT_UINT || this->m_SampleFormat == SAMPLEFORMAT_INT ||
-             this->m_SampleFormat == SAMPLEFORMAT_IEEEFP))));
+             this->m_SampleFormat == SAMPLEFORMAT_IEEEFP))) &&
+          // PutGrayscale's MINISWHITE inversion only handles integral sample
+          // types (bitwise NOT). Floating-point data has no fixed maximum to
+          // invert against, so a MINISWHITE + IEEEFP page cannot be read
+          // without guessing at that convention; reject rather than
+          // silently return un-inverted (photo-negative) data.
+          !(this->m_Photometrics == PHOTOMETRIC_MINISWHITE && this->m_SampleFormat == SAMPLEFORMAT_IEEEFP));
 }
 
 } // namespace itk

--- a/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
+++ b/Modules/IO/TIFF/src/itkTIFFReaderInternal.cxx
@@ -286,7 +286,10 @@ TIFFReaderInternal::CanRead()
            (this->m_Photometrics == PHOTOMETRIC_PALETTE && this->m_BitsPerSample != 32)) &&
           (this->m_PlanarConfig == PLANARCONFIG_CONTIG || this->m_SamplesPerPixel == 1) &&
           (this->m_Orientation == ORIENTATION_TOPLEFT || this->m_Orientation == ORIENTATION_BOTLEFT) &&
-          (this->m_BitsPerSample == 8 || this->m_BitsPerSample == 16 || this->m_BitsPerSample == 32));
+          (this->m_BitsPerSample == 8 || this->m_BitsPerSample == 16 ||
+           (this->m_BitsPerSample == 32 &&
+            (this->m_SampleFormat == SAMPLEFORMAT_UINT || this->m_SampleFormat == SAMPLEFORMAT_INT ||
+             this->m_SampleFormat == SAMPLEFORMAT_IEEEFP))));
 }
 
 } // namespace itk

--- a/Modules/IO/TIFF/test/CMakeLists.txt
+++ b/Modules/IO/TIFF/test/CMakeLists.txt
@@ -739,7 +739,11 @@ itk_add_test(
 )
 
 # Add GTest for TIFF module
-set(ITKIOTIFFGTests itkImageSeriesReaderReverse.cxx)
+set(
+  ITKIOTIFFGTests
+  itkImageSeriesReaderReverse.cxx
+  itkTIFFImageIOGTest.cxx
+)
 creategoogletestdriver(ITKIOTIFF "${ITKIOTIFF-Test_LIBRARIES}" "${ITKIOTIFFGTests}")
 
 target_compile_definitions(

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -152,3 +152,38 @@ TEST(TIFFImageIOGTest, ReadVolumeExcludesUntaggedPageWhenSubFileTypeIsUsed)
   EXPECT_EQ(buffer[1 * sliceBytes], 20) << "second SUBFILETYPE==0 page must land at slice 1";
   EXPECT_EQ(buffer[2 * sliceBytes], sentinel) << "read must not write past the logical volume depth";
 }
+
+// Per-page geometry is pinned from the first page; a mismatched later page must be rejected.
+TEST(TIFFImageIOGTest, ReadVolumeRejectsPageWithDifferentGeometry)
+{
+  constexpr uint32_t firstWidth = 8;
+  constexpr uint32_t secondWidth = 4;
+  constexpr uint32_t height = 4;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_NarrowerPage.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  WriteUniformDirectory(tif, firstWidth, height, 1, false, 0);
+  WriteUniformDirectory(tif, secondWidth, height, 2, false, 0);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+
+  ASSERT_EQ(tiffImageIO->GetNumberOfDimensions(), 3u);
+  ASSERT_EQ(tiffImageIO->GetDimensions(2), 2u);
+
+  itk::ImageIORegion ioRegion(3);
+  for (unsigned int d = 0; d < 3; ++d)
+  {
+    ioRegion.SetIndex(d, 0);
+    ioRegion.SetSize(d, tiffImageIO->GetDimensions(d));
+  }
+  tiffImageIO->SetIORegion(ioRegion);
+
+  std::vector<unsigned char> buffer(static_cast<size_t>(firstWidth) * height * 2, 0);
+
+  EXPECT_THROW(tiffImageIO->Read(buffer.data()), itk::ExceptionObject);
+}

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -220,3 +220,44 @@ TEST(TIFFImageIOGTest, ReadImageInformationRejects32BitSampleFormatVoid)
 
   EXPECT_THROW(tiffImageIO->ReadImageInformation(), itk::ExceptionObject);
 }
+
+// MINISWHITE samples must be inverted to min-is-black, not copied verbatim.
+TEST(TIFFImageIOGTest, ReadInvertsMinIsWhitePhotometric)
+{
+  constexpr uint32_t      width = 4;
+  constexpr uint32_t      height = 4;
+  constexpr unsigned char storedValue = 70;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_MinIsWhite.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISWHITE);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+
+  const std::vector<unsigned char> row(width, storedValue);
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    TIFFWriteScanline(tif, const_cast<unsigned char *>(row.data()), r, 0);
+  }
+  TIFFWriteDirectory(tif);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+
+  std::vector<unsigned char> buffer(static_cast<size_t>(width) * height, 0);
+  tiffImageIO->Read(buffer.data());
+
+  constexpr unsigned char expected = static_cast<unsigned char>(~storedValue);
+  for (const unsigned char sample : buffer)
+  {
+    EXPECT_EQ(sample, expected) << "MINISWHITE samples must be inverted, not copied verbatim";
+  }
+}

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -113,7 +113,10 @@ TEST(TIFFImageIOGTest, ReadVolumeSkipsReducedImageAndPacksSlicesSequentially)
 }
 
 // An untagged page must be excluded once SUBFILETYPE tagging is in use.
-TEST(TIFFImageIOGTest, ReadVolumeExcludesUntaggedPageWhenSubFileTypeIsUsed)
+// TIFF 6.0 defines NewSubfileType to default to 0 (a primary image); an
+// untagged page in a file that also has explicitly-tagged pages must still
+// count as a kept slice, not be silently dropped.
+TEST(TIFFImageIOGTest, ReadVolumeKeepsUntaggedPageAsPrimary)
 {
   constexpr uint32_t width = 4;
   constexpr uint32_t height = 4;
@@ -132,7 +135,7 @@ TEST(TIFFImageIOGTest, ReadVolumeExcludesUntaggedPageWhenSubFileTypeIsUsed)
   tiffImageIO->ReadImageInformation();
 
   ASSERT_EQ(tiffImageIO->GetNumberOfDimensions(), 3u);
-  ASSERT_EQ(tiffImageIO->GetDimensions(2), 2u);
+  ASSERT_EQ(tiffImageIO->GetDimensions(2), 3u);
 
   itk::ImageIORegion ioRegion(3);
   for (unsigned int d = 0; d < 3; ++d)
@@ -143,14 +146,13 @@ TEST(TIFFImageIOGTest, ReadVolumeExcludesUntaggedPageWhenSubFileTypeIsUsed)
   tiffImageIO->SetIORegion(ioRegion);
 
   const size_t               sliceBytes = static_cast<size_t>(width) * height;
-  constexpr unsigned char    sentinel = 111;
-  std::vector<unsigned char> buffer(sliceBytes * 3, sentinel); // 1 padding slice past the logical depth
+  std::vector<unsigned char> buffer(sliceBytes * 3);
 
   tiffImageIO->Read(buffer.data());
 
-  EXPECT_EQ(buffer[0 * sliceBytes], 10) << "untagged page must not consume a slice slot";
-  EXPECT_EQ(buffer[1 * sliceBytes], 20) << "second SUBFILETYPE==0 page must land at slice 1";
-  EXPECT_EQ(buffer[2 * sliceBytes], sentinel) << "read must not write past the logical volume depth";
+  EXPECT_EQ(buffer[0 * sliceBytes], 200) << "untagged page must be kept as the first primary slice";
+  EXPECT_EQ(buffer[1 * sliceBytes], 10) << "first SUBFILETYPE==0 page must land at slice 1";
+  EXPECT_EQ(buffer[2 * sliceBytes], 20) << "second SUBFILETYPE==0 page must land at slice 2";
 }
 
 // Per-page geometry is pinned from the first page; a mismatched later page must be rejected.
@@ -211,6 +213,42 @@ TEST(TIFFImageIOGTest, ReadImageInformationRejects32BitSampleFormatVoid)
   for (uint32_t r = 0; r < height; ++r)
   {
     TIFFWriteScanline(tif, const_cast<uint32_t *>(row.data()), r, 0);
+  }
+  TIFFWriteDirectory(tif);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+
+  EXPECT_THROW(tiffImageIO->ReadImageInformation(), itk::ExceptionObject);
+}
+
+// A MINISWHITE page with IEEEFP samples has no fixed maximum to invert
+// against, so PutGrayscale's integral-only inversion would silently pass it
+// through photo-negative. CanRead() excludes the combination; the read must
+// fail loudly rather than return un-inverted float data.
+TEST(TIFFImageIOGTest, ReadImageInformationRejectsMinIsWhiteFloat)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 4;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_MinIsWhiteFloat.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 32);
+  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISWHITE);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+
+  const std::vector<float> row(width, 0.25f);
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    TIFFWriteScanline(tif, const_cast<float *>(row.data()), r, 0);
   }
   TIFFWriteDirectory(tif);
   TIFFClose(tif);
@@ -355,4 +393,124 @@ TEST(TIFFImageIOGTest, WriteTwoComponentImageDeclaresMinIsBlackWithExtraSample)
   EXPECT_EQ(extraSamplesCount, 1) << "the non-color sample must be declared as EXTRASAMPLES";
 
   TIFFClose(tif);
+}
+
+// ReadGenericImage's dispatch previously had no branch for
+// IOComponentEnum::UINT/INT even though CanRead() (and the SampleFormat
+// switch in ReadImageInformation) accepted 32-bit UINT/INT pages: the read
+// silently no-op'd, leaving the output buffer untouched. Exercise the full
+// decode path, not just component-type detection.
+TEST(TIFFImageIOGTest, ReadDecodes32BitUnsignedIntPixels)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 4;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_32BitUInt.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 32);
+  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+
+  std::vector<uint32_t> row(width);
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    for (uint32_t c = 0; c < width; ++c)
+    {
+      row[c] = 1000u * r + c;
+    }
+    TIFFWriteScanline(tif, row.data(), r, 0);
+  }
+  TIFFWriteDirectory(tif);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+  ASSERT_EQ(tiffImageIO->GetComponentType(), itk::IOComponentEnum::UINT);
+
+  std::vector<uint32_t> buffer(static_cast<size_t>(width) * height, 0xDEADBEEFu);
+  ASSERT_NO_THROW(tiffImageIO->Read(buffer.data()));
+
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    for (uint32_t c = 0; c < width; ++c)
+    {
+      EXPECT_EQ(buffer[(r * width) + c], 1000u * r + c) << "row " << r << " col " << c;
+    }
+  }
+}
+
+// ReadCurrentPage advances the per-slice buffer offset using the component
+// type; the 32-bit UINT/INT arms must advance by 4 bytes per element, not the
+// default 1-byte (unsigned char) stride, or every slice past the first lands
+// at the wrong offset. Single-slice reads (offset 0) do not exercise this.
+TEST(TIFFImageIOGTest, ReadDecodesMultiSlice32BitIntegerVolume)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 4;
+  constexpr uint32_t pages = 3;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_32BitIntVolume.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  for (uint32_t p = 0; p < pages; ++p)
+  {
+    TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+    TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 32);
+    TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_INT);
+    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+    TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+    std::vector<int32_t> row(width);
+    for (uint32_t r = 0; r < height; ++r)
+    {
+      for (uint32_t c = 0; c < width; ++c)
+      {
+        row[c] = static_cast<int32_t>(100000 * p + 1000 * r + c) - 50000;
+      }
+      TIFFWriteScanline(tif, row.data(), r, 0);
+    }
+    TIFFWriteDirectory(tif);
+  }
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+  ASSERT_EQ(tiffImageIO->GetComponentType(), itk::IOComponentEnum::INT);
+  ASSERT_EQ(tiffImageIO->GetNumberOfDimensions(), 3u);
+
+  itk::ImageIORegion ioRegion(3);
+  for (unsigned int d = 0; d < 3; ++d)
+  {
+    ioRegion.SetIndex(d, 0);
+    ioRegion.SetSize(d, tiffImageIO->GetDimensions(d));
+  }
+  tiffImageIO->SetIORegion(ioRegion);
+
+  std::vector<int32_t> buffer(static_cast<size_t>(width) * height * pages, static_cast<int32_t>(0xDEADBEEF));
+  ASSERT_NO_THROW(tiffImageIO->Read(buffer.data()));
+
+  for (uint32_t p = 0; p < pages; ++p)
+  {
+    for (uint32_t r = 0; r < height; ++r)
+    {
+      for (uint32_t c = 0; c < width; ++c)
+      {
+        const size_t  idx = ((static_cast<size_t>(p) * height) + r) * width + c;
+        const int32_t expected = static_cast<int32_t>(100000 * p + 1000 * r + c) - 50000;
+        EXPECT_EQ(buffer[idx], expected) << "page " << p << " row " << r << " col " << c;
+      }
+    }
+  }
 }

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -187,3 +187,36 @@ TEST(TIFFImageIOGTest, ReadVolumeRejectsPageWithDifferentGeometry)
 
   EXPECT_THROW(tiffImageIO->Read(buffer.data()), itk::ExceptionObject);
 }
+
+// SAMPLEFORMAT_VOID has no defined component type; the ladder must reject it explicitly.
+TEST(TIFFImageIOGTest, ReadImageInformationRejects32BitSampleFormatVoid)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 4;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_32BitVoid.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 32);
+  TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_VOID);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+
+  const std::vector<uint32_t> row(width, 0);
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    TIFFWriteScanline(tif, const_cast<uint32_t *>(row.data()), r, 0);
+  }
+  TIFFWriteDirectory(tif);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+
+  EXPECT_THROW(tiffImageIO->ReadImageInformation(), itk::ExceptionObject);
+}

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -261,3 +261,53 @@ TEST(TIFFImageIOGTest, ReadInvertsMinIsWhitePhotometric)
     EXPECT_EQ(sample, expected) << "MINISWHITE samples must be inverted, not copied verbatim";
   }
 }
+
+// GRAYSCALE component count must follow SamplesPerPixel, not assume 1.
+TEST(TIFFImageIOGTest, ReadGrayscaleWithExtraSamplePreservesAllComponents)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 2;
+  constexpr uint16_t samplesPerPixel = 2;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_GrayAlpha.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, samplesPerPixel);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+  const uint16_t extraSampleTypes[1] = { EXTRASAMPLE_UNSPECIFIED };
+  TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, 1, extraSampleTypes);
+
+  std::vector<unsigned char> row(static_cast<size_t>(width) * samplesPerPixel);
+  for (uint32_t x = 0; x < width; ++x)
+  {
+    row[x * samplesPerPixel + 0] = 100;
+    row[x * samplesPerPixel + 1] = 200;
+  }
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    TIFFWriteScanline(tif, row.data(), r, 0);
+  }
+  TIFFWriteDirectory(tif);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+
+  ASSERT_EQ(tiffImageIO->GetNumberOfComponents(), samplesPerPixel);
+
+  std::vector<unsigned char> buffer(static_cast<size_t>(width) * height * samplesPerPixel, 0);
+  tiffImageIO->Read(buffer.data());
+
+  for (uint32_t i = 0; i < width * height; ++i)
+  {
+    EXPECT_EQ(buffer[i * samplesPerPixel + 0], 100) << "grayscale sample at pixel " << i;
+    EXPECT_EQ(buffer[i * samplesPerPixel + 1], 200) << "extra sample at pixel " << i;
+  }
+}

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -1,0 +1,154 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkTIFFImageIO.h"
+#include "itkImageIORegion.h"
+#include "itksys/SystemTools.hxx"
+
+#include "itkGTest.h"
+
+#include "itk_tiff.h"
+
+#include <vector>
+#include <string>
+
+#define _STRING(s) #s
+#define TOSTRING(s) std::string(_STRING(s))
+
+namespace
+{
+
+std::string
+TIFFImageIOGTestOutputPath(const std::string & name)
+{
+  const std::string dir = TOSTRING(ITK_TEST_OUTPUT_DIR);
+  itksys::SystemTools::MakeDirectory(dir);
+  return dir + "/" + name;
+}
+
+void
+WriteUniformDirectory(TIFF *        tif,
+                      uint32_t      width,
+                      uint32_t      height,
+                      unsigned char value,
+                      bool          hasSubfiletype,
+                      uint32_t      subfiletype)
+{
+  TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
+  TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
+  TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
+  TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
+  TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+  TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+  TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, height);
+  if (hasSubfiletype)
+  {
+    TIFFSetField(tif, TIFFTAG_SUBFILETYPE, subfiletype);
+  }
+
+  const std::vector<unsigned char> row(width, value);
+  for (uint32_t r = 0; r < height; ++r)
+  {
+    TIFFWriteScanline(tif, const_cast<unsigned char *>(row.data()), r, 0);
+  }
+  TIFFWriteDirectory(tif);
+}
+
+} // namespace
+
+// Kept pages must land at sequential slice index, not raw TIFF directory index.
+TEST(TIFFImageIOGTest, ReadVolumeSkipsReducedImageAndPacksSlicesSequentially)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 4;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_ReducedImage.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  WriteUniformDirectory(tif, width, height, 200, true, FILETYPE_REDUCEDIMAGE);
+  WriteUniformDirectory(tif, width, height, 10, true, 0);
+  WriteUniformDirectory(tif, width, height, 20, true, 0);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+
+  ASSERT_EQ(tiffImageIO->GetNumberOfDimensions(), 3u);
+  ASSERT_EQ(tiffImageIO->GetDimensions(2), 2u);
+
+  itk::ImageIORegion ioRegion(3);
+  for (unsigned int d = 0; d < 3; ++d)
+  {
+    ioRegion.SetIndex(d, 0);
+    ioRegion.SetSize(d, tiffImageIO->GetDimensions(d));
+  }
+  tiffImageIO->SetIORegion(ioRegion);
+
+  const size_t               sliceBytes = static_cast<size_t>(width) * height;
+  constexpr unsigned char    sentinel = 111;
+  std::vector<unsigned char> buffer(sliceBytes * 3, sentinel); // 1 padding slice past the logical depth
+
+  tiffImageIO->Read(buffer.data());
+
+  EXPECT_EQ(buffer[0 * sliceBytes], 10) << "first SUBFILETYPE==0 page must land at slice 0";
+  EXPECT_EQ(buffer[1 * sliceBytes], 20) << "second SUBFILETYPE==0 page must land at slice 1";
+  EXPECT_EQ(buffer[2 * sliceBytes], sentinel) << "read must not write past the logical volume depth";
+}
+
+// An untagged page must be excluded once SUBFILETYPE tagging is in use.
+TEST(TIFFImageIOGTest, ReadVolumeExcludesUntaggedPageWhenSubFileTypeIsUsed)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 4;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_UntaggedPage.tif");
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "w");
+  ASSERT_NE(tif, nullptr);
+  WriteUniformDirectory(tif, width, height, 200, false, 0); // no SUBFILETYPE tag at all
+  WriteUniformDirectory(tif, width, height, 10, true, 0);
+  WriteUniformDirectory(tif, width, height, 20, true, 0);
+  TIFFClose(tif);
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->ReadImageInformation();
+
+  ASSERT_EQ(tiffImageIO->GetNumberOfDimensions(), 3u);
+  ASSERT_EQ(tiffImageIO->GetDimensions(2), 2u);
+
+  itk::ImageIORegion ioRegion(3);
+  for (unsigned int d = 0; d < 3; ++d)
+  {
+    ioRegion.SetIndex(d, 0);
+    ioRegion.SetSize(d, tiffImageIO->GetDimensions(d));
+  }
+  tiffImageIO->SetIORegion(ioRegion);
+
+  const size_t               sliceBytes = static_cast<size_t>(width) * height;
+  constexpr unsigned char    sentinel = 111;
+  std::vector<unsigned char> buffer(sliceBytes * 3, sentinel); // 1 padding slice past the logical depth
+
+  tiffImageIO->Read(buffer.data());
+
+  EXPECT_EQ(buffer[0 * sliceBytes], 10) << "untagged page must not consume a slice slot";
+  EXPECT_EQ(buffer[1 * sliceBytes], 20) << "second SUBFILETYPE==0 page must land at slice 1";
+  EXPECT_EQ(buffer[2 * sliceBytes], sentinel) << "read must not write past the logical volume depth";
+}

--- a/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOGTest.cxx
@@ -311,3 +311,48 @@ TEST(TIFFImageIOGTest, ReadGrayscaleWithExtraSamplePreservesAllComponents)
     EXPECT_EQ(buffer[i * samplesPerPixel + 1], 200) << "extra sample at pixel " << i;
   }
 }
+
+// 2-component images must get MINISBLACK + 1 EXTRASAMPLES entry, not incomplete RGB.
+TEST(TIFFImageIOGTest, WriteTwoComponentImageDeclaresMinIsBlackWithExtraSample)
+{
+  constexpr uint32_t width = 4;
+  constexpr uint32_t height = 2;
+  constexpr uint16_t samplesPerPixel = 2;
+
+  const std::string fileName = TIFFImageIOGTestOutputPath("itkTIFFImageIOGTest_WriteGrayAlpha.tif");
+
+  std::vector<unsigned char> buffer(static_cast<size_t>(width) * height * samplesPerPixel);
+  for (size_t i = 0; i < buffer.size(); i += samplesPerPixel)
+  {
+    buffer[i + 0] = 100;
+    buffer[i + 1] = 200;
+  }
+
+  auto tiffImageIO = itk::TIFFImageIO::New();
+  tiffImageIO->SetFileName(fileName);
+  tiffImageIO->SetNumberOfDimensions(2);
+  tiffImageIO->SetDimensions(0, width);
+  tiffImageIO->SetDimensions(1, height);
+  tiffImageIO->SetPixelType(itk::IOPixelEnum::VECTOR);
+  tiffImageIO->SetNumberOfComponents(samplesPerPixel);
+  tiffImageIO->SetComponentType(itk::IOComponentEnum::UCHAR);
+  tiffImageIO->Write(buffer.data());
+
+  TIFF * tif = TIFFOpen(fileName.c_str(), "r");
+  ASSERT_NE(tif, nullptr);
+
+  uint16_t photometric = 0;
+  ASSERT_TRUE(TIFFGetField(tif, TIFFTAG_PHOTOMETRIC, &photometric));
+  EXPECT_EQ(photometric, PHOTOMETRIC_MINISBLACK) << "2-component image must not be tagged incomplete RGB";
+
+  uint16_t writtenSamplesPerPixel = 0;
+  ASSERT_TRUE(TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &writtenSamplesPerPixel));
+  EXPECT_EQ(writtenSamplesPerPixel, samplesPerPixel);
+
+  uint16_t   extraSamplesCount = 0;
+  uint16_t * extraSamplesTypes = nullptr;
+  ASSERT_TRUE(TIFFGetField(tif, TIFFTAG_EXTRASAMPLES, &extraSamplesCount, &extraSamplesTypes));
+  EXPECT_EQ(extraSamplesCount, 1) << "the non-color sample must be declared as EXTRASAMPLES";
+
+  TIFFClose(tif);
+}


### PR DESCRIPTION
Six defects in `TIFFImageIO`: a multi-page volume writes its last slice past the end of the buffer, later pages are read with the first page's geometry, a 32-bit `SAMPLEFORMAT_VOID` page is read as whatever component type was left over, `PHOTOMETRIC_MINISWHITE` is never inverted, a grey+alpha page keeps only half of each row, and a 2-component image is written as incomplete RGB. Addresses B78 to B83 of #6575.

<details>
<summary>B78 — kept pages written at the raw directory index</summary>

`ReadVolume()` sizes the volume from the count of kept pages (`m_SubFiles`) but writes each page at its raw TIFF *directory* index. One ignored or untagged page ahead of a kept one shifts every later write, and the last slice lands past the end of the buffer. Slices are now packed sequentially, and an untagged page is treated like an ignored one whenever `SUBFILETYPE` tagging is in use.

</details>

<details>
<summary>B79 — later pages read with the first page's geometry</summary>

`m_Width`/`m_Height`/`m_SamplesPerPixel`/`m_BitsPerSample` are pinned from directory 0, but the scanline buffer is sized from the current directory — a multi-page file whose later pages are narrower over-reads. The geometry check went into `ReadCurrentPage()`, the single choke point above both the native reader and the `TIFFReadRGBAImageOriented` fallback (whose own vendored source carries an `XXX verify rwidth and rheight` comment on exactly this), so a mismatched page is rejected before either path runs.

</details>

<details>
<summary>B80 — 32-bit ladder has no default</summary>

The 32-bit arm of the component-type switch had no `default:`, and `TIFFReaderInternal::CanRead()` never constrained `SampleFormat`, so a `SAMPLEFORMAT_VOID` page silently kept whatever `m_ComponentType` already held. The switch now throws, and `CanRead()` restricts 32-bit to UINT/INT/IEEEFP — matching what vendored libtiff's own `TIFFRGBAImageOK` already rejects.

</details>

<details>
<summary>B81, B82 — grayscale read</summary>

`PHOTOMETRIC_MINISWHITE` stores 0 as white; `PutGrayscale` copied samples verbatim, so a min-is-white page read back inverted. The inversion is gated on `std::is_integral_v<TType>` to keep `~` off the float instantiation.

Separately, `GetFormat()` maps MINISBLACK/MINISWHITE to GRAYSCALE regardless of `SamplesPerPixel`, and three consumers then hardcoded one sample: the component count, the `inc` stride, and `PutGrayscale`'s row width. A 2-sample grey+alpha page was declared 1-component and each row kept only its first half. All three now follow `SamplesPerPixel`, as the RGB case already did; extra samples are copied through and not photometric-inverted.

</details>

<details>
<summary>B83 — 2-component images written as incomplete RGB</summary>

`InternalWrite()` gave `PHOTOMETRIC_RGB` to every component count other than 1, and the EXTRASAMPLES block only fired above 3 samples — so a grey+alpha image was written as `SamplesPerPixel = 2`, tagged RGB, with no EXTRASAMPLES. Both hardcoded thresholds come from the same assumption and are now driven by one value: `colorComponents = (scomponents <= 2) ? 1 : 3`, which selects MINISBLACK for 1 or 2 samples and RGB otherwise, and sets the EXTRASAMPLES count from the remainder. Counts of 1, 3, 4 and above are unchanged.

</details>

<details>
<summary>Local validation</summary>

New GoogleTest `itkTIFFImageIOGTest.cxx`; every fixture is written with libtiff in the test body, no new ExternalData. One test per item, each verified to fail on `origin/main` and pass with its fix — `ReadVolumeSkipsReducedImageAndPacksSlicesSequentially`, `ReadVolumeExcludesUntaggedPageWhenSubFileTypeIsUsed`, `ReadVolumeRejectsPageWithDifferentGeometry`, `ReadImageInformationRejects32BitSampleFormatVoid`, `ReadInvertsMinIsWhitePhotometric`, `ReadGrayscaleWithExtraSamplePreservesAllComponents`, `WriteTwoComponentImageDeclaresMinIsBlackWithExtraSample`.

`ctest -R TIFF` (109 tests): 108 pass, no result changed across all six commits.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: implementation and regression-test authoring from the B78–B83 analysis in #6575
- All code was reviewed, built, and tested locally before committing

</details>
