### PR TITLE
COMP: Fail early when wrapped Python is older than the 3.11 minimum

### DIFF
--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -168,6 +168,7 @@ else()
     list(APPEND _python_find_components NumPy)
   endif()
   set(_missing_required_component FALSE)
+  set(_missing_python_components "")
   find_package(
     Python3
     ${ITK_WRAP_PYTHON_VERSION}
@@ -183,6 +184,7 @@ else()
         " o Python3 Missing COMPONENT: Python3_${_required_component}_FOUND: ${Python3_${_required_component}_FOUND}"
       )
       set(_missing_required_component TRUE)
+      list(APPEND _missing_python_components ${_required_component})
     else()
       message(
         STATUS
@@ -192,9 +194,39 @@ else()
   endforeach()
   unset(_required_component)
   if(_missing_required_component)
+    set(_missing_component_remedy "")
+    if(NumPy IN_LIST _missing_python_components)
+      string(
+        APPEND
+        _missing_component_remedy
+        "
+          NumPy: ${Python3_EXECUTABLE} -m pip install numpy"
+      )
+    endif()
+    if(
+      Development.Module
+        IN_LIST
+        _missing_python_components
+      OR
+        Development.SABIModule
+          IN_LIST
+          _missing_python_components
+    )
+      string(
+        APPEND
+        _missing_component_remedy
+        "
+          Development: install the development headers matching this interpreter
+                       (Debian/Ubuntu: apt install python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}-dev)"
+      )
+    endif()
     message(
       FATAL_ERROR
-      "At least 1 required Python3 COMPONENT could not be found from : ${_python_find_components}
+      "Missing required Python3 COMPONENT(s): ${_missing_python_components}${_missing_component_remedy}
+
+          Or set ITK_WRAP_PYTHON=OFF to build without Python wrapping.
+          ---
+          Searched for : ${_python_find_components}
           in range ${PYTHON_VERSION_MIN}...${PYTHON_VERSION_MAX}:
           Python3_EXECUTABLE=:${Python3_EXECUTABLE}:
           ITK_WRAP_PYTHON_VERSION=:${ITK_WRAP_PYTHON_VERSION}:
@@ -210,12 +242,14 @@ else()
           Python3_NumPy_FOUND=${Python3_NumPy_FOUND}
     "
     )
+    unset(_missing_component_remedy)
   else()
     message(STATUS " o Python3_EXECUTABLE=${Python3_EXECUTABLE}")
     message(STATUS " o Python3_ROOT_DIR=${Python3_ROOT_DIR}")
     message(STATUS " o ITK_WRAP_PYTHON_VERSION=${ITK_WRAP_PYTHON_VERSION}")
   endif()
   unset(_missing_required_component)
+  unset(_missing_python_components)
   unset(_python_find_components)
   # _ITK_MINIMUM_SUPPORTED_LIMITED_API_VERSION is cached (INTERNAL) and intentionally
   # left set so itk_end_wrap_module.cmake can pin USE_SABI to the same floor.

--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -7,7 +7,9 @@
 # may become less reliable with newer versions of CMake (as opposed setting FindPython3 HINTS).  Current
 # implementation gives preference to active virtualenvs.
 cmake_policy(SET CMP0094 NEW) # makes FindPython3 prefer activated virtualenv Python to latest version
-set(PYTHON_VERSION_MIN 3.11)
+# Canonical floor; a specified Python3_EXECUTABLE narrows PYTHON_VERSION_MIN below, so keep it separate.
+set(ITK_WRAP_PYTHON_MINIMUM_VERSION 3.11)
+set(PYTHON_VERSION_MIN ${ITK_WRAP_PYTHON_MINIMUM_VERSION})
 set(PYTHON_VERSION_MAX 3.999)
 if(DEFINED Python3_EXECUTABLE) # if already specified
   set(_specified_Python3_EXECUTABLE ${Python3_EXECUTABLE})
@@ -22,6 +24,22 @@ if(DEFINED Python3_EXECUTABLE) # if already specified
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
   if(_specified_Python3_VERSION_MM)
+    # execute_process re-runs every configure, so this also rejects incremental
+    # reconfigures of a cached below-floor tree, before any wrapping work.
+    if(
+      PYTHON_DEVELOPMENT_REQUIRED
+      AND
+        _specified_Python3_VERSION_MM
+          VERSION_LESS
+          ${ITK_WRAP_PYTHON_MINIMUM_VERSION}
+    )
+      message(
+        FATAL_ERROR
+        "ITK Python wrapping (ITK_WRAP_PYTHON=ON) requires Python >= ${ITK_WRAP_PYTHON_MINIMUM_VERSION}, "
+        "but the specified Python3_EXECUTABLE=${_specified_Python3_EXECUTABLE} is Python ${_specified_Python3_VERSION_MM}. "
+        "Provide a Python >= ${ITK_WRAP_PYTHON_MINIMUM_VERSION} interpreter, or set ITK_WRAP_PYTHON=OFF."
+      )
+    endif()
     set(PYTHON_VERSION_MIN ${_specified_Python3_VERSION_MM})
     set(PYTHON_VERSION_MAX ${_specified_Python3_VERSION_MM})
   endif()
@@ -56,6 +74,25 @@ else()
       NumPy
   )
   set(ITK_WRAP_PYTHON_VERSION "${Python3_VERSION}")
+
+  # An empty Python3_VERSION means the range found nothing; otherwise the second
+  # find_package below runs unversioned and silently accepts a below-floor Python.
+  if(
+    NOT
+      Python3_VERSION
+    OR
+      Python3_VERSION
+        VERSION_LESS
+        ${ITK_WRAP_PYTHON_MINIMUM_VERSION}
+  )
+    message(
+      FATAL_ERROR
+      "ITK Python wrapping (ITK_WRAP_PYTHON=ON) requires Python >= ${ITK_WRAP_PYTHON_MINIMUM_VERSION}, "
+      "but no such interpreter was found in range ${PYTHON_VERSION_MIN}...${PYTHON_VERSION_MAX} "
+      "(resolved version '${Python3_VERSION}', Python3_EXECUTABLE='${Python3_EXECUTABLE}'). "
+      "Provide a Python >= ${ITK_WRAP_PYTHON_MINIMUM_VERSION} interpreter, or set ITK_WRAP_PYTHON=OFF."
+    )
+  endif()
 
   # start section to define package components based on LIMITED_API support and choices
   # Cached so the abi3 floor is a single source of truth shared with the module


### PR DESCRIPTION
Abort configuration when `ITK_WRAP_PYTHON=ON` and the resolved Python is older than the 3.11 minimum raised in #6490, instead of failing at `import itk` after a full build + test cycle.

A second commit names the missing Python3 component and the command that installs it, so a numpy-less interpreter reports `Missing required Python3 COMPONENT(s): NumPy` plus a copy-pasteable `pip install` line instead of a wall of `Python3_*_FOUND` variables.

**@dzenanz** — this targets your `Ubuntu-22.04-gcc11.4-Rel-Python` nightly (RogueResearch/Kitware dashboard), which currently submits with Python 3.10 and produces ~194 `import itk` failures every night. That dashboard's submission needs its interpreter updated to Python ≥ 3.11 (or `ITK_WRAP_PYTHON=OFF`). Once this merges, that config will fail fast at configure with an actionable message rather than after ~3 hours of building and testing.

<details>
<summary>Why the 3.11 floor is currently bypassed</summary>

`CMake/ITKSetPython3Vars.cmake` sets `PYTHON_VERSION_MIN 3.11`, but when a dashboard passes an explicit `Python3_EXECUTABLE`, this block narrows the range to that interpreter's exact version:

```cmake
set(PYTHON_VERSION_MIN ${_specified_Python3_VERSION_MM})   # e.g. 3.10
set(PYTHON_VERSION_MAX ${_specified_Python3_VERSION_MM})
```

So `find_package(Python3 3.11...3.999)` never rejects the older interpreter. Wrapping configures and builds normally, then every wrapped test fails identically at runtime:

```
from typing import Self, TypeAlias, Union, TYPE_CHECKING   # itk/support/types.py
ImportError: cannot import name 'Self' from 'typing'  (python3.10)
```

`typing.Self` (PEP 673) is Python 3.11+, consistent with #6490 raising the wrapped-Python minimum to 3.11.

</details>

<details>
<summary>Fix and local verification</summary>

Adds a canonical `ITK_WRAP_PYTHON_MINIMUM_VERSION` floor and asserts the resolved `Python3_VERSION` against it immediately after `find_package`, before any wrapping/SWIG work.

Verified locally against `upstream/main`:

- `-DITK_WRAP_PYTHON=ON -DPython3_EXECUTABLE=python3.10` → configure aborts (exit 1) after ~75 lines with `ITK Python wrapping (ITK_WRAP_PYTHON=ON) requires Python >= 3.11 …`, before SWIG/wrapping.
- `-DITK_WRAP_PYTHON=ON -DPython3_EXECUTABLE=python3.11` → guard silent, full configure succeeds (exit 0), `ITK_WRAP_PYTHON_VERSION=3.11.15`.
- `pre-commit run --all-files`: clean.

</details>

<details>
<summary>Second commit: name the missing component and its remedy</summary>

`BUILD_TESTING` appends `NumPy` to the hard-required component list, so an interpreter without numpy aborts configure. The previous error never stated which component was missing or how to supply it. That failure is **pre-existing and unrelated to the version guard** — `main` behaves identically, verified below.

Before:

```
At least 1 required Python3 COMPONENT could not be found from :
Interpreter;Development.Module;Development.SABIModule;NumPy
          in range 3.12.13...3.12.13:
          ... 12 more lines of Python3_*_FOUND variables ...
```

After:

```
Missing required Python3 COMPONENT(s): NumPy

          NumPy: /usr/bin/python3.11 -m pip install numpy

          Or set ITK_WRAP_PYTHON=OFF to build without Python wrapping.
```

A missing `Development.Module` / `Development.SABIModule` gets its own line pointing at the matching `-dev` package. The original variable dump is retained below the summary. Behavior is unchanged; only the diagnostic text differs.

Failure tracks numpy, not the Python version (Ubuntu 24.04, cmake 3.28.3, `ITK_WRAP_PYTHON=ON`, `BUILD_TESTING=ON`):

| ref | interpreter | numpy | result |
|---|---|---|---|
| main | python3.11 | no | `COMPONENT could not be found` |
| main | python3.12 | yes | configures |
| main | python3.13 | no | `COMPONENT could not be found` |
| this PR | python3.11 | no | `Missing … NumPy` + remedy |
| this PR | python3.12 | yes | configures |
| this PR | python3.13 | no | `Missing … NumPy` + remedy |

Full ITK configures (not a harness):

- `-DITK_WRAP_PYTHON=ON` with a numpy-less interpreter → aborts with the new message.
- `-DITK_WRAP_PYTHON=ON` with numpy present → `Configuring done (79.4s) / Generating done`, exit 0.
- All four missing-component combinations (`NumPy`, `Development.Module`, both, `Development.SABIModule`) exercised directly.
- `pre-commit run --all-files`: clean.

</details>

<!--
provenance: claude-code session 2026-07-17; found via nightly build 11422005 (Ubuntu-22.04-gcc11.4-Rel-Python, 194 import-itk failures)
file: CMake/ITKSetPython3Vars.cmake (guard after first wrapping find_package)
related: #6490 (raised wrapped Python minimum to 3.11), #6012 (py3.10), #6657 (unrelated Math::abs nightly fix same day)
dashboard_action: dzenanz Ubuntu-22.04-gcc11.4-Rel-Python submission must move to Python >= 3.11
                  AND that interpreter needs numpy installed (numpy-missing aborts configure on main too)
commit2: d98d270160b — name missing Python3 component + install command
commit2_verified: 2026-07-18 macOS + cortex.ecn.uiowa.edu (Ubuntu 24.04.4, cmake 3.28.3);
                  numpy-missing failure reproduced identically on main (21253ca) and PR head (56cdfa7)
numpy_requirement_site: CMake/ITKSetPython3Vars.cmake — BUILD_TESTING appends NumPy to required components
held_separately: naming rework (_ITK_PYTHON_VERSION_MIN single knob) on branch itk-python-version-min-single-knob, not part of this PR
-->

