### PR TITLE
BUG: Decode single-bit DICOM contiguously; validate PixelSpacing multiplicity

### DIFF
--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
@@ -357,10 +357,15 @@ GDCMImageIO::Read(void * pointer)
 
   if (m_SingleBit)
   {
-    const auto copy = make_unique_for_overwrite<unsigned char[]>(len);
-    auto *     t = reinterpret_cast<unsigned char *>(pointer);
-    size_t     j = 0;
-    for (size_t i = 0; i < len / 8; ++i)
+    // DICOM PS3.5 packs 1-bit Pixel Data contiguously (no per-row byte padding):
+    // bit i of the pixel stream is bit (i % 8) of byte (i / 8). `len` pixels
+    // require ceil(len / 8) source bytes; the final byte may be only partially
+    // used when `len` is not a multiple of 8.
+    const auto   copy = make_unique_for_overwrite<unsigned char[]>(len);
+    const auto * t = reinterpret_cast<const unsigned char *>(pointer);
+    const size_t fullBytes = len / 8;
+    size_t       j = 0;
+    for (size_t i = 0; i < fullBytes; ++i)
     {
       const unsigned char c = t[i];
       copy[j + 0] = (c & 0x01) ? 255 : 0;
@@ -372,6 +377,15 @@ GDCMImageIO::Read(void * pointer)
       copy[j + 6] = (c & 0x40) ? 255 : 0;
       copy[j + 7] = (c & 0x80) ? 255 : 0;
       j += 8;
+    }
+    const size_t remainder = len % 8;
+    if (remainder > 0)
+    {
+      const unsigned char c = t[fullBytes];
+      for (size_t bit = 0; bit < remainder; ++bit)
+      {
+        copy[j + bit] = (c & (1 << bit)) ? 255 : 0;
+      }
     }
     memcpy(static_cast<char *>(pointer), copy.get(), len);
   }
@@ -662,26 +676,45 @@ GDCMImageIO::InternalReadImageInformation()
       const gdcm::Tag     spacingTag(0x0028, 0x0030);
       if (const gdcm::DataElement & de = ds.GetDataElement(spacingTag); !de.IsEmpty())
       {
-        std::stringstream                            m_Ss;
-        gdcm::Element<gdcm::VR::DS, gdcm::VM::VM1_n> m_El;
-        const gdcm::ByteValue *                      bv = de.GetByteValue();
+        const gdcm::ByteValue * bv = de.GetByteValue();
         assert(bv);
-        const std::string s(bv->GetPointer(), bv->GetLength());
-        m_Ss.str(s);
-        // Erroneous file CT-MONO2-8-abdo.dcm,
-        // The spacing is something like that [0.2\0\0.200000],
-        // TODO throw an exception that VM is not compatible.
-        m_El.SetLength(16);
-        m_El.Read(m_Ss);
-        assert(m_El.GetLength() == 2);
-        for (unsigned long i = 0; i < m_El.GetLength(); ++i)
+        const size_t numberOfValues = gdcm::VM::GetNumberOfElementsFromArray(bv->GetPointer(), bv->GetLength());
+        if (numberOfValues == 1)
         {
-          sp.push_back(m_El.GetValue(i));
+          // Isotropic spacing encoded as a single value rather than the usual two.
+          const std::string  singleValue(bv->GetPointer(), bv->GetLength());
+          std::istringstream iss(singleValue.substr(0, singleValue.find('\\')));
+          double             value = 0.0;
+          if (!(iss >> value) || value <= 0.0 || !(iss >> std::ws).eof())
+          {
+            itkExceptionMacro("PixelSpacing (0028,0030) single value '" << singleValue
+                                                                        << "' is not a positive number.");
+          }
+          spacing[0] = value;
+          spacing[1] = value;
         }
-        std::swap(sp[0], sp[1]);
-        assert(sp.size() == 2);
-        spacing[0] = sp[0];
-        spacing[1] = sp[1];
+        else if (numberOfValues == 2)
+        {
+          std::stringstream                            m_Ss;
+          gdcm::Element<gdcm::VR::DS, gdcm::VM::VM1_n> m_El;
+          m_Ss.str(std::string(bv->GetPointer(), bv->GetLength()));
+          m_El.SetLength(16);
+          m_El.Read(m_Ss);
+          for (unsigned long i = 0; i < m_El.GetLength(); ++i)
+          {
+            sp.push_back(m_El.GetValue(i));
+          }
+          std::swap(sp[0], sp[1]);
+          spacing[0] = sp[0];
+          spacing[1] = sp[1];
+        }
+        else
+        {
+          // Erroneous file CT-MONO2-8-abdo.dcm has PixelSpacing values like
+          // [0.2\0\0.200000] (three, one of them empty): VM is not compatible.
+          itkExceptionMacro("PixelSpacing (0028,0030) has " << numberOfValues
+                                                            << " values; expected 1 (isotropic) or 2.");
+        }
       }
       else
       {

--- a/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx
@@ -18,12 +18,19 @@
 
 #include "itkImage.h"
 #include "itkImageFileWriter.h"
+#include "itkImageFileReader.h"
 #include "itkGDCMImageIO.h"
 #include "itkGDCMSeriesFileNames.h"
 #include "itkMetaDataObject.h"
 #include "itkGTest.h"
 #include "itksys/SystemTools.hxx"
 #include "itkImageSeriesReader.h"
+#include "gdcmReader.h"
+#include "gdcmWriter.h"
+#include "gdcmAttribute.h"
+#include "gdcmDataSet.h"
+#include "gdcmDataElement.h"
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -39,6 +46,12 @@ struct ITKGDCMImageIO : public ::testing::Test
   void
   SetUp() override
   {
+    // CTest may run TEST_F cases from this fixture concurrently; a shared
+    // scratch directory lets one test's TearDown remove the directory
+    // another test is still writing into. Suffix with the test name so
+    // each process owns its own scratch directory.
+    const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
+    m_TempDir = TOSTRING(ITK_TEST_OUTPUT_DIR) + "/ITKGDCMImageIO_" + info->name();
     itksys::SystemTools::MakeDirectory(m_TempDir);
   }
 
@@ -48,7 +61,7 @@ struct ITKGDCMImageIO : public ::testing::Test
     itksys::SystemTools::RemoveADirectory(m_TempDir);
   }
 
-  const std::string m_TempDir{ TOSTRING(ITK_TEST_OUTPUT_DIR) + "/ITKGDCMImageIO" };
+  std::string       m_TempDir;
   const std::string m_DicomSeriesInput{ TOSTRING(DICOM_SERIES_INPUT) };
 };
 
@@ -151,6 +164,225 @@ private:
     }
   }
 };
+
+// DICOM PS3.5 packs 1-bit Pixel Data contiguously (no per-row byte padding):
+// bit i of the pixel stream is bit (i % 8) of byte (i / 8).
+std::vector<uint8_t>
+PackContiguousBits(const std::vector<uint8_t> & pixels)
+{
+  std::vector<uint8_t> packed((pixels.size() + 7) / 8, 0);
+  for (size_t i = 0; i < pixels.size(); ++i)
+  {
+    if (pixels[i] != 0)
+    {
+      packed[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+    }
+  }
+  return packed;
+}
+
+std::string
+WriteSingleBitDicom(const std::string & dir, size_t width, size_t height, const std::vector<uint8_t> & pixels)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto                image = ImageType::New();
+  ImageType::SizeType size{ { static_cast<itk::SizeValueType>(width), static_cast<itk::SizeValueType>(height) } };
+  image->SetRegions(ImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(0);
+
+  auto & dict = image->GetMetaDataDictionary();
+  itk::EncapsulateMetaData<std::string>(dict, "0008|0060", "OT");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0010", "Test^Patient");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0020", "12345");
+
+  auto gdcmIO = itk::GDCMImageIO::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetImageIO(gdcmIO);
+  writer->SetInput(image);
+  const std::string basePath = dir + "/singlebit_base.dcm";
+  writer->SetFileName(basePath);
+  writer->Update();
+
+  gdcm::Reader reader;
+  reader.SetFileName(basePath.c_str());
+  if (!reader.Read())
+  {
+    return {};
+  }
+  gdcm::DataSet & ds = reader.GetFile().GetDataSet();
+
+  gdcm::Attribute<0x0028, 0x0002> samplesPerPixel;
+  samplesPerPixel.SetValue(1);
+  ds.Replace(samplesPerPixel.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0100> bitsAllocated;
+  bitsAllocated.SetValue(1);
+  ds.Replace(bitsAllocated.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0101> bitsStored;
+  bitsStored.SetValue(1);
+  ds.Replace(bitsStored.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0102> highBit;
+  highBit.SetValue(0);
+  ds.Replace(highBit.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0103> pixelRepresentation;
+  pixelRepresentation.SetValue(0);
+  ds.Replace(pixelRepresentation.GetAsDataElement());
+
+  const std::vector<uint8_t> packed = PackContiguousBits(pixels);
+  gdcm::DataElement          pixelData{ gdcm::Tag(0x7fe0, 0x0010) };
+  pixelData.SetVR(gdcm::VR::OB);
+  pixelData.SetByteValue(reinterpret_cast<const char *>(packed.data()), static_cast<uint32_t>(packed.size()));
+  ds.Replace(pixelData);
+
+  const std::string outPath = dir + "/singlebit.dcm";
+  gdcm::Writer      gdcmWriter;
+  gdcmWriter.SetFileName(outPath.c_str());
+  gdcmWriter.SetFile(reader.GetFile());
+  if (!gdcmWriter.Write())
+  {
+    return {};
+  }
+  return outPath;
+}
+
+// Builds a multi-frame single-bit DICOM whose entire pixel stream (all
+// frames concatenated) is packed as one contiguous bitstream -- matching
+// pydicom.pixels.utils.pack_bits(), which highdicom calls directly: it
+// ravels the full (frames, rows, columns) array in C order before packing,
+// padding only at the very end of the whole stream, never per-row or
+// per-frame (issue #6575, reviewer-cited highdicom scenario).
+std::string
+WriteMultiFrameSingleBitDicom(const std::string &          dir,
+                              size_t                       width,
+                              size_t                       height,
+                              size_t                       frames,
+                              const std::vector<uint8_t> & pixels)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto                image = ImageType::New();
+  ImageType::SizeType size{ { static_cast<itk::SizeValueType>(width), static_cast<itk::SizeValueType>(height) } };
+  image->SetRegions(ImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(0);
+
+  auto & dict = image->GetMetaDataDictionary();
+  itk::EncapsulateMetaData<std::string>(dict, "0008|0060", "OT");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0010", "Test^Patient");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0020", "12345");
+
+  auto gdcmIO = itk::GDCMImageIO::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetImageIO(gdcmIO);
+  writer->SetInput(image);
+  const std::string basePath = dir + "/singlebit_mf_base.dcm";
+  writer->SetFileName(basePath);
+  writer->Update();
+
+  gdcm::Reader reader;
+  reader.SetFileName(basePath.c_str());
+  if (!reader.Read())
+  {
+    return {};
+  }
+  gdcm::DataSet & ds = reader.GetFile().GetDataSet();
+
+  gdcm::Attribute<0x0028, 0x0002> samplesPerPixel;
+  samplesPerPixel.SetValue(1);
+  ds.Replace(samplesPerPixel.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0100> bitsAllocated;
+  bitsAllocated.SetValue(1);
+  ds.Replace(bitsAllocated.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0101> bitsStored;
+  bitsStored.SetValue(1);
+  ds.Replace(bitsStored.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0102> highBit;
+  highBit.SetValue(0);
+  ds.Replace(highBit.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0103> pixelRepresentation;
+  pixelRepresentation.SetValue(0);
+  ds.Replace(pixelRepresentation.GetAsDataElement());
+
+  gdcm::Attribute<0x0028, 0x0008> numberOfFrames;
+  numberOfFrames.SetValue(static_cast<int>(frames));
+  ds.Replace(numberOfFrames.GetAsDataElement());
+
+  const std::vector<uint8_t> packed = PackContiguousBits(pixels);
+  gdcm::DataElement          pixelData{ gdcm::Tag(0x7fe0, 0x0010) };
+  pixelData.SetVR(gdcm::VR::OB);
+  pixelData.SetByteValue(reinterpret_cast<const char *>(packed.data()), static_cast<uint32_t>(packed.size()));
+  ds.Replace(pixelData);
+
+  const std::string outPath = dir + "/singlebit_mf.dcm";
+  gdcm::Writer      gdcmWriter;
+  gdcmWriter.SetFileName(outPath.c_str());
+  gdcmWriter.SetFile(reader.GetFile());
+  if (!gdcmWriter.Write())
+  {
+    return {};
+  }
+  return outPath;
+}
+
+std::string
+WriteHardcopyDicomWithPixelSpacing(const std::string & dir, const std::string & pixelSpacingValue)
+{
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto                image = ImageType::New();
+  ImageType::SizeType size{ { 4, 4 } };
+  image->SetRegions(ImageType::RegionType(size));
+  image->Allocate();
+  image->FillBuffer(0);
+
+  auto & dict = image->GetMetaDataDictionary();
+  itk::EncapsulateMetaData<std::string>(dict, "0008|0060", "OT");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0010", "Test^Patient");
+  itk::EncapsulateMetaData<std::string>(dict, "0010|0020", "12345");
+
+  auto gdcmIO = itk::GDCMImageIO::New();
+  auto writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetImageIO(gdcmIO);
+  writer->SetInput(image);
+  const std::string basePath = dir + "/pixelspacing_base.dcm";
+  writer->SetFileName(basePath);
+  writer->Update();
+
+  gdcm::Reader reader;
+  reader.SetFileName(basePath.c_str());
+  if (!reader.Read())
+  {
+    return {};
+  }
+  gdcm::DataSet & ds = reader.GetFile().GetDataSet();
+
+  const std::string sopClassUIDValue = "1.2.840.10008.5.1.1.29"; // HardcopyGrayscaleImageStorage
+  gdcm::DataElement sopClassUID{ gdcm::Tag(0x0008, 0x0016) };
+  sopClassUID.SetVR(gdcm::VR::UI);
+  sopClassUID.SetByteValue(sopClassUIDValue.c_str(), static_cast<uint32_t>(sopClassUIDValue.size()));
+  ds.Replace(sopClassUID);
+
+  gdcm::DataElement pixelSpacing{ gdcm::Tag(0x0028, 0x0030) };
+  pixelSpacing.SetVR(gdcm::VR::DS);
+  pixelSpacing.SetByteValue(pixelSpacingValue.c_str(), static_cast<uint32_t>(pixelSpacingValue.size()));
+  ds.Replace(pixelSpacing);
+
+  const std::string outPath = dir + "/pixelspacing.dcm";
+  gdcm::Writer      gdcmWriter;
+  gdcmWriter.SetFileName(outPath.c_str());
+  gdcmWriter.SetFile(reader.GetFile());
+  if (!gdcmWriter.Write())
+  {
+    return {};
+  }
+  return outPath;
+}
 
 } // namespace
 
@@ -336,4 +568,176 @@ TEST_F(ITKGDCMSeriesTestData, ReadSeriesBottomToTop)
   EXPECT_GT(image2->GetSpacing()[2], 0.0);
   // and the direction should have a positive Z component
   EXPECT_GT(image2->GetDirection()[2][2], 0.0);
+}
+
+// DICOM PS3.5 packs 1-bit Pixel Data contiguously; a pixel count that is not
+// a multiple of 8 must not silently drop the trailing partial byte's bits
+// (issue #6575, B-gdcm-singlebit). Alternating pattern (not all-one) also
+// catches bit-order and stride errors that a uniform fixture would miss.
+TEST_F(ITKGDCMImageIO, SingleBitContiguousPackingDecodesNonByteAlignedPixelCount)
+{
+  constexpr size_t     width = 9;
+  constexpr size_t     height = 3;
+  std::vector<uint8_t> pixels(width * height);
+  for (size_t i = 0; i < pixels.size(); ++i)
+  {
+    pixels[i] = static_cast<uint8_t>(i % 2);
+  }
+
+  const std::string path = WriteSingleBitDicom(m_TempDir, width, height, pixels);
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  for (size_t row = 0; row < height; ++row)
+  {
+    for (size_t col = 0; col < width; ++col)
+    {
+      const ImageType::IndexType idx{ { static_cast<itk::IndexValueType>(col),
+                                        static_cast<itk::IndexValueType>(row) } };
+      const size_t               i = (row * width) + col;
+      const unsigned char        expected = pixels[i] ? 255 : 0;
+      EXPECT_EQ(image->GetPixel(idx), expected) << "row " << row << " col " << col;
+    }
+  }
+}
+
+TEST_F(ITKGDCMImageIO, SingleValuePixelSpacingIsIsotropic)
+{
+  const std::string path = WriteHardcopyDicomWithPixelSpacing(m_TempDir, "0.5 ");
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[0], 0.5);
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[1], 0.5);
+}
+
+// A single value followed by a stray trailing backslash and no second value
+// must still be treated as isotropic, not as a two-value tag with an
+// uninitialized second element (issue #6575, B-gdcm-pixelspacing).
+TEST_F(ITKGDCMImageIO, TrailingBackslashPixelSpacingIsStillIsotropic)
+{
+  const std::string path = WriteHardcopyDicomWithPixelSpacing(m_TempDir, "0.5\\");
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[0], 0.5);
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[1], 0.5);
+}
+
+TEST_F(ITKGDCMImageIO, TwoValuePixelSpacingIsRespected)
+{
+  const std::string path = WriteHardcopyDicomWithPixelSpacing(m_TempDir, "0.5\\0.25 ");
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  // The reader swaps the two DICOM (row, column) values to ITK (x, y) order.
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[0], 0.25);
+  EXPECT_DOUBLE_EQ(image->GetSpacing()[1], 0.5);
+}
+
+// A single-value PixelSpacing whose text is not a positive number must be
+// rejected, not silently accepted as zero spacing.
+TEST_F(ITKGDCMImageIO, MalformedSingleValuePixelSpacingThrows)
+{
+  const std::string path = WriteHardcopyDicomWithPixelSpacing(m_TempDir, "N/A ");
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}
+
+TEST_F(ITKGDCMImageIO, TrailingGarbageSingleValuePixelSpacingThrows)
+{
+  // Stream extraction of "0.5abc" reads 0.5 and leaves "abc" unread; the
+  // trailing-content check rejects it instead of accepting a truncated value.
+  const std::string path = WriteHardcopyDicomWithPixelSpacing(m_TempDir, "0.5abc ");
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 2>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}
+
+// Reproduces the multi-frame scenario a reviewer cited (12 x 13 x 8, a
+// non-byte-aligned per-frame size) to challenge the single-bit decode fix.
+// Verified against pydicom.pixels.utils.pack_bits (the function highdicom
+// itself calls to encode BitsAllocated=1 SEG frames): it ravels the ENTIRE
+// (frames, rows, columns) array in C order and packs it as one continuous
+// bitstream, padding only at the very end -- never per-row or per-frame.
+// Columns=12 keeps each row byte-misaligned on its own, so this can only
+// pass if frames are decoded as part of one contiguous stream rather than
+// each restarting byte alignment at its own boundary.
+TEST_F(ITKGDCMImageIO, ReadDecodesMultiFrameSingleBitAsOneContiguousBitstream)
+{
+  constexpr size_t     width = 12;
+  constexpr size_t     height = 13;
+  constexpr size_t     frames = 8;
+  std::vector<uint8_t> pixels(width * height * frames);
+  for (size_t i = 0; i < pixels.size(); ++i)
+  {
+    // A varied, non-uniform pattern so any misalignment (row, frame, or
+    // otherwise) shows up as a wrong value rather than being masked by a
+    // uniform fixture.
+    pixels[i] = static_cast<uint8_t>((i * 7 + 3) % 5 < 2 ? 1 : 0);
+  }
+
+  const std::string path = WriteMultiFrameSingleBitDicom(m_TempDir, width, height, frames, pixels);
+  ASSERT_FALSE(path.empty());
+
+  using ImageType = itk::Image<unsigned char, 3>;
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(itk::GDCMImageIO::New());
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer    image = reader->GetOutput();
+  const ImageType::RegionType region = image->GetLargestPossibleRegion();
+  ASSERT_EQ(region.GetSize(0), width);
+  ASSERT_EQ(region.GetSize(1), height);
+  ASSERT_EQ(region.GetSize(2), frames);
+
+  for (size_t f = 0; f < frames; ++f)
+  {
+    for (size_t row = 0; row < height; ++row)
+    {
+      for (size_t col = 0; col < width; ++col)
+      {
+        const size_t               i = (f * width * height) + (row * width) + col;
+        const ImageType::IndexType idx{ { static_cast<itk::IndexValueType>(col),
+                                          static_cast<itk::IndexValueType>(row),
+                                          static_cast<itk::IndexValueType>(f) } };
+        const unsigned char        expected = pixels[i] ? 255 : 0;
+        EXPECT_EQ(image->GetPixel(idx), expected) << "frame " << f << " row " << row << " col " << col;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Correct single-bit decode and PixelSpacing parsing in `itkGDCMImageIO`, replacing the reverted #6629 (see #6638). Now rebased directly on `main` (the #6638 revert has merged), so the diff is a single self-contained commit.

Thanks to **@issakomi** for pushing back with a real multi-frame example (13×12×8, `Columns=12`) that let this be verified against actual data rather than just analysis — see below.

<details>
<summary>What changed</summary>

**Single-bit decode.** DICOM PS3.5 packs 1-bit Pixel Data contiguously (no per-row byte padding) — the pre-#6629 code already unpacked this way, but silently dropped the trailing `len % 8` pixels whenever the total pixel count wasn't a multiple of 8 (the fixture in #6629 happened to use 40 pixels, a multiple of 8, so this went uncaught). Fixed: the final partial byte is now unpacked for its remaining bits.

**PixelSpacing (0028,0030).** Replaced `s.find('\\')` (which only asked "is there a backslash anywhere", not "how many values") with `gdcm::VM::GetNumberOfElementsFromArray`, GDCM's own multiplicity counter. This correctly distinguishes:
- 1 value → isotropic, both axes set from it (parsed directly, not through `gdcm::Element`, which requires a length divisible by its per-value size and rejects arbitrary single-value strings); a non-numeric or non-positive single value (e.g. `N/A`) is rejected rather than silently accepted as 0.0 spacing
- 2 values → the existing row/column swap logic, unchanged
- a trailing separator with no following value (e.g. `"0.5\"`) → still correctly counted as 1 value, not 2, per GDCM's own counting rules (verified: `GetNumberOfElementsFromArray` never increments the count after a backslash unless a value followed it)
- anything else (e.g. the known-malformed `CT-MONO2-8-abdo.dcm` `[0.2\0\0.200000]`) → throws, rather than reading garbage

</details>

<details>
<summary>Verification against a real multi-frame SEG file (prompted by @issakomi)</summary>

@issakomi raised a serious concern: GDCM's own `Bitmap::GetBufferLength()` computes single-bit buffer length with **row padding**, and cited a real highdicom-generated 13×12×8 SEG file they believed ITK mis-decodes. This deserved empirical verification, not just re-asserting the analysis.

**Tracing GDCM's actual decode path** (`RAWCodec::DecodeBytes`, the decoder for uncompressed transfer syntax): its fast path does a **verbatim `memcpy` of on-disk bytes, no row-repacking**. `GetBufferLength()`'s row-padded value only affects how much buffer ITK allocates (harmlessly over-allocating for non-conformant widths); it does not change what bytes are written where.

**Tracing highdicom's own encoder** (`highdicom/frame.py::encode_frame`, for `BitsAllocated=1`): it calls `pydicom.pixels.utils.pack_bits`, which ravels the **entire** `(frames, rows, columns)` array in C order into one stream and packs it with `numpy.packbits(bitorder="little")`, padding only at the very end — never per-row, never per-frame.

**@issakomi's linked file, downloaded and checked directly:** `Rows=13, Columns=12, NumberOfFrames=8` (1248 total pixels). Contiguous packing predicts 156 bytes; row-padding predicts 208 bytes. The file's actual on-disk `PixelData` length is **156 bytes** — matching contiguous exactly. Decoded with pydicom (`ds.pixel_array`) as ground truth and with this PR's fixed `GDCMImageIO`: **all 1248 pixel values across all 8 frames match pydicom pixel-for-pixel.**

New test `ReadDecodesMultiFrameSingleBitAsOneContiguousBitstream` reproduces this exact scenario (12×13×8, non-uniform bit pattern, packed the same way pydicom does) as a permanent regression guard.

</details>

<details>
<summary>Local validation</summary>

New tests: `SingleBitContiguousPackingDecodesNonByteAlignedPixelCount` (9×3 = 27 pixels, alternating bit pattern), `SingleValuePixelSpacingIsIsotropic`, `TrailingBackslashPixelSpacingIsStillIsotropic`, `TwoValuePixelSpacingIsRespected`, `ReadDecodesMultiFrameSingleBitAsOneContiguousBitstream`.

`pre-commit run --all-files`: exit 0. `ITKGDCMImageIOGTestDriver`: 35/35 pass. `ctest -L ITKIOGDCM`: 42/42 pass, 0 regressions.

</details>

<!--
provenance: claude-code session 2026-07-14/15, forward-fix for reverted #6629; verification round prompted by @issakomi's review comment
key_facts: single-bit decode was always contiguous (matches pydicom), just missing the trailing-partial-byte case; PixelSpacing fix uses gdcm::VM::GetNumberOfElementsFromArray; empirically verified against a real highdicom-generated 13x12x8 SEG file (SOPClassUID 1.2.840.10008.5.1.4.1.1.66.4) -- on-disk PixelData length 156 bytes matches contiguous formula exactly (not 208, the row-padded formula); pydicom pixel_array matches ITK decode pixel-for-pixel across all 8 frames
related_files: Modules/IO/GDCM/src/itkGDCMImageIO.cxx (single-bit decode block, PixelSpacing block ~line 675), Modules/IO/GDCM/test/itkGDCMImageIOGTest.cxx (SingleBit*, ReadDecodesMultiFrameSingleBitAsOneContiguousBitstream)
post_merge_action: merge after #6638 (the revert) lands; this PR's base is revert-6629-gdcm-singlebit, will need rebase onto main once #6638 merges. Separate, larger-scope issue raised by @issakomi (multi-segment DICOM SEG files with differing per-segment z-extents collapse to one 3D output) is out of scope for this PR -- worth its own issue.
-->

