### PR TITLE
DOC: note HDF5ImageIO compression-default change in migration guide

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -1009,3 +1009,15 @@ baseline that encodes origin, re-verify that value -- it now reflects the
 corrected collapsed-axis center. Formats that do not store an origin (`.tif`,
 `.png`) and dimension-reducing projections (output dimension less than input)
 are unaffected.
+
+## `HDF5ImageIO` no longer compresses by default
+
+`HDF5ImageIO` previously applied deflate compression unconditionally,
+ignoring the `UseCompression` flag. The flag is now respected.
+`ImageFileWriter` defaults `UseCompression` to `false`, so HDF5 files
+written through the standard writer pipeline are **uncompressed by default**.
+
+### What you need to do
+
+Call `writer->UseCompressionOn()` to restore compressed output. To control the
+deflate level (1–9, default 5), also call `writer->SetCompressionLevel(N)`.


### PR DESCRIPTION
Adds a migration-guide entry for the behavior change landed in #6637: HDF5 files written through `ImageFileWriter` are now uncompressed by default, since `ImageFileWriter` defaults `UseCompression` to `false` and the IO now respects that flag.