### PR TITLE
BUG: HDF5ImageIO: gate deflate filter on UseCompression flag

### DIFF
--- a/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
+++ b/Modules/IO/HDF5/src/itkHDF5ImageIO.cxx
@@ -42,6 +42,7 @@ HDF5ImageIO::HDF5ImageIO()
   }
   this->Self::SetMaximumCompressionLevel(9);
   this->Self::SetCompressionLevel(5);
+  this->Self::UseCompressionOn();
 }
 
 HDF5ImageIO::~HDF5ImageIO() { this->ResetToInitialState(); }
@@ -1187,8 +1188,10 @@ HDF5ImageIO::WriteImageInformation()
     // region
     const H5::DSetCreatPropList plist;
 
-    // we have implicit compression enabled here?
-    plist.setDeflate(this->GetCompressionLevel());
+    if (this->GetUseCompression())
+    {
+      plist.setDeflate(this->GetCompressionLevel());
+    }
 
     dims[0] = 1;
     plist.setChunk(numDims, dims.get());


### PR DESCRIPTION
Gate `setDeflate` in `HDF5ImageIO::Write` on `GetUseCompression()`, and add `UseCompressionOn()` to the constructor to preserve existing behavior.

<details>
<summary>Root cause</summary>

`plist.setDeflate(GetCompressionLevel())` was called unconditionally, making `UseCompressionOff()` have no effect (S28 from SimpleITK/SimpleITK#2625). Since `ImageIOBase` defaults `m_UseCompression = false`, HDF5 files were always written with deflate regardless of the flag state. Adding `UseCompressionOn()` to the constructor restores the previous always-compress default while making the flag meaningful.

</details>

<details>
<summary>AI assistance</summary>

- GitHub Copilot: identified root cause, authored fix, verified with local tests

</details>

<details>
<summary>Test results</summary>

```
ctest --preset default -R HDF5 --output-on-failure
100% tests passed, 0 tests failed out of 9
```

</details>