### PR TITLE
BUG: Do not compile NrrdIO's sampleIO.c demo into the library

### DIFF
--- a/Modules/ThirdParty/NrrdIO/src/NrrdIO/CMakeLists.txt
+++ b/Modules/ThirdParty/NrrdIO/src/NrrdIO/CMakeLists.txt
@@ -85,7 +85,6 @@ set(nrrdio_SRCS
     preamble.c
     read.c
     reorder.c
-    sampleIO.c
     sane.c
     simple.c
     string.c


### PR DESCRIPTION
`sampleIO.c` is NrrdIO's usage demo and defines `main()`. Compiling it into `libITKNrrdIO` makes the library export `main()`, so downstream executables that link ITK's NrrdIO alongside `gtest_main` can silently resolve to the demo instead of their own entry point — on ITK 6.0.0 this silently deleted 17 BRAINSTools unit tests from a **passing** suite (413 → 396). One-line removal; ITK builds no executable from this file.

This is the minimal unblock for ITKv6 downstreams. The durable fix is upstream in NrrdIO (`nrrdio_SRCS` derived from `NrrdIO_Srcs.txt` rather than kept as a second hand-written copy), which a future re-vendor picks up.

<details>
<summary>Symptom — a GTest binary that was silently NrrdIO's demoIO</summary>

The executables build and run. They are simply the wrong program:

```console
$ ImageCalculatorUtilsGTest --gtest_list_tests      # ITK 6.0.0, before
(from Teem 2.0.0, early 2026)
demoIO: trouble reading "--gtest_list_tests":
[nrrd] nrrdLoad: fopen("--gtest_list_tests","rb") failed
```

`gtest_discover_tests` runs the binary at build time to enumerate tests, receives Teem's banner instead of a test list, parses **zero**, and registers nothing. ctest then reports `396 tests passed` — success, with 17 tests absent rather than failing. Nothing errors or warns at any layer.

```console
$ nm -g libITKNrrdIO-6.0.a | grep ' T _main'
sampleIO.c.o: T _main            # ITK 6.0.0  -- a library defining main()
                                 # ITK 5.4.6  -- no match
```

ITK 5.4.6 is unaffected because its vendored list predates the change.

</details>

<details>
<summary>Why sampleIO.c is not library code</summary>

Three artifacts already vendored beside `CMakeLists.txt` say so:

| file | says |
|---|---|
| `0-README.txt:93` | "Tiny little command-line program demonstrating the basic NrrdIO API." |
| `sample-GNUmakefile:56,74` | `ALL = libNrrdIO.a sampleIO` — two separate products; `sampleIO : sampleIO.c ... -L. -lNrrdIO` **links against** the library |
| `NrrdIO_Srcs.txt` | 41 Teem-extracted sources; omits `sampleIO.c` |

Only `nrrdio_SRCS` in `CMakeLists.txt` listed it — and that is the list the build executes. `git grep sampleIO` confirms ITK has no `add_executable` for it; it built as nothing but an archive member.

It entered ITK via 9f0a5d3888f (`ENH: Update NrrdIO from upstream`), inherited from NrrdIO's own hand-maintained list.

</details>

<details>
<summary>Verification (local, BRAINSTools against ITK main)</summary>

BRAINSTools `767ba471` built against ITK `main`, this change the only variable:

| check | before | after |
|---|---|---|
| `libITKNrrdIO-6.0.a` `main()` definitions | 1 | **0** |
| `ImageCalculatorUtilsGTest --gtest_list_tests` | Teem `demoIO` banner | `Running main() from gtest_main.cc`, 16 tests |
| registered tests (`ctest -N`) | 396 | **413** — matches ITK 5.4.6 exactly |

Found by a downstream build testbed that builds ITK consumers against a changed ITK; not visible to ITK's own CI, which does not build BRAINSTools' GTest suite.

</details>

<!--
provenance: claude-code session 2026-07-17
branch: hjmjohnson/ITK bug-nrrdio-drop-sampleio-demo (2b91d02c12b), off upstream/main b3d21b6e0a9
root_cause_doc: hjmjohnson/itk_forest_build_testbed docs/analysis/2026-07-17-nrrdio-main-collision.md
origin_commit: nrrdio 1279d6bc (2025-10-22) "ENH: Adding missing files from the cmake build list"
  -- added 4 files, 3 correct (encodingZRL.c, preamble.c, subset.c); sampleIO.c was the 4th
upstream_durable_fix: ~/src/nrrdio main dc2d8d2 -- derives nrrdio_SRCS from NrrdIO_Srcs.txt,
  adds CMAKE_CONFIGURE_DEPENDS + FATAL_ERROR existence guard. UNPUSHED as of this PR.
enabling_condition: one fact, two authorities -- NrrdIO_Srcs.txt (41, generated, correct)
  vs nrrdio_SRCS (43, hand-maintained, wrong). ITK vendors BOTH files, byte-identical lists.
follow_ups:
  - ITK could adopt the derive-from-NrrdIO_Srcs.txt form on re-vendor (do NOT add a third
    copy of the list to ITK's vendored CMakeLists -- that is the same defect again)
  - CI guard candidate: assert built libraries export no main() (nm)
  - separate, unrelated, ROOT-CAUSED 2026-07-17 (nothing for ITK to fix; do not chase
    this from here): BRAINSFitTest_MIHAffineRotationMasks and
    BRAINSFitTest_MIHScaleSkewVersorRotationMasks pass 10/10 on ITK 5.4.6, fail 0/10 on
    ITK 6.0.0. Cause: PR #6569 (merged 2026-07-16) corrected JointHistogramMutualInformation
    marginal pairing + derivative -- the metric --costMetric MIH selects. BRAINSTools'
    baselines date to 2018-11-24 and encode the OLD (buggy) metric's output, so they now
    disagree with a corrected answer. Proven: reverting only da915f91578+3ddebbf1d94 on v6
    -> 2/2 pass; main's derivative test vs the old math gives analytic -0.000731416 vs
    central finite difference 0.270065 (wrong sign, ~369x). Corrected metric is closer to
    ground truth (in-mask MSE vs fixed: new 54.792 < 2018 baseline 55.721 < old 55.898).
    Action is downstream baseline regeneration, mirroring what #6569 did for ITK's own
    itkSimpleImageRegistrationTest{Float,Double}.
    Analysis: itk_forest_build_testbed docs/analysis/2026-07-17-jhmi-metric-correction.md
verification: pre-commit run --all-files clean; gersemi excludes /ThirdParty/*/*/*/ by policy
-->

