### PR TITLE
BUG: Order vnl legacy-guard include after itkConfigure.h is defined

### DIFF
--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -19,9 +19,6 @@
 #define itkImagePCAShapeModelEstimator_h
 
 #include <ctime>
-#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
-#  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
-#endif
 #include <cmath>
 #include <cfloat>
 
@@ -31,6 +28,9 @@
 
 #include "itkImageRegionIterator.h"
 #include "itkMacro.h"
+#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
+#  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
+#endif
 
 #include "itkImageShapeModelEstimatorBase.h"
 #include "itkConceptChecking.h"

--- a/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
@@ -19,9 +19,6 @@
 #define itkImageGaussianModelEstimator_h
 
 #include <cmath>
-#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
-#  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
-#endif
 #include <cfloat>
 #include <memory> // For unique_ptr.
 
@@ -32,6 +29,9 @@
 
 #include "itkImageRegionIterator.h"
 #include "itkMacro.h"
+#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
+#  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
+#endif
 
 #include "itkImageModelEstimatorBase.h"
 

--- a/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
+++ b/Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
@@ -19,9 +19,6 @@
 #define itkImageKmeansModelEstimator_h
 
 #include <ctime>
-#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
-#  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
-#endif
 #include <cmath>
 #include <cfloat>
 
@@ -31,6 +28,9 @@
 
 #include "itkImageRegionIterator.h"
 #include "itkMacro.h"
+#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
+#  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
+#endif
 
 #include "itkImageModelEstimatorBase.h"
 


### PR DESCRIPTION
Fixes the `ITK_FUTURE_LEGACY_REMOVE` build (macOS `*-dbg` nightlies) broken by the vnl_svd/vnl_matrix_inverse deprecation in #6564. The transitional legacy guard was evaluated before any ITK header defined the macro, so the guarded deprecated include fired anyway and tripped its own `#error`.

<details>
<summary>Root cause</summary>

#6564 deprecated the `vnl_svd`/`vnl_matrix_inverse` family (hard `#error` under `ITK_FUTURE_LEGACY_REMOVE`) and added transitional guards to internal consumers:

```c
#if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
#  include "vnl/algo/vnl_matrix_inverse.h"
#endif
```

In three old-style estimator headers the guard sat at the top of the file, **before any ITK header pulls in `itkConfigure.h`**. `ITK_FUTURE_LEGACY_REMOVE` was therefore undefined when the guard was tested, the guard passed, the vnl header was included, and it then included `itkConfigure.h` itself and hit its own deprecation `#error`.

`itkMatrix.h` places the same guard after `#include "itkMathSVD.h"`, so its macro is defined in time — this PR brings the three stragglers in line by moving the guarded include to immediately after `#include "itkMacro.h"` (which directly pulls in `itkConfigure.h`), making the dependency explicit.

</details>

<details>
<summary>Failing builds / verification</summary>

Nightly failures: `Mac26.x-ClangMain-dbg-arm64` (11416418), `Mac10.15-AppleClang-dbg` (11417144), and the other macOS `*-dbg` builds — each `#error` at `vnl_matrix_inverse.h:12` / `vnl_svd.h:13`.

Reproduced and verified locally in a dedicated `ITK_FUTURE_LEGACY_REMOVE` build:

- Previously-failing drivers `ITKClassifiersTestDriver` and `ITKImageStatisticsTestDriver` now compile and link.
- `itkKmeansModelEstimatorTest`, `itkImagePCAShapeModelEstimatorTest`, `itkSupervisedImageClassifierTest` pass.
- `pre-commit run` clean.

</details>

<!--
provenance: claude-code session 2026-07-15 (cdash-build-analysis skill)
root_cause: guard evaluated before itkConfigure.h include; ITK_FUTURE_LEGACY_REMOVE undefined
introduced_by: PR #6564 (commit fc7ab6bb550 ENH: Migrate ITK consumers off vnl_svd/vnl_matrix_inverse)
deprecation_error_from: commit 232a2ad2d44
files:
  Modules/Segmentation/Classifiers/include/itkImageKmeansModelEstimator.h
  Modules/Segmentation/Classifiers/include/itkImageGaussianModelEstimator.h
  Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
fix: move guarded vnl include to immediately after #include "itkMacro.h" (per dzenanz + greptile review on #6643)
-->

