### PR TITLE
STYLE: Remove unused m_UserSpecifiedImageIO from writers

### DIFF
--- a/Modules/IO/ImageBase/include/itkImageFileWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageFileWriter.h
@@ -225,7 +225,6 @@ private:
   std::string m_FileName{};
 
   ImageIOBase::Pointer m_ImageIO{};
-  bool                 m_UserSpecifiedImageIO{ false };
 
   ImageIORegion m_PasteIORegion{ TInputImage::ImageDimension };
   unsigned int  m_NumberOfStreamDivisions{ 1 };

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.h
@@ -229,9 +229,6 @@ protected:
 
   ImageIOBase::Pointer m_ImageIO{};
 
-  // track whether the ImageIO is user specified
-  bool m_UserSpecifiedImageIO{ false };
-
 private:
   /** A list of filenames to be processed. */
   FileNamesContainer m_FileNames{};

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -351,7 +351,6 @@ ImageSeriesWriter<TInputImage, TOutputImage>::PrintSelf(std::ostream & os, Inden
 
   itkPrintSelfObjectMacro(ImageIO);
 
-  itkPrintSelfBooleanMacro(UserSpecifiedImageIO);
   for (unsigned int i = 0; i < m_FileNames.size(); ++i)
   {
     os << indent << "FileNames[" << i << "]: " << m_FileNames[i] << std::endl;


### PR DESCRIPTION
Remove the `m_UserSpecifiedImageIO` member from `ImageFileWriter` and `ImageSeriesWriter`. The member was declared in both classes but never read or written in their implementations (`itkImageFileWriter.hxx` / `itkImageSeriesWriter.hxx`).

<details>
<summary>AI assistance</summary>

GitHub Copilot (Claude Sonnet 4.6) identified the unused members via workspace-wide grep, verified no usages existed in the implementation files, removed the declarations, and committed the change.

</details>