### PR TITLE
BUG: Widen TileImageFilter auto-size divisor to avoid overflow

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
@@ -216,10 +216,18 @@ TileImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
 
   if (m_Layout[OutputImageDimension - 1] == 0)
   {
-    int used = 1;
+    // SizeValueType (64-bit on most platforms), not int: the product of the
+    // other axes' layout counts can exceed INT_MAX, and computing it in a
+    // 32-bit int can wrap to 0, turning the division below into a
+    // division-by-zero (SIGFPE on architectures whose idiv traps).
+    SizeValueType used = 1;
     for (unsigned int d = 0; d < OutputImageDimension - 1; ++d)
     {
       used *= m_Layout[d];
+    }
+    if (used == 0)
+    {
+      itkExceptionMacro("Layout has a zero entry on a non-last axis; only the last axis may be zero (auto-sized).");
     }
     outputSize[OutputImageDimension - 1] =
       (static_cast<SizeValueType>(this->GetNumberOfIndexedInputs()) - 1) / used + 1;


### PR DESCRIPTION
Follow-up to merged #6630 (`BUG: Validate TileImageFilter Layout has no zero before the last axis`), fixing a division-by-zero this reviewer found in that PR: the divisor used to auto-size the last axis was accumulated in a 32-bit `int`, which can wrap to exactly 0 for a large `Layout`.

<details>
<summary>Root cause</summary>

```cpp
int used = 1;
for (unsigned int d = 0; d < OutputImageDimension - 1; ++d)
{
  used *= m_Layout[d];   // m_Layout[d] is unsigned int
}
outputSize[OutputImageDimension - 1] =
  (static_cast<SizeValueType>(this->GetNumberOfIndexedInputs()) - 1) / used + 1;
```

`m_Layout[d]` values are `unsigned int`. `Layout{65536, 65536, 0}` gives `used = 65536 * 65536 = 2^32`, which wraps to exactly `0` in 32-bit arithmetic — turning the division above into a division-by-zero. On architectures whose `idiv` traps (the dominant CI arch), that's an immediate SIGFPE; on others it falls through to a pathological allocation attempt.

#6630's own new guard (rejecting a zero `Layout` entry on a non-last axis) doesn't cover this: `65536` and `65536` are both nonzero: the guard the PR added is orthogonal to this defect.

</details>

<details>
<summary>Fix and validation</summary>

Widened the accumulator to `SizeValueType` (64-bit on the platforms that matter) — `65536 * 65536` then computes correctly as `4294967296`, well within range — and added an explicit rejection if the widened product is still exactly zero (a defensive backstop, not expected to be reachable in practice).

I attempted an end-to-end regression test reproducing the original overflow-triggering `Layout` and confirmed it's impractical: the product that overflows *is* the number of elements `TileImageFilter` allocates for its internal tile-bookkeeping image (`GenerateOutputInformation()` calls `m_TileImage->Allocate()` directly, not deferred to `GenerateData()`), so any `Layout` large enough to exercise the 32-bit overflow requires allocating on the order of `2^32` bookkeeping elements — hundreds of GB, regardless of how the axes are split. No practical test can drive the actual overflow through the filter's public API.

`pre-commit run --all-files`: exit 0. `ctest -L ITKImageGrid`: 69/69 pass, 0 regressions (including the pre-existing `RejectsZeroInNonLastLayoutAxis` and `RejectsDefaultZeroLayout` GTests, unaffected by this change).

</details>

<!--
provenance: claude-code session 2026-07-15, forward-fix for a review finding on merged PR #6630
key_facts: used accumulator widened from int to SizeValueType in itkTileImageFilter.hxx (~line 219); end-to-end test is infeasible because the overflow-triggering product equals the tile-bookkeeping allocation size
related_files: Modules/Filtering/ImageGrid/include/itkTileImageFilter.hxx
post_merge_action: none
-->
