### PR TITLE
COMP: Spell out Montage AllPeakInterpolationMethods return type

### DIFF
--- a/Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.h
+++ b/Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.h
@@ -51,11 +51,11 @@ public:
     // PhaseFrequencySlope = 4,
   };
 
-  // For iteration
-  static constexpr auto
+  // For iteration. Type is spelled out: igenerator emits "?unknown?" for a deduced return.
+  static constexpr std::array<PeakInterpolationMethod, 4>
   AllPeakInterpolationMethods()
   {
-    return std::array{
+    return {
       PeakInterpolationMethod::None,
       PeakInterpolationMethod::Parabolic,
       PeakInterpolationMethod::Cosine,


### PR DESCRIPTION
`igenerator` cannot resolve a deduced return type: it emits the literal `?unknown?` into `itkPhaseCorrelationOptimizer.i`, which swig then rejects, failing the `itkTileMontage` wrapping target on all three Python builds. Spelling out the `std::array` type restores wrapping and keeps the `-Winit-list-lifetime` fix from 6f0a2800353 intact.

Companion to #6652: the two together account for every build error on the current nightly dashboard (this one the 3 Python builds, #6652 the 6 macOS dbg builds). They are independent — no merge ordering required.

<details>
<summary>Failing builds (Nightly 20260716-0100)</summary>

| Build | Errors |
|---|---|
| `MacOS-Rel-Python` | 4 |
| `Ubuntu-22.04-gcc11.4-Rel-Python` | 4 |
| `Windows11-VS22x64-Release-Python` | 2 |

```
FAILED: Wrapping/Modules/Montage/itkTileMontagePython.cpp
swig -c++ -python ... -Werror ... .../Wrapping/Typedefs/itkTileMontage.i
.../Wrapping/Typedefs/itkPhaseCorrelationOptimizer.i:249: Error: Syntax error in input(3).
```

Reproduces identically on macOS, Linux and Windows, so it is source rather than toolchain. The failure appeared with the first nightly after 6f0a2800353 (2026-07-15) landed.

</details>

<details>
<summary>Root cause</summary>

6f0a2800353 fixed a genuine `-Winit-list-lifetime` defect by returning a `std::array` by value instead of a `std::initializer_list` whose backing array did not outlive the return. In doing so it also changed the return type to a deduced one:

```cpp
static constexpr auto
AllPeakInterpolationMethods()
{
  return std::array{ /* ... */ };
}
```

`igenerator` cannot name that type, and emits it literally. Line 249 of the generated `itkPhaseCorrelationOptimizer.i`:

```
class itkPhaseCorrelationOptimizerEnums {
  public:
    enum class PeakInterpolationMethod: uint8_t {  None,  Parabolic,  Cosine,  WeightedMeanPhase };

    static ?unknown? AllPeakInterpolationMethods();
```

swig fails on the `?`. Naming the type makes `igenerator` emit a declaration it can wrap:

```
static std::array<itkPhaseCorrelationOptimizerEnums::PeakInterpolationMethod, 4> AllPeakInterpolationMethods();
```

The lifetime fix is unaffected — the array is still returned by value. Only the return type is spelled out.

</details>

<details>
<summary>Local validation</summary>

Generated the real `.i` (castxml + igenerator) and ran the exact swig invocation and version CI uses (4.4.1, fetched via `ITK_SWIG_VERSION`), with CI's full flag set including `-Werror`:

- **Fail-before:** reproduced CI's message byte-for-byte — `itkPhaseCorrelationOptimizer.i:249: Error: Syntax error in input(3).`
- **Pass-after:** `?unknown?` is gone; swig exits 0 on `itkPhaseCorrelationOptimizer.i` and, more importantly, on `itkTileMontage.i` — the target CI actually fails on.
- `itkPhaseCorrelationOptimizer.cxx.o` compiles with 0 errors and 0 warnings, so the `-Winit-list-lifetime` fix still holds.

`pre-commit run --all-files` exits 0.

</details>

<details>
<summary>Note on wrapping-visible signatures</summary>

A deduced return type on a wrapped public API silently degrades to `?unknown?` rather than failing loudly at the point of authorship, and swig only rejects it later while wrapping an unrelated class that imports the header. `AllPeakInterpolationMethods()` currently has no live callers — the three references in `itkMontageTestHelper.hxx` and `itkPairwiseTestHelper.hxx` are commented out — so the construct was not exercised by anything except the wrapping pass.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-opus-4-8)
- Role: CDash triage and root-cause analysis
- Contribution: generated the real `.i` to identify the `?unknown?` emission after an initial hypothesis (swig cannot parse `constexpr auto`) failed to reproduce the reported syntax error against swig 4.4.1
- All code was reviewed, built, and tested locally before committing

</details>

<!--
provenance: CDash triage of Insight Nightly 20260716-0100 (open.cdash.org, project id 2).
scope: fixes ONLY the itkPhaseCorrelationOptimizer.i:249 syntax error affecting the 3
  Rel-Python builds. The other nightly failure (vnl_det/vnl_determinant #error on 6 Mac
  dbg builds) is a separate root cause and is PR #6652.
  Remaining nightly error not addressed by either: Mac26.x-AppleClang-dbg-TSan reports
  "ninja: error: loading 'build.ninja'" -- infrastructure, not code.
caused_by: 6f0a2800353 "COMP: Fix -Winit-list-lifetime in Montage PhaseCorrelationOptimizer"
  (2026-07-15). That commit's lifetime fix is correct and is preserved here; only its
  deduced return type is replaced with an explicit one.
false_lead: swig 4.4.1 parses `constexpr auto` + CTAD with only Warning 345, NOT a syntax
  error -- so the minimal repro did not reproduce CI. The syntax error comes from
  igenerator's "?unknown?" emission, visible only in the generated .i. Note Warning 345 is
  absent from CI's -w suppression list, so under -Werror it would fail the build anyway.
repro_recipe: cmake -DModule_Montage=ON <build-python>; ninja Wrapping/Typedefs/
  itkPhaseCorrelationOptimizer.i; inspect line 249. build-python's cached SWIG_EXECUTABLE
  may predate ITK_SWIG_VERSION=4.4.1; swig can be run manually against the generated .i.
key_files: Modules/Registration/Montage/include/itkPhaseCorrelationOptimizer.h:54-65
-->
