### PR TITLE
BUG: Use itk::Math::Absolute instead of legacy itk::Math::abs in tests

### DIFF
--- a/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterGTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterGTest.cxx
@@ -162,7 +162,7 @@ TEST(InverseDisplacementFieldImageFilter, CenteredSubsamplingBoundsHighEdgeError
     {
       back[i] = point[i] + it.Get()[i];
       back[i] += 0.002 * back[i] * back[i];
-      maxError = std::max(maxError, itk::Math::abs(back[i] - point[i]));
+      maxError = std::max(maxError, itk::Math::Absolute(back[i] - point[i]));
     }
   }
   EXPECT_LT(maxError, 0.06);
@@ -231,7 +231,7 @@ TEST(InverseDisplacementFieldImageFilter, NonZeroStartRegionInvertsCorrectly)
     {
       back[i] = point[i] + it.Get()[i];
       back[i] += 0.002 * back[i] * back[i];
-      maxError = std::max(maxError, itk::Math::abs(back[i] - point[i]));
+      maxError = std::max(maxError, itk::Math::Absolute(back[i] - point[i]));
     }
   }
   EXPECT_LT(maxError, 0.06);

--- a/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx
@@ -131,9 +131,9 @@ itkJointHistogramMutualInformationImageToImageMetricv4Test(int, char *[])
     const double analytic = detunedDerivative[0];
     // Band brackets the measured analytic/central-difference ratio (~1.08 at h=0.5)
     // tightly enough to trip on a lost 1/log2 or stray factor-of-2 scale regression.
-    if (itk::Math::abs(finiteDifference) < 1e-10 || analytic * finiteDifference >= 0.0 ||
-        itk::Math::abs(analytic) < 0.7 * itk::Math::abs(finiteDifference) ||
-        itk::Math::abs(analytic) > 1.4 * itk::Math::abs(finiteDifference))
+    if (itk::Math::Absolute(finiteDifference) < 1e-10 || analytic * finiteDifference >= 0.0 ||
+        itk::Math::Absolute(analytic) < 0.7 * itk::Math::Absolute(finiteDifference) ||
+        itk::Math::Absolute(analytic) > 1.4 * itk::Math::Absolute(finiteDifference))
     {
       std::cerr << "Analytic derivative disagrees with finite difference of the value:" << std::endl
                 << "  analytic[0]: " << analytic << std::endl


### PR DESCRIPTION
Replace the deprecated `itk::Math::abs` shim with its non-deprecated equivalent `itk::Math::Absolute` in two test files, fixing the nightly build failures on all dashboard clients that set `ITK_FUTURE_LEGACY_REMOVE`.

<details>
<summary>Why the nightlies fail</summary>

`itk::Math::abs` is a backward-compatibility shim in `itkMath.h`, wrapped in `#if !defined(ITK_FUTURE_LEGACY_REMOVE)`. Dashboard clients that build with `ITK_FUTURE_LEGACY_REMOVE:BOOL=1` compile the shim out, so `itk::Math::abs` no longer resolves and these translation units fail with `no member named 'abs' in namespace 'itk::Math'`.

`itk::Math::Absolute` is the non-deprecated function the shim forwards to. For the `double` arguments used in both tests it has identical behavior.

Affected nightly builds (2026-07-17): RogueResearch Mac13/Mac14/Mac15/Mac10.15/Mac11 dbg-Universal, Mac26 ClangMain, Mac15 ASan/UBSan — every dashboard build-error on that day traced to this single site.

</details>

<details>
<summary>The second file is a latent breakage</summary>

The nightly reported only `itkInverseDisplacementFieldImageFilterGTest.cxx`, because the build stops at the first compile error. `itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx` uses the same deprecated call and would fail as soon as the first is fixed, so both are corrected here in one commit.

</details>

<details>
<summary>Local verification</summary>

Replicated the RogueResearch24 `Mac13.x-AppleClang-dbg-Universal` cache locally (`ITK_LEGACY_REMOVE=1`, `ITK_FUTURE_LEGACY_REMOVE=1`, universal Debug).

- `ITKDisplacementFieldGTestDriver` + `ITKMetricsv4TestDriver`: 0 compile errors.
- `InverseDisplacementFieldImageFilter` GTest: 8/8 cases pass (including the two whose `maxError` assertions use the changed lines).
- `itkJointHistogramMutualInformationImageToImageMetricv4Test`: passes.
- `pre-commit run --all-files`: clean.

</details>

<!--
provenance: claude-code session 2026-07-17, replicating open.cdash.org/builds/11422664 (RogueResearch24 Mac13 dbg-Universal)
root_cause: itk::Math::abs shim gated by #if !defined(ITK_FUTURE_LEGACY_REMOVE) in itkMath.h:1182
fix: s/itk::Math::abs(/itk::Math::Absolute(/ in the two test TUs
files: Modules/Filtering/DisplacementField/test/itkInverseDisplacementFieldImageFilterGTest.cxx (165,234); Modules/Registration/Metricsv4/test/itkJointHistogramMutualInformationImageToImageMetricv4Test.cxx (134-136)
related: deprecated-copy-with-dtor warnings on the same nightly are handled separately by blowekamp PR #6538
-->
