### PR TITLE
COMP: Fix GCC warnings across IO/Filtering/Registration modules

### DIFF
--- a/Modules/Filtering/BoneEnhancement/include/itkEigenToMeasureImageFilter.h
+++ b/Modules/Filtering/BoneEnhancement/include/itkEigenToMeasureImageFilter.h
@@ -22,6 +22,7 @@
 #include "itkImageToImageFilter.h"
 #include "itkSimpleDataObjectDecorator.h"
 #include "itkSpatialObject.h"
+#include "itkSymmetricEigenAnalysis.h"
 
 namespace itk
 {
@@ -85,20 +86,8 @@ public:
   itkSetInputMacro(Mask, MaskSpatialObjectType);
   itkGetInputMacro(Mask, MaskSpatialObjectType);
 
-  /**\class EigenValueOrderEnum
-   * Template the EigenValueOrderEnum. Methods that inherit from this class can override this function
-   * to produce a different eigenvalue ordering. Ideally, the enum EigenValueOrderEnum should come from
-   * itkSymmetricEigenAnalysisImageFilter.h or itkSymmetricEigenAnalysis.h. That turns out to be non-trivial
-   * because the enumeration is hidden within the templated class. Therefore, you would need the hessian type
-   * and eigenvalue type to do such an operation. We do not necessarily have the hessian type information.
-   * \ingroup BoneEnhancement
-   */
-  enum class EigenValueOrderEnum : uint8_t
-  {
-    OrderByValue = 1,
-    OrderByMagnitude,
-    DoNotOrder
-  };
+  /** Eigenvalue ordering, shared with itkSymmetricEigenAnalysis.h. */
+  using EigenValueOrderEnum = SymmetricEigenAnalysisEnums::EigenValueOrder;
 /**Exposes enums values for backwards compatibility*/
 #if !defined(ITK_LEGACY_REMOVE)
   static constexpr EigenValueOrderEnum OrderByValue = EigenValueOrderEnum::OrderByValue;

--- a/Modules/Filtering/MeshToPolyData/test/itkPolyDataTest.cxx
+++ b/Modules/Filtering/MeshToPolyData/test/itkPolyDataTest.cxx
@@ -111,7 +111,7 @@ itkPolyDataTest(int, char *[])
   pointDataContainer->InsertElement(0, 2.0);
   pointDataContainer->InsertElement(1, 7.0);
   polyData->SetPointData(pointDataContainer);
-  double pointData;
+  double pointData{};
   polyData->GetPointData(1, &pointData);
   ITK_TEST_SET_GET_VALUE(7.0, pointData);
   polyData->SetPointData(2, 9.9);
@@ -122,7 +122,7 @@ itkPolyDataTest(int, char *[])
   cellDataContainer->InsertElement(0, 2.0);
   cellDataContainer->InsertElement(1, 7.0);
   polyData->SetCellData(cellDataContainer);
-  double cellData;
+  double cellData{};
   polyData->GetCellData(1, &cellData);
   ITK_TEST_SET_GET_VALUE(7.0, cellData);
   polyData->SetCellData(2, 9.9);

--- a/Modules/IO/IOScanco/include/itkScancoHeaderIO.h
+++ b/Modules/IO/IOScanco/include/itkScancoHeaderIO.h
@@ -56,7 +56,7 @@ public:
   ScancoHeaderIO(itkScancoHeaderData * headerData, std::string filename = "");
 
   /** Destructor */
-  ~ScancoHeaderIO() = default;
+  virtual ~ScancoHeaderIO() = default;
 
   void
   SetFilename(const std::string filename);

--- a/Modules/IO/IOScanco/src/itkAIMHeaderIO.cxx
+++ b/Modules/IO/IOScanco/src/itkAIMHeaderIO.cxx
@@ -235,7 +235,8 @@ AIMHeaderIO::WriteHeader(std::ofstream & outfile, unsigned long imageSize)
 
   outfile.write(processingLog.c_str(), this->m_ProcessingLogSize);
 
-  if (outfile.tellp() != bytesWritten + this->m_PreHeaderSize + this->m_ImgStructSize + this->m_ProcessingLogSize)
+  if (outfile.tellp() != static_cast<std::streamoff>(bytesWritten + this->m_PreHeaderSize + this->m_ImgStructSize +
+                                                     this->m_ProcessingLogSize))
   {
     throw std::runtime_error("Error: write size mismatch");
   }
@@ -247,8 +248,6 @@ AIMHeaderIO::WriteHeader(std::ofstream & outfile, unsigned long imageSize)
 int
 AIMHeaderIO::ReadPreHeader(std::ifstream & file, size_t offset)
 {
-  unsigned long bytesRead = this->m_IntSize; // We assume the pre-header length (int) has already been read
-
   if (!file.is_open())
   {
     return -1;
@@ -321,7 +320,7 @@ AIMHeaderIO::ReadImgStructHeader(AIMV020StructHeader * headerData)
   }
 
   // Set the pixel data origin
-  for (int i = 0; i < 3; ++i)
+  for (i = 0; i < 3; ++i)
   {
     this->m_HeaderData->m_PixelData.m_Origin[i] =
       DecodeInt(headerData->m_Position[i]) * this->m_HeaderData->m_PixelData.m_Spacing[i];
@@ -353,7 +352,7 @@ AIMHeaderIO::ReadImgStructHeader(AIMV030StructHeader * headerData)
   }
 
   // Set the pixel data origin
-  for (int i = 0; i < 3; ++i)
+  for (i = 0; i < 3; ++i)
   {
     this->m_HeaderData->m_PixelData.m_Origin[i] =
       DecodeInt(headerData->m_Position[i]) * this->m_HeaderData->m_PixelData.m_Spacing[i];
@@ -540,7 +539,7 @@ AIMHeaderIO::ReadProcessingLog(std::ifstream & infile, size_t offset, size_t len
 AIMV020StructHeader
 AIMHeaderIO::WriteStructHeaderV020()
 {
-  AIMV020StructHeader structHeader{ 0 };
+  AIMV020StructHeader structHeader{};
   EncodeInt(this->m_HeaderData->m_PixelData.m_ComponentType, structHeader.m_Type);
 
   EncodeFloat(AIM020WriteVersion, structHeader.m_Version);
@@ -561,7 +560,7 @@ AIMHeaderIO::WriteStructHeaderV020()
   }
 
   // pixel data origin
-  for (int i = 0; i < 3; ++i)
+  for (i = 0; i < 3; ++i)
   {
     EncodeInt(this->m_HeaderData->m_PixelData.m_Origin[i] / (float)this->m_HeaderData->m_PixelData.m_Spacing[i],
               structHeader.m_Position[i]);
@@ -572,7 +571,7 @@ AIMHeaderIO::WriteStructHeaderV020()
 AIMV030StructHeader
 AIMHeaderIO::WriteStructHeaderV030()
 {
-  AIMV030StructHeader structHeader{ 0 };
+  AIMV030StructHeader structHeader{};
   EncodeInt(this->m_HeaderData->m_PixelData.m_ComponentType, structHeader.m_Type);
 
   int i = 0;
@@ -591,7 +590,7 @@ AIMHeaderIO::WriteStructHeaderV030()
   }
 
   // Set the pixel data origin
-  for (int i = 0; i < 3; ++i)
+  for (i = 0; i < 3; ++i)
   {
     EncodeInt64(this->m_HeaderData->m_PixelData.m_Origin[i] / (float)this->m_HeaderData->m_PixelData.m_Spacing[i],
                 structHeader.m_Position[i]);
@@ -666,7 +665,7 @@ AIMHeaderIO::WritePreHeader(std::ofstream & outfile, size_t imageSize, ScancoFil
 
   if (version == ScancoFileVersions::AIM_020)
   {
-    AIMPreHeaderV020 preHeader{ 0 };
+    AIMPreHeaderV020 preHeader{};
     EncodeInt((int)sizeof(AIMPreHeaderV020), preHeader.m_PreHeaderLength);
     EncodeInt((int)this->m_ImgStructSize, preHeader.m_ImageStructLength);
     EncodeInt((int)this->m_ProcessingLogSize, preHeader.m_ProcessingLogLength);
@@ -677,7 +676,7 @@ AIMHeaderIO::WritePreHeader(std::ofstream & outfile, size_t imageSize, ScancoFil
   }
   else if (version == ScancoFileVersions::AIM_030)
   {
-    AIMPreHeaderV030 preHeader{ 0 };
+    AIMPreHeaderV030 preHeader{};
     EncodeInt64(sizeof(AIMPreHeaderV030), preHeader.m_PreHeaderLength);
     EncodeInt64(this->m_ImgStructSize, preHeader.m_ImageStructLength);
     EncodeInt64(this->m_ProcessingLogSize, preHeader.m_ProcessingLogLength);

--- a/Modules/IO/IOScanco/src/itkISQHeaderIO.cxx
+++ b/Modules/IO/IOScanco/src/itkISQHeaderIO.cxx
@@ -197,7 +197,7 @@ ISQHeaderIO::WriteHeader(std::ofstream & outfile, unsigned long imageSize)
     return 0;
   }
 
-  ISQEncodedHeaderBlock header = { 0 };
+  ISQEncodedHeaderBlock header{};
 
   PadString(header.m_PreHeader.m_Version, this->m_HeaderData->m_Version, ScancoHeaderField::VersionDiskWidth);
   EncodeInt(3, header.m_PreHeader.m_DataType);
@@ -261,8 +261,6 @@ ISQHeaderIO::ReadDateValues(const int year,
 {
   // Convert date information into a string
   month = ((month > 12 || month < 1) ? 0 : month);
-  static const char * months[] = { "XXX", "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-                                   "JUL", "AUG", "SEP", "OCT", "NOV", "DEC" };
   DateToString(this->m_HeaderData->m_CreationDate, year, month, day, hour, minute, second, milli);
   DateToString(this->m_HeaderData->m_ModificationDate, year, month, day, hour, minute, second, milli);
 }
@@ -433,7 +431,7 @@ ISQHeaderIO::ReadExtendedHeader(const char * buffer, unsigned long length)
 unsigned long
 ISQHeaderIO::WriteExtendedHeader(std::ofstream & outfile)
 {
-  ISQCalibrationHeaderBlock calHeader = { 0 };
+  ISQCalibrationHeaderBlock calHeader{};
   outfile.seekp(ScancoHeaderBlockSize, std::ios::beg); // seek past first header block
 
   // First block adds multiheader

--- a/Modules/IO/IOScanco/src/itkScancoHeaderIO.cxx
+++ b/Modules/IO/IOScanco/src/itkScancoHeaderIO.cxx
@@ -35,13 +35,13 @@ ScancoHeaderIO::ScancoHeaderIO(itkScancoHeaderData * headerData, std::string fil
 }
 
 unsigned long
-ScancoHeaderIO::ReadHeader(std::ifstream & infile)
+ScancoHeaderIO::ReadHeader(std::ifstream &)
 {
   throw std::runtime_error("ScancoHeaderIO::ReadHeader(std::ifstream&) not implemented.");
 }
 
 unsigned long
-ScancoHeaderIO::WriteHeader(std::ofstream & outfile, unsigned long imageSize)
+ScancoHeaderIO::WriteHeader(std::ofstream &, unsigned long)
 {
   throw std::runtime_error("ScancoHeaderIO::WriteHeader(std::ofstream&) not implemented.");
 }

--- a/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
+++ b/Modules/IO/PhilipsREC/src/itkPhilipsPAR.cxx
@@ -539,16 +539,16 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
     {
       // Start at line 12 and work through PAR file.
       // Line numbers are hard-coded on purpose.
-      strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name));
-      strncpy(pPar->exam_name, this->GetGeneralInfoString(parFile, 13).c_str(), sizeof(pPar->exam_name));
-      strncpy(pPar->protocol_name, this->GetGeneralInfoString(parFile, 14).c_str(), sizeof(pPar->protocol_name));
+      strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name) - 1);
+      strncpy(pPar->exam_name, this->GetGeneralInfoString(parFile, 13).c_str(), sizeof(pPar->exam_name) - 1);
+      strncpy(pPar->protocol_name, this->GetGeneralInfoString(parFile, 14).c_str(), sizeof(pPar->protocol_name) - 1);
       strncpy(pPar->exam_date,
               this->GetGeneralInfoString(parFile, 15).c_str(),
               this->GetGeneralInfoString(parFile, 15).find('/'));
       strncpy(
         pPar->exam_time,
         this->GetGeneralInfoString(parFile, 15).substr(this->GetGeneralInfoString(parFile, 15).find('/') + 1).c_str(),
-        sizeof(pPar->exam_time));
+        sizeof(pPar->exam_time) - 1);
       inString.str(this->GetGeneralInfoString(parFile, 16));
       inString >> pPar->scno;
       inString.clear();
@@ -576,8 +576,8 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
       inString.str(this->GetGeneralInfoString(parFile, 24));
       inString >> pPar->bit;
       inString.clear();
-      strncpy(pPar->technique, this->GetGeneralInfoString(parFile, 25).c_str(), sizeof(pPar->technique));
-      strncpy(pPar->scan_mode, this->GetGeneralInfoString(parFile, 26).c_str(), sizeof(pPar->scan_mode));
+      strncpy(pPar->technique, this->GetGeneralInfoString(parFile, 25).c_str(), sizeof(pPar->technique) - 1);
+      strncpy(pPar->scan_mode, this->GetGeneralInfoString(parFile, 26).c_str(), sizeof(pPar->scan_mode) - 1);
       inString.str(this->GetGeneralInfoString(parFile, 27));
       inString >> pPar->scan_resolution[0];
       inString >> pPar->scan_resolution[1];
@@ -1031,17 +1031,17 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
     {
       // Start at line 12 and work through PAR file.
       // Line numbers are hard-coded on purpose.
-      strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name));
-      strncpy(pPar->exam_name, this->GetGeneralInfoString(parFile, 13).c_str(), sizeof(pPar->exam_name));
-      strncpy(pPar->protocol_name, this->GetGeneralInfoString(parFile, 14).c_str(), sizeof(pPar->protocol_name));
+      strncpy(pPar->patient_name, this->GetGeneralInfoString(parFile, 12).c_str(), sizeof(pPar->patient_name) - 1);
+      strncpy(pPar->exam_name, this->GetGeneralInfoString(parFile, 13).c_str(), sizeof(pPar->exam_name) - 1);
+      strncpy(pPar->protocol_name, this->GetGeneralInfoString(parFile, 14).c_str(), sizeof(pPar->protocol_name) - 1);
       strncpy(pPar->exam_date,
               this->GetGeneralInfoString(parFile, 15).c_str(),
               this->GetGeneralInfoString(parFile, 15).find('/'));
       strncpy(
         pPar->exam_time,
         this->GetGeneralInfoString(parFile, 15).substr(this->GetGeneralInfoString(parFile, 15).find('/') + 1).c_str(),
-        sizeof(pPar->exam_time));
-      strncpy(pPar->series_type, this->GetGeneralInfoString(parFile, 16).c_str(), sizeof(pPar->series_type));
+        sizeof(pPar->exam_time) - 1);
+      strncpy(pPar->series_type, this->GetGeneralInfoString(parFile, 16).c_str(), sizeof(pPar->series_type) - 1);
       inString.str(this->GetGeneralInfoString(parFile, 17));
       inString >> pPar->scno;
       inString.clear();
@@ -1066,9 +1066,10 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
       inString.str(this->GetGeneralInfoString(parFile, 24));
       inString >> pPar->mixes;
       inString.clear();
-      strncpy(pPar->patient_position, this->GetGeneralInfoString(parFile, 25).c_str(), sizeof(pPar->patient_position));
-      strncpy(pPar->prep_direction, this->GetGeneralInfoString(parFile, 26).c_str(), sizeof(pPar->prep_direction));
-      strncpy(pPar->technique, this->GetGeneralInfoString(parFile, 27).c_str(), sizeof(pPar->technique));
+      strncpy(
+        pPar->patient_position, this->GetGeneralInfoString(parFile, 25).c_str(), sizeof(pPar->patient_position) - 1);
+      strncpy(pPar->prep_direction, this->GetGeneralInfoString(parFile, 26).c_str(), sizeof(pPar->prep_direction) - 1);
+      strncpy(pPar->technique, this->GetGeneralInfoString(parFile, 27).c_str(), sizeof(pPar->technique) - 1);
       inString.str(this->GetGeneralInfoString(parFile, 28));
       inString >> pPar->scan_resolution[0];
       inString >> pPar->scan_resolution[1];
@@ -1087,7 +1088,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
         inString >> pPar->repetition_time[repTime];
       }
       inString.clear();
-      struct image_info_defV4 tempInfo;
+      struct image_info_defV4 tempInfo{};
       switch (pPar->ResToolsVersion)
       {
         case RESEARCH_IMAGE_EXPORT_TOOL_V4:
@@ -1214,7 +1215,7 @@ PhilipsPAR::ReadPAR(std::string parFile, struct par_parameter * pPar)
         int                     lineIncrement = 92;
         int                     echoIndex = 0;
         int                     cardiacIndex = 0;
-        struct image_info_defV4 tempInfo1;
+        struct image_info_defV4 tempInfo1{};
         switch (pPar->ResToolsVersion)
         {
           case RESEARCH_IMAGE_EXPORT_TOOL_V4:

--- a/Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.h
+++ b/Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.h
@@ -22,6 +22,7 @@
 #include "itkNumericTraits.h"
 #include "itkProcessObject.h"
 #include "itkSimpleDataObjectDecorator.h"
+#include <array>
 #include <vector>
 #include "MontageExport.h"
 #include "itkNMinimaMaximaImageCalculator.h"
@@ -51,17 +52,16 @@ public:
   };
 
   // For iteration
-  static const std::initializer_list<PeakInterpolationMethod>
+  static constexpr auto
   AllPeakInterpolationMethods()
   {
-    static constexpr std::initializer_list<PeakInterpolationMethod> methods{
+    return std::array{
       PeakInterpolationMethod::None,
       PeakInterpolationMethod::Parabolic,
       PeakInterpolationMethod::Cosine,
       PeakInterpolationMethod::WeightedMeanPhase,
       // PeakInterpolationMethod::PhaseFrequencySlope
     };
-    return methods;
   }
 };
 

--- a/Modules/Registration/RANSAC/include/itkLandmarkRegistrationEstimator.hxx
+++ b/Modules/Registration/RANSAC/include/itkLandmarkRegistrationEstimator.hxx
@@ -276,7 +276,8 @@ LandmarkRegistrationEstimator<Dimension, TTransform>::SetAgreeData(std::vector<P
 template <unsigned int Dimension, typename TTransform>
 bool
 LandmarkRegistrationEstimator<Dimension, TTransform>::CheckCorresspondenceEdgeLength(
-  std::vector<double> &                     parameters,
+  // Unused by this estimator; part of the polymorphic ParametersEstimator interface.
+  [[maybe_unused]] std::vector<double> &    parameters,
   std::vector<Point<double, Dimension> *> & data,
   double                                    inputEdgeLength)
 {


### PR DESCRIPTION
Fixes GCC warnings across five in-tree modules (IOScanco, PhilipsREC, Montage, RANSAC, MeshToPolyData). All fixes are behavior-preserving; each module's tests pass locally. proxTV third-party warnings are handled separately in a proxTV PR.

<details>
<summary>Warnings fixed, by module</summary>

| Module | Warnings | Fix |
|---|---|---|
| IOScanco | `-Wmissing-field-initializers` (88), `-Wshadow` (4), `-Wunused-variable` (2), `-Wunused-parameter` (3), `-Wdelete-non-virtual-dtor` (2), `-Wsign-compare` (1) | `{}` value-init of header-block structs; virtual destructor on the polymorphic `ScancoHeaderIO` base; drop dead locals/params; reuse outer loop index; cast the size comparison |
| PhilipsREC | `-Wstringop-truncation` (14), `-Wmaybe-uninitialized` (7) | copy `sizeof-1` into the pre-zeroed (`*pPar = {}`) fixed-width buffers; value-initialize `image_info_defV4` locals |
| Montage | `-Winit-list-lifetime` (8) | `AllPeakInterpolationMethods()` returned a local `std::initializer_list` whose backing array did not outlive the return — now returns `std::array` by value |
| RANSAC | `-Wunused-parameter` (1) | drop the unused parameter name |
| MeshToPolyData (test) | `-Wmaybe-uninitialized` (2) | value-initialize `pointData`/`cellData` filled through a pointer |

BoneEnhancement `-Wshadow` (9): the nested `EigenValueOrderEnum` enumerators shadowed the namespace-scope legacy `itk::OrderByValue`/etc. constants; the duplicate enum is now aliased to `itk::SymmetricEigenAnalysisEnums::EigenValueOrder` (the module's own comment already recommended this; enumerator values are identical).

</details>

<details>
<summary>Local verification</summary>

- All affected targets rebuild with zero warnings (GCC).
- Tests pass: `itkPolyDataTest`; 82 Montage/IOScanco tests; 37 BoneEnhancement tests.

</details>

<!--
provenance: claude-code session 2026-07-15
branch: fix-gcc-warnings-modules (off upstream/main)
scope: ITK-proper GCC-warning cleanup only; proxTV third-party warnings are a separate proxTV-repo PR
companion: InsightSoftwareConsortium/proxTV warnings-cleanup-gcc (pragma guards, sign-compare, misleading-indentation, input-validation guards); after that merges, bump Modules/ThirdParty/proxTV/proxTVGitTag.cmake
key_facts:
  - Montage init-list-lifetime was a genuine dangling std::initializer_list (AllPeakInterpolationMethods)
  - ScancoHeaderIO gained a virtual dtor (deleted polymorphically in itkScancoImageIO.cxx)
  - BoneEnhancement EigenValueOrderEnum aliased to itk::EigenValueOrderEnum (API-adjacent; wrapped enum)
-->
