### PR TITLE
COMP: Harden CI apt/locale install against transient failures

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -103,7 +103,18 @@ jobs:
           echo "CCACHE_DIR=${{ runner.temp }}/ccache" >> "$GITHUB_ENV"
           echo "CCACHE_MAXSIZE=5G" >> "$GITHUB_ENV"
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update -qq && sudo apt-get install -y ccache locales
+            sudo mkdir -p /etc/apt/apt.conf.d
+            echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+            echo 'Acquire::Retries "5";'      | sudo tee /etc/apt/apt.conf.d/80-retries >/dev/null
+
+            for i in 1 2 3; do
+              sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ccache locales && break
+              echo "apt attempt $i failed; retrying..."
+              [ "$i" -lt 3 ] && sleep $((i * 10))
+            done
+
+            command -v ccache >/dev/null || { echo "ccache install failed"; exit 1; }
+            command -v locale-gen >/dev/null || { echo "locales install failed"; exit 1; }
             sudo locale-gen de_DE.UTF-8
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install ccache

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -55,7 +55,17 @@ jobs:
             echo "CCACHE_MAXSIZE=5G" >> "$GITHUB_ENV"
             # ccache now comes from the pixi cxx env; only the locale needs OS setup.
             if [ "$RUNNER_OS" == "Linux" ]; then
-              sudo apt-get update -qq && sudo apt-get install -y locales
+              sudo mkdir -p /etc/apt/apt.conf.d
+              echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+              echo 'Acquire::Retries "5";'      | sudo tee /etc/apt/apt.conf.d/80-retries >/dev/null
+
+              for i in 1 2 3; do
+                sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends locales && break
+                echo "apt attempt $i failed; retrying..."
+                [ "$i" -lt 3 ] && sleep $((i * 10))
+              done
+
+              command -v locale-gen >/dev/null || { echo "locales install failed"; exit 1; }
               sudo locale-gen de_DE.UTF-8
             fi
 


### PR DESCRIPTION
Harden the CI apt/locale install steps against transient apt/mirror failures. The ARM job intermittently failed at *Install ccache* with exit 127 (`ccache: command not found`) when the apt install silently errored; the Linux pixi job has the same exposure on its `locales` install.

<details>
<summary>What changed</summary>

Both `arm.yml` (Install ccache) and `pixi.yml` (Linux locale setup) now:

- Force IPv4 for apt (`Acquire::ForceIPv4`) and set `Acquire::Retries "5"`.
- Wrap the `apt-get update && install` in a 3-attempt loop with backoff (no `sleep` after the final attempt).
- Use `--no-install-recommends`.
- Fail loudly if a required binary is missing after install — `ccache` **and** `locale-gen` in `arm.yml`; `locale-gen` in `pixi.yml` (ccache there comes from the pixi cxx env, so only `locales` is installed).

The `locale-gen` guard closes a gap where an apt failure that dropped only the `locales` package would slip past a ccache-only check and fail later with a misleading `locale-gen: command not found`.

</details>

<!--
provenance: claude-code session 2026-07-15
branch: fix-arm-ccache-install (off upstream/main)
trigger: ARMBUILD-Ubuntu-24.04-arm exit 127 at "Install ccache" on PR #6644; dzenanz flagged it
review: /code-review high — added locale-gen guard + dropped final-iteration sleep from the maintainer-suggested snippet
followup: consider a shared composite action to dedupe the apt/locale hardening across workflows
-->
