### PR TITLE
BUG: Make FastMarching AllTargets stop condition count distinct targets

### DIFF
--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.h
@@ -319,6 +319,9 @@ private:
   double m_TargetValue{};
 
   SizeValueType m_NumberOfTargets{};
+
+  // Distinct target count; duplicates must not make AllTargets unreachable.
+  SizeValueType m_TotalDistinctTargets{};
 };
 } // namespace itk
 

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingUpwindGradientImageFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkMath.h"
 #include <algorithm>
+#include <set>
 #include "itkPrintHelper.h"
 
 namespace itk
@@ -99,6 +100,21 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::Initialize(LevelS
   // Even if there are no targets, a new NodeContainer should be created
   // so that querying this structure does not crash.
   m_ReachedTargetPoints = NodeContainer::New();
+
+  // Each index is reached at most once, so AllTargets must compare against the
+  // distinct target count rather than the container size.
+  m_TotalDistinctTargets = 0;
+  if (m_TargetPoints)
+  {
+    std::set<IndexType> distinctTargetIndices;
+    for (typename NodeContainer::ConstIterator pointsIter = m_TargetPoints->Begin();
+         pointsIter != m_TargetPoints->End();
+         ++pointsIter)
+    {
+      distinctTargetIndices.insert(pointsIter.Value().GetIndex());
+    }
+    m_TotalDistinctTargets = static_cast<SizeValueType>(distinctTargetIndices.size());
+  }
 }
 
 template <typename TLevelSet, typename TSpeedImage>
@@ -201,7 +217,7 @@ FastMarchingUpwindGradientImageFilter<TLevelSet, TSpeedImage>::UpdateNeighbors(c
         }
       }
 
-      if (m_ReachedTargetPoints->Size() == m_TargetPoints->Size())
+      if (m_ReachedTargetPoints->Size() == m_TotalDistinctTargets)
       {
         targetReached = true;
       }

--- a/Modules/Filtering/FastMarching/test/CMakeLists.txt
+++ b/Modules/Filtering/FastMarching/test/CMakeLists.txt
@@ -414,5 +414,9 @@ set_property(
       RUNS_LONG
 )
 
-set(ITKFastMarchingGTests itkFastMarchingImageFilterBaseGTest.cxx)
+set(
+  ITKFastMarchingGTests
+  itkFastMarchingImageFilterBaseGTest.cxx
+  itkFastMarchingUpwindGradientImageFilterGTest.cxx
+)
 creategoogletestdriver(ITKFastMarching "${ITKFastMarching-Test_LIBRARIES}" "${ITKFastMarchingGTests}")

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientImageFilterGTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingUpwindGradientImageFilterGTest.cxx
@@ -1,0 +1,70 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkFastMarchingUpwindGradientImageFilter.h"
+#include "itkGTest.h"
+
+// Duplicate entries in the target container must not make the AllTargets stop
+// condition unreachable: each index is reached at most once, so the condition
+// must compare against the number of distinct targets (issue #6575, B24).
+TEST(FastMarchingUpwindGradientImageFilter, AllTargetsReachedWithDuplicateTargets)
+{
+  using ImageType = itk::Image<float, 2>;
+  using FilterType = itk::FastMarchingUpwindGradientImageFilter<ImageType, ImageType>;
+  using NodeType = FilterType::NodeType;
+  using NodeContainer = FilterType::NodeContainer;
+
+  constexpr auto imageSize = ImageType::SizeType::Filled(32);
+
+  // Constant unit speed.
+  auto speed = ImageType::New();
+  speed->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, imageSize });
+  speed->Allocate();
+  speed->FillBuffer(1.0F);
+
+  // One seed at the origin.
+  auto     trialPoints = NodeContainer::New();
+  NodeType node;
+  node.SetValue(0.0);
+  node.SetIndex(ImageType::IndexType{});
+  trialPoints->InsertElement(0, node);
+
+  // Two target entries with the SAME index: only one distinct target.
+  const auto targetIndex = itk::MakeIndex(10, 10);
+  auto       targetPoints = NodeContainer::New();
+  node.SetValue(0.0);
+  node.SetIndex(targetIndex);
+  targetPoints->InsertElement(0, node);
+  targetPoints->InsertElement(1, node);
+
+  auto filter = FilterType::New();
+  filter->SetInput(speed);
+  filter->SetOutputSize(imageSize);
+  filter->SetTrialPoints(trialPoints);
+  filter->SetTargetPoints(targetPoints);
+  filter->SetTargetOffset(0.0);
+  filter->SetStoppingValue(1000.0);
+  filter->SetTargetReachedModeToAllTargets();
+  filter->Update();
+
+  // The single distinct target must be registered as reached, and the recorded
+  // target arrival time must be the (positive) arrival time at that index.
+  EXPECT_EQ(filter->GetReachedTargetPoints()->Size(), 1u);
+  EXPECT_GT(filter->GetTargetValue(), 0.0);
+  EXPECT_NEAR(filter->GetTargetValue(), static_cast<double>(filter->GetOutput()->GetPixel(targetIndex)), 1e-6);
+}


### PR DESCRIPTION
Fixes the `AllTargets` stop condition in `FastMarchingUpwindGradientImageFilter`, which compared the reached-target count against the raw target-container size and so never triggered when the target list held duplicate indices. Addresses item **B24** of #6575.

<details>
<summary>Root cause &amp; fix</summary>

Each index is accepted (reached) at most once, so a target container with duplicate indices could never satisfy `reachedCount == containerSize`; `AllTargets` mode therefore never halted and the front marched the whole image.

The filter now computes the number of **distinct** target indices once in `Initialize()` (via `std::set<IndexType>`) and compares the reached count against that. The change is scoped strictly to the `AllTargets` branch of `UpdateNeighbors`; `SomeTargets`/`OneTarget` behavior is unchanged.
</details>

<details>
<summary>Test</summary>

Adds a GoogleTest with a duplicated target index. On the unfixed code `GetTargetValue()` stays 0 (target never registered / never halts as intended); after the fix it reports the correct arrival time. Fail-before/pass-after was verified locally. Self-contained synthetic image — no ITKTestingData fixture.
</details>

<!--
provenance: claude-code session 2026-07-17, ledger issue #6575 item B24
branch: hjmjohnson:bug-fastmarching-alltargets-6575 (rebased on upstream/main)
local-verify: ITKFastMarchingGTestDriver -R AllTargetsReachedWithDuplicateTargets PASS; fail-before proven by reverting include/ sources; pre-commit --all-files clean
-->
