### PR TITLE
COMP: Fix GDCM re-configuration writing libraries to /bin

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/CMakeLists.txt
@@ -118,18 +118,6 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 #-----------------------------------------------------------------------------
-# Compatibility with older usage of EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH.
-# This should be removed in the future.
-if(EXECUTABLE_OUTPUT_PATH)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${EXECUTABLE_OUTPUT_PATH})
-  message(WARNING "EXECUTABLE_OUTPUT_PATH is deprecated. Use CMAKE_RUNTIME_OUTPUT_DIRECTORY instead.")
-endif()
-if(LIBRARY_OUTPUT_PATH)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})
-  message(WARNING "LIBRARY_OUTPUT_PATH is deprecated. Use CMAKE_LIBRARY_OUTPUT_DIRECTORY and CMAKE_ARCHIVE_OUTPUT_DIRECTORY instead.")
-endif()
-
 if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
@@ -140,16 +128,11 @@ if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
 
-# Set for legacy internal usage of EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH
-if (NOT EXECUTABLE_OUTPUT_PATH)
-  set(EXECUTABLE_OUTPUT_PATH ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-endif()
-if (NOT LIBRARY_OUTPUT_PATH)
-  if (BUILD_SHARED_LIBS)
-    set(LIBRARY_OUTPUT_PATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-  else()
-    set(LIBRARY_OUTPUT_PATH ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
-  endif()
+# Shared libraries land in the library directory, static ones in the archive directory.
+if(BUILD_SHARED_LIBS)
+  set(GDCM_LIBRARY_OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+else()
+  set(GDCM_LIBRARY_OUTPUT_DIR ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 endif()
 
 #-----------------------------------------------------------------------------
@@ -570,8 +553,8 @@ if(GDCM_STANDALONE)
   endif()
 endif()
 
-set(GDCM_LIBRARY_DIR ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})
-set(GDCM_EXECUTABLE_DIR ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_CFG_INTDIR})
+set(GDCM_LIBRARY_DIR ${GDCM_LIBRARY_OUTPUT_DIR}/${CMAKE_CFG_INTDIR})
+set(GDCM_EXECUTABLE_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
 
 #-----------------------------------------------------------------------------
 # we need to link against CoreFoundation so that we can use CFBundle to get the executable path.
@@ -1164,7 +1147,7 @@ if(GDCM_USE_VTK)
       "${GDCM_SOURCE_DIR}/Utilities/VTK"
       )
 endif()
-set(GDCM_LIBRARY_DIRS ${LIBRARY_OUTPUT_PATH})
+set(GDCM_LIBRARY_DIRS ${GDCM_LIBRARY_OUTPUT_DIR})
 if(GDCM_STANDALONE)
 add_subdirectory(CMake/ExportConfiguration)
 endif()

--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/Common/gdcmConfigure.h.in
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/Common/gdcmConfigure.h.in
@@ -38,8 +38,8 @@
 /* Useful in particular for loadshared where the full path
  * to the lib is needed */
 #define GDCM_SOURCE_DIR "@GDCM_SOURCE_DIR@"
-#define GDCM_EXECUTABLE_OUTPUT_PATH "@EXECUTABLE_OUTPUT_PATH@"
-#define GDCM_LIBRARY_OUTPUT_PATH    "@LIBRARY_OUTPUT_PATH@"
+#define GDCM_EXECUTABLE_OUTPUT_PATH "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@"
+#define GDCM_LIBRARY_OUTPUT_PATH    "@GDCM_LIBRARY_OUTPUT_DIR@"
 
 #cmakedefine GDCM_BUILD_TESTING
 

--- a/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt
@@ -177,9 +177,6 @@ configure_file(
 #-----------------------------------------------------------------------------
 # OpenJPEG build configuration options.
 #option(BUILD_SHARED_LIBS "Build OpenJPEG shared library and link executables against it." ON)
-set (EXECUTABLE_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all executables.")
-set (LIBRARY_OUTPUT_PATH ${OPENJPEG_BINARY_DIR}/bin CACHE PATH "Single output directory for building all libraries.")
-mark_as_advanced(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)
 
 #-----------------------------------------------------------------------------
 # configure name mangling to allow multiple libraries to coexist


### PR DESCRIPTION
Fixes #6617: re-configuring a `release-5.4` build tree redirects all GDCM libraries to `/bin`, breaking the build on the second `make`.

Cherry-picks two patches submitted upstream to GDCM:

- malaterre/GDCM#226 — the fix: OpenJPEG wrote `EXECUTABLE_OUTPUT_PATH`/`LIBRARY_OUTPUT_PATH` **CACHE** entries resolving to the literal path `/bin`.
- malaterre/GDCM#227 — removes GDCM's legacy handling of those variables.

⚠️ Both upstream PRs are **open and unreviewed**. If they change during review, this PR should be updated to match.

<details>
<summary>Root cause</summary>

`Utilities/gdcmopenjpeg/CMakeLists.txt` set both variables as CACHE entries from `OPENJPEG_BINARY_DIR`, which is never defined — `Utilities/CMakeLists.txt` sets `OPENJPEG_NAMESPACE "GDCMOPENJPEG"`, so `project()` defines `GDCMOPENJPEG_BINARY_DIR` instead. The cached value is therefore the literal path `/bin`, present in `CMakeCache.txt` after the very first configure:

```
EXECUTABLE_OUTPUT_PATH:PATH=/bin
LIBRARY_OUTPUT_PATH:PATH=/bin
```

On configure 1 GDCM's compatibility block runs before `add_subdirectory(Utilities)`, so the variables are undefined and everything is placed correctly. On configure 2 the cache is preloaded first, so the block reads `/bin` back and redirects `CMAKE_RUNTIME/LIBRARY/ARCHIVE_OUTPUT_DIRECTORY` for all of GDCM.

**#6557 did not cause this.** It removed the two `set(EXECUTABLE_OUTPUT_PATH ...)` normal variables from `Modules/ThirdParty/GDCM/src/CMakeLists.txt`, which had been *shadowing* the poisoned cache values — the block still fired (that was the #6551 warning) but wrote correct paths. Removing the shadow let the stale `/bin` value win.

`main` is unaffected for an unrelated reason: a6dd845c17 removed GDCM's vendored OpenJPEG source entirely. `main` vendors the same GDCM — it is immune by accident, not because its GDCM is fixed.

</details>

<details>
<summary>Reproduction</summary>

Per #6617, with the Makefiles generator:

```
cmake -G "Unix Makefiles" ../itk -DBUILD_TESTING:BOOL=OFF   # no warnings
make                                                        # exit 0
cmake .                                                     # 2 deprecation warnings return
make                                                        # exit 2
```

```
/usr/bin/ar: /bin/libitkgdcmjpeg16-5.4.a: Permission denied
/usr/bin/ar: /bin/libitkgdcmCommon-5.4.a: Permission denied
make: *** [Makefile:156: all] Error 2
```

Windows warns rather than errors because `/bin` resolves against the current drive and merely misplaces the artifacts.

</details>

<details>
<summary>Why not just bump the GDCM tag</summary>

No GDCM release fixes this. `Utilities/gdcmopenjpeg/CMakeLists.txt:180-182` is byte-identical in v3.2.8 (vendored here), v3.2.9, v3.2.10 and `master`, hence the upstream PRs.

Correcting the typo alone (`${${OPENJPEG_NAMESPACE}_BINARY_DIR}`) would not be enough: the CACHE entries would still exist, the compatibility block would still fire on re-configure, and all GDCM libraries would be redirected into OpenJPEG's `bin` directory.

</details>

<details>
<summary>Testing</summary>

Linux, GNU Make generator, `BUILD_TESTING=OFF`, on `release-5.4` @ c8721a5c93.

| | configure ×2 | warnings | make ×2 | make ×3 |
|---|---|---|---|---|
| before | cache → `/bin` | 2 | **exit 2** | — |
| after | no cache entries | 0 | exit 0 | exit 0 |

Libraries land in `<build>/lib`; nothing is written to `/bin`. The third pass confirms idempotency rather than merely surviving one re-configure.

Upstream, the same patches were verified against GDCM's own suite (195/198 both before and after; the three failures are pre-existing network-DICOM tests), and `TestSystem1` — which consumes `GDCM_EXECUTABLE_OUTPUT_PATH` — passes.

`pre-commit` is not run: `release-5.4` predates `.pre-commit-config.yaml`.

</details>

<details>
<summary>Notes for reviewers</summary>

This patches the vendored GDCM subtree directly, so it is a divergence from `malaterre/GDCM` that a future `UpdateFromUpstream.sh` re-import would revert. That seems acceptable for `release-5.4`, which is unlikely to take a GDCM re-import, and both patches are upstream so the divergence closes when they merge.

Unrelated observation while tracing this: `release-5.4` pins `readonly tag="release"` (a moving branch) in `Modules/ThirdParty/GDCM/UpdateFromUpstream.sh`, while `main` pins `v3.2.8`. Possibly worth a separate look.

</details>

<!--
provenance: claude-code session 2026-07-16, issue #6617
upstream_prs: malaterre/GDCM#226 (fix), malaterre/GDCM#227 (cleanup) - both OPEN/unreviewed at time of writing
worktree: /home/johnsonhj/src/ITK-6617-pr-src (branch fix-gdcm-reconfigure-6617)
builds: /home/johnsonhj/src/ITK-6617-pr-bld (BUILD_TESTING=OFF, 3x cfg+make green)
        /home/johnsonhj/src/ITK-6617-pr-bld-t (BUILD_TESTING=ON, Module_ITKIOGDCM)
key_refs:
  - gdcm/Utilities/gdcmopenjpeg/CMakeLists.txt:180-182  poison lines (removed)
  - gdcm/Utilities/CMakeLists.txt:26                    OPENJPEG_NAMESPACE mismatch
  - gdcm/CMakeLists.txt:123-131                         compat block (removed)
  - a6dd845c17                                          main: removed GDCM OpenJPEG source
post_merge_action: if upstream #226/#227 change during review, update this PR to match
-->
