### PR TITLE
COMP: Gate VXL svd and matrix_inverse tests under ITK_FUTURE_LEGACY_REMOVE

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/CMakeLists.txt
@@ -19,10 +19,7 @@ set(vnl_algo_test_sources
   test_qr.cxx
   test_rank.cxx
   test_sparse_matrix.cxx
-  test_svd.cxx
-  test_svd_fixed.cxx
   test_integral.cxx
-  test_solve_qp.cxx
   test_sparse_lu.cxx
   test_bracket_minimum.cxx
   test_brent_minimizer.cxx
@@ -38,9 +35,25 @@ if(NOT ITK_FUTURE_LEGACY_REMOVE)
   )
 endif()
 
+# The LINPACK-svdc-backed vnl_svd family and vnl_solve_qp are excluded from the
+# build under ITK_FUTURE_LEGACY_REMOVE, so their tests cannot link there.
+if(NOT ITK_FUTURE_LEGACY_REMOVE)
+  list(APPEND vnl_algo_test_sources
+    test_svd.cxx
+    test_svd_fixed.cxx
+    test_solve_qp.cxx
+  )
+endif()
+
 add_executable( vnl_algo_test_all ${vnl_algo_test_sources} )
 if(ITK_FUTURE_LEGACY_REMOVE)
-  target_compile_definitions( vnl_algo_test_all PRIVATE VNL_EISPACK_REMOVED )
+  # The ThirdParty VXL compile cannot see itkConfigure.h, so the removed-API
+  # state is conveyed to the test sources as explicit compile definitions.
+  target_compile_definitions( vnl_algo_test_all PRIVATE
+    VNL_EISPACK_REMOVED
+    VNL_SVD_REMOVED
+    VNL_MATRIX_INVERSE_REMOVED
+  )
 endif()
 
 target_link_libraries( vnl_algo_test_all itkvnl_algo itktestlib ${CMAKE_THREAD_LIBS} )
@@ -58,18 +71,18 @@ add_test( NAME vnl_algo_test_powell COMMAND vnl_algo_test_all test_powell       
 add_test( NAME vnl_algo_test_qr COMMAND vnl_algo_test_all test_qr                      )
 add_test( NAME vnl_algo_test_rank COMMAND vnl_algo_test_all test_rank                    )
 add_test( NAME vnl_algo_test_integral COMMAND vnl_algo_test_all test_integral                )
-add_test( NAME vnl_algo_test_solve_qp COMMAND vnl_algo_test_all test_solve_qp                )
 add_test( NAME vnl_algo_test_sparse_lu COMMAND vnl_algo_test_all test_sparse_lu               )
 add_test( NAME vnl_algo_test_bracket_minimum COMMAND vnl_algo_test_all test_bracket_minimum         )
 add_test( NAME vnl_algo_test_brent_minimizer COMMAND vnl_algo_test_all test_brent_minimizer         )
 add_test( NAME vnl_algo_test_sparse_matrix COMMAND vnl_algo_test_all test_sparse_matrix           )
-add_test( NAME vnl_algo_test_svd COMMAND vnl_algo_test_all test_svd                     )
-add_test( NAME vnl_algo_test_svd_fixed COMMAND vnl_algo_test_all test_svd_fixed               )
 
 if(NOT ITK_FUTURE_LEGACY_REMOVE)
   add_test( NAME vnl_algo_test_generalized_eigensystem COMMAND vnl_algo_test_all test_generalized_eigensystem )
   add_test( NAME vnl_algo_test_real_eigensystem COMMAND vnl_algo_test_all test_real_eigensystem )
   add_test( NAME vnl_algo_test_symmetric_eigensystem COMMAND vnl_algo_test_all test_symmetric_eigensystem )
+  add_test( NAME vnl_algo_test_svd COMMAND vnl_algo_test_all test_svd )
+  add_test( NAME vnl_algo_test_svd_fixed COMMAND vnl_algo_test_all test_svd_fixed )
+  add_test( NAME vnl_algo_test_solve_qp COMMAND vnl_algo_test_all test_solve_qp )
 endif()
 
 add_executable( vnl_algo_test_include test_include.cxx )

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_algo.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_algo.cxx
@@ -24,34 +24,40 @@
 #include <vnl/algo/vnl_lbfgs.h>
 #include <vnl/algo/vnl_lbfgsb.h>
 #include <vnl/algo/vnl_lsqr.h>
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef VNL_MATRIX_INVERSE_REMOVED
 #  define ITK_LEGACY_TEST // exercising the deprecated vnl_matrix_inverse
 #  include <vnl/algo/vnl_matrix_inverse.h>
 #endif
 #include <vnl/algo/vnl_powell.h>
-#include <vnl/algo/vnl_svd_economy.h>
-#include <vnl/algo/vnl_svd.h>
+#ifndef VNL_SVD_REMOVED
+#  include <vnl/algo/vnl_svd_economy.h>
+#  include <vnl/algo/vnl_svd.h>
+#endif
 #include "vnl/vnl_sparse_matrix_linear_system.h"
 #include "vnl/vnl_least_squares_function.h"
 
+#if !defined(VNL_SVD_REMOVED) || !defined(VNL_MATRIX_INVERSE_REMOVED)
 static void
 test_matrix_inverse()
 {
   double data[] = { 1., -1., 1., -1., 1., 1., -1., -1., 1., 1., 1., 1., 1., -1., -1., 1. };
   const vnl_matrix<double> m(data, 4, 4);
+#  ifndef VNL_SVD_REMOVED
   vnl_svd_economy<double> svde(m);
   vnl_matrix<double> V = svde.V();
   vnl_svd<double> svd(m);
   vnl_matrix<double> V0 = svd.V();
   TEST_NEAR("vnl_svd_economy", V[0][1], V0[0][1], 1e-6);
+#  endif
 
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  ifndef VNL_MATRIX_INVERSE_REMOVED
   const vnl_matrix<double> inv{ vnl_matrix_inverse<double>(m).as_matrix() };
   vnl_matrix<double> identity(4, 4);
   identity.set_identity();
   TEST_NEAR("vnl_matrix_inverse", (m * inv - identity).array_inf_norm(), 0, 1e-6);
-#endif
+#  endif
 }
+#endif
 
 class F_test_powell : public vnl_cost_function
 {
@@ -195,7 +201,9 @@ test_discrete_diff()
 void
 test_algo()
 {
+#if !defined(VNL_SVD_REMOVED) || !defined(VNL_MATRIX_INVERSE_REMOVED)
   test_matrix_inverse();
+#endif
   test_powell();
   test_lsqr();
   test_discrete_diff();

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_complex_algo.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_complex_algo.cxx
@@ -12,13 +12,16 @@
 // \date 9 January 2011
 
 #include "testlib/testlib_test.h"
-#include <vnl/algo/vnl_svd_economy.h>
-#include <vnl/algo/vnl_svd.h>
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#ifndef VNL_SVD_REMOVED
+#  include <vnl/algo/vnl_svd_economy.h>
+#  include <vnl/algo/vnl_svd.h>
+#endif
+#ifndef VNL_MATRIX_INVERSE_REMOVED
 #  define ITK_LEGACY_TEST // exercising the deprecated vnl_matrix_inverse
 #  include <vnl/algo/vnl_matrix_inverse.h>
 #endif
 
+#if !defined(VNL_SVD_REMOVED) || !defined(VNL_MATRIX_INVERSE_REMOVED)
 static void
 test_matrix_inverse()
 {
@@ -39,24 +42,29 @@ test_matrix_inverse()
                                   std::complex<double>(-1., -1.),
                                   1. };
   const vnl_matrix<std::complex<double>> m(data, 4, 4);
+#  ifndef VNL_SVD_REMOVED
   vnl_svd_economy<std::complex<double>> svde(m);
   vnl_matrix<std::complex<double>> V = svde.V();
   vnl_svd<std::complex<double>> svd(m);
   vnl_matrix<std::complex<double>> V0 = svd.V();
   TEST_NEAR("complex vnl_svd_economy", V[0][1], V0[0][1], 1e-6);
+#  endif
 
-#ifndef ITK_FUTURE_LEGACY_REMOVE
+#  ifndef VNL_MATRIX_INVERSE_REMOVED
   const vnl_matrix<std::complex<double>> inv{ vnl_matrix_inverse<std::complex<double>>(m).as_matrix() };
   vnl_matrix<std::complex<double>> identity(4, 4);
   identity.set_identity();
   TEST_NEAR("complex vnl_matrix_inverse", (m * inv - identity).array_inf_norm(), 0, 1e-6);
-#endif
+#  endif
 }
+#endif
 
 void
 test_complex_algo()
 {
+#if !defined(VNL_SVD_REMOVED) || !defined(VNL_MATRIX_INVERSE_REMOVED)
   test_matrix_inverse();
+#endif
 }
 
 TESTMAIN(test_complex_algo);

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_driver.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_driver.cxx
@@ -21,13 +21,19 @@ DECLARE(test_real_eigensystem);
 #endif
 DECLARE(test_sparse_matrix);
 DECLARE(test_integral);
+#ifndef VNL_SVD_REMOVED
 DECLARE(test_svd);
+#endif
+#ifndef VNL_SVD_REMOVED
 DECLARE(test_svd_fixed);
+#endif
 #ifndef VNL_EISPACK_REMOVED
 DECLARE(test_symmetric_eigensystem);
 #endif
 DECLARE(test_algo);
+#ifndef VNL_SVD_REMOVED
 DECLARE(test_solve_qp);
+#endif
 DECLARE(test_sparse_lu);
 DECLARE(test_bracket_minimum);
 DECLARE(test_brent_minimizer);
@@ -54,13 +60,19 @@ register_tests()
 #endif
   REGISTER(test_integral);
   REGISTER(test_sparse_matrix);
+#ifndef VNL_SVD_REMOVED
   REGISTER(test_svd);
+#endif
+#ifndef VNL_SVD_REMOVED
   REGISTER(test_svd_fixed);
+#endif
 #ifndef VNL_EISPACK_REMOVED
   REGISTER(test_symmetric_eigensystem);
 #endif
   REGISTER(test_algo);
+#ifndef VNL_SVD_REMOVED
   REGISTER(test_solve_qp);
+#endif
   REGISTER(test_sparse_lu);
   REGISTER(test_bracket_minimum);
   REGISTER(test_brent_minimizer);

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_rank.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/test_rank.cxx
@@ -1,23 +1,30 @@
 #include "vnl/vnl_matrix.h"
-#include <vnl/algo/vnl_svd.h>
+#ifndef VNL_SVD_REMOVED
+#  include <vnl/algo/vnl_svd.h>
+#endif
 #include "vnl/vnl_rank.h"
 #include "testlib/testlib_test.h"
 
+#ifndef VNL_SVD_REMOVED
 inline int
 svd_rank(const vnl_matrix<double> & M)
 {
   return vnl_svd<double>(M, 1e-8).rank();
 }
+#  define TEST_SVD_RANK(msg, m, expected) TEST(msg, svd_rank(m), expected)
+#else
+#  define TEST_SVD_RANK(msg, m, expected) /* vnl_svd removed */
+#endif
 
 void
 test_rank()
 {
   // 1x1 double
   vnl_matrix<double> m11(1, 1, 0.0); // all zero matrix
-  TEST("zero_1x1.vnl_svd().rank()", svd_rank(m11), 0);
+  TEST_SVD_RANK("zero_1x1.vnl_svd().rank()", m11, 0);
   TEST("vnl_rank(zero_1x1)", vnl_rank(m11), 0);
   m11[0][0] = -3.0;
-  TEST("-3_1x1.vnl_svd().rank()", svd_rank(m11), 1);
+  TEST_SVD_RANK("-3_1x1.vnl_svd().rank()", m11, 1);
   TEST("vnl_rank(-3_1x1)", vnl_rank(m11), 1);
   TEST("vnl_rank(-3_1x1, vnl_rank_row)", vnl_rank(m11, vnl_rank_row), 1);
   TEST("vnl_rank(-3_1x1, vnl_rank_column)", vnl_rank(m11, vnl_rank_column), 1);
@@ -32,17 +39,17 @@ test_rank()
 
   // 1x2 double
   vnl_matrix<double> m12(1, 2, 0.0); // all zero matrix
-  TEST("zero_1x2.vnl_svd().rank()", svd_rank(m12), 0);
+  TEST_SVD_RANK("zero_1x2.vnl_svd().rank()", m12, 0);
   TEST("vnl_rank(zero_1x2)", vnl_rank(m12), 0);
   TEST("vnl_rank(zero_1x2, vnl_rank_row)", vnl_rank(m12, vnl_rank_row), 0);
   TEST("vnl_rank(zero_1x2, vnl_rank_column)", vnl_rank(m12, vnl_rank_column), 0);
   m12[0][1] = -2.0;
-  TEST("0-2_1x2.vnl_svd().rank()", svd_rank(m12), 1);
+  TEST_SVD_RANK("0-2_1x2.vnl_svd().rank()", m12, 1);
   TEST("vnl_rank(0-2_1x2)", vnl_rank(m12), 1);
   TEST("vnl_rank(0-2_1x2, vnl_rank_row)", vnl_rank(m12, vnl_rank_row), 1);
   TEST("vnl_rank(0-2_1x2, vnl_rank_column)", vnl_rank(m12, vnl_rank_column), 1);
   m12[0][0] = 1.0;
-  TEST("1-2_1x2.vnl_svd().rank()", svd_rank(m12), 1);
+  TEST_SVD_RANK("1-2_1x2.vnl_svd().rank()", m12, 1);
   TEST("vnl_rank(1-2_1x2)", vnl_rank(m12), 1);
   TEST("vnl_rank(1-2_1x2, vnl_rank_row)", vnl_rank(m12, vnl_rank_row), 1);
   TEST("vnl_rank(1-2_1x2, vnl_rank_column)", vnl_rank(m12, vnl_rank_column), 1);
@@ -63,34 +70,34 @@ test_rank()
 
   // 2x2 double
   vnl_matrix<double> m22(2, 2, 0.0); // all zero matrix
-  TEST("zero_2x2.vnl_svd().rank()", svd_rank(m22), 0);
+  TEST_SVD_RANK("zero_2x2.vnl_svd().rank()", m22, 0);
   TEST("vnl_rank(zero_2x2)", vnl_rank(m22), 0);
   TEST("vnl_rank(zero_2x2, vnl_rank_row)", vnl_rank(m22, vnl_rank_row), 0);
   TEST("vnl_rank(zero_2x2, vnl_rank_column)", vnl_rank(m22, vnl_rank_column), 0);
   m22[0][1] = 6.0;
-  TEST("0300_2x2.vnl_svd().rank()", svd_rank(m22), 1);
+  TEST_SVD_RANK("0300_2x2.vnl_svd().rank()", m22, 1);
   TEST("vnl_rank(0600_2x2)", vnl_rank(m22), 1);
   TEST("vnl_rank(0600_2x2, vnl_rank_row)", vnl_rank(m22, vnl_rank_row), 1);
   TEST("vnl_rank(0600_2x2, vnl_rank_column)", vnl_rank(m22, vnl_rank_column), 1);
   m22[1][0] = -1.0;
-  TEST("06-10_2x2.vnl_svd().rank()", svd_rank(m22), 2);
+  TEST_SVD_RANK("06-10_2x2.vnl_svd().rank()", m22, 2);
   TEST("vnl_rank(06-10_2x2)", vnl_rank(m22), 2);
   TEST("vnl_rank(06-10_2x2, vnl_rank_row)", vnl_rank(m22, vnl_rank_row), 2);
   TEST("vnl_rank(06-10_2x2, vnl_rank_column)", vnl_rank(m22, vnl_rank_column), 2);
   m22[0][0] = -2.0;
   m22[1][1] = 3.0;
-  TEST("-26-13_2x2.vnl_svd().rank()", svd_rank(m22), 1);
+  TEST_SVD_RANK("-26-13_2x2.vnl_svd().rank()", m22, 1);
   TEST("vnl_rank(-26-13_2x2)", vnl_rank(m22), 1);
   TEST("vnl_rank(-26-13_2x2, vnl_rank_row)", vnl_rank(m22, vnl_rank_row), 1);
   TEST("vnl_rank(-26-13_2x2, vnl_rank_column)", vnl_rank(m22, vnl_rank_column), 1);
   m22[1][0] = -3.0;
   m22[1][1] = 9.0;
-  TEST("-26-39_2x2.vnl_svd().rank()", svd_rank(m22), 1);
+  TEST_SVD_RANK("-26-39_2x2.vnl_svd().rank()", m22, 1);
   TEST("vnl_rank(-26-39_2x2)", vnl_rank(m22), 1);
   TEST("vnl_rank(-26-39_2x2, vnl_rank_row)", vnl_rank(m22, vnl_rank_row), 1);
   TEST("vnl_rank(-26-39_2x2, vnl_rank_column)", vnl_rank(m22, vnl_rank_column), 1);
   m22 *= 2.0; // now the pivot element will never be 1
-  TEST("-4_12_-6_18_2x2.vnl_svd().rank()", svd_rank(m22), 1);
+  TEST_SVD_RANK("-4_12_-6_18_2x2.vnl_svd().rank()", m22, 1);
   TEST("vnl_rank(-4_12_-6_18_2x2)", vnl_rank(m22), 1);
   TEST("vnl_rank(-4_12_-6_18_2x2, vnl_rank_row)", vnl_rank(m22, vnl_rank_row), 1);
   TEST("vnl_rank(-4_12_-6_18_2x2, vnl_rank_column)", vnl_rank(m22, vnl_rank_column), 1);
@@ -125,34 +132,34 @@ test_rank()
 
   // 3x2 double
   vnl_matrix<double> m32(3, 2, 0.0); // all zero matrix
-  TEST("zero_3x2.vnl_svd().rank()", svd_rank(m32), 0);
+  TEST_SVD_RANK("zero_3x2.vnl_svd().rank()", m32, 0);
   TEST("vnl_rank(zero_3x2)", vnl_rank(m32), 0);
   TEST("vnl_rank(zero_3x2, vnl_rank_row)", vnl_rank(m32, vnl_rank_row), 0);
   TEST("vnl_rank(zero_3x2, vnl_rank_column)", vnl_rank(m32, vnl_rank_column), 0);
   m32[0][1] = 6.0;
-  TEST("3x2.vnl_svd().rank()", svd_rank(m32), 1);
+  TEST_SVD_RANK("3x2.vnl_svd().rank()", m32, 1);
   TEST("vnl_rank(3x2)", vnl_rank(m32), 1);
   TEST("vnl_rank(3x2, vnl_rank_row)", vnl_rank(m32, vnl_rank_row), 1);
   TEST("vnl_rank(3x2, vnl_rank_column)", vnl_rank(m32, vnl_rank_column), 1);
   m32[2][0] = -1.0;
-  TEST("3x2.vnl_svd().rank()", svd_rank(m32), 2);
+  TEST_SVD_RANK("3x2.vnl_svd().rank()", m32, 2);
   TEST("vnl_rank(3x2)", vnl_rank(m32), 2);
   TEST("vnl_rank(3x2, vnl_rank_row)", vnl_rank(m32, vnl_rank_row), 2);
   TEST("vnl_rank(3x2, vnl_rank_column)", vnl_rank(m32, vnl_rank_column), 2);
   m32[1][0] = 3.0;
   m32[2][1] = 1.0;
-  TEST("3x2.vnl_svd().rank()", svd_rank(m32), 2);
+  TEST_SVD_RANK("3x2.vnl_svd().rank()", m32, 2);
   TEST("vnl_rank(3x2)", vnl_rank(m32), 2);
   TEST("vnl_rank(3x2, vnl_rank_row)", vnl_rank(m32, vnl_rank_row), 2);
   TEST("vnl_rank(3x2, vnl_rank_column)", vnl_rank(m32, vnl_rank_column), 2);
   m32[0][0] = -6.0;
   m32[1][1] = -3.0;
-  TEST("3x2.vnl_svd().rank()", svd_rank(m32), 1);
+  TEST_SVD_RANK("3x2.vnl_svd().rank()", m32, 1);
   TEST("vnl_rank(3x2)", vnl_rank(m32), 1);
   TEST("vnl_rank(3x2, vnl_rank_row)", vnl_rank(m32, vnl_rank_row), 1);
   TEST("vnl_rank(3x2, vnl_rank_column)", vnl_rank(m32, vnl_rank_column), 1);
   m32 *= 2.0;
-  TEST("3x2.vnl_svd().rank()", svd_rank(m32), 1);
+  TEST_SVD_RANK("3x2.vnl_svd().rank()", m32, 1);
   TEST("vnl_rank(3x2)", vnl_rank(m32), 1);
 
   // 3x2 int
@@ -183,33 +190,33 @@ test_rank()
 
   // 3x3 double
   vnl_matrix<double> m33(3, 3, 0.0); // all zero matrix
-  TEST("zero_3x3.vnl_svd().rank()", svd_rank(m33), 0);
+  TEST_SVD_RANK("zero_3x3.vnl_svd().rank()", m33, 0);
   TEST("vnl_rank(zero_3x3)", vnl_rank(m33), 0);
   TEST("vnl_rank(zero_3x3, vnl_rank_row)", vnl_rank(m33, vnl_rank_row), 0);
   TEST("vnl_rank(zero_3x3, vnl_rank_column)", vnl_rank(m33, vnl_rank_column), 0);
   m33[0][1] = 6.0;
   m33[0][2] = -2.0;
-  TEST("3x3.vnl_svd().rank()", svd_rank(m33), 1);
+  TEST_SVD_RANK("3x3.vnl_svd().rank()", m33, 1);
   TEST("vnl_rank(3x3)", vnl_rank(m33), 1);
   TEST("vnl_rank(3x3, vnl_rank_row)", vnl_rank(m33, vnl_rank_row), 1);
   TEST("vnl_rank(3x3, vnl_rank_column)", vnl_rank(m33, vnl_rank_column), 1);
   m33[1][2] = -1.0;
   m33[1][0] = 7.0;
-  TEST("3x3.vnl_svd().rank()", svd_rank(m33), 2);
+  TEST_SVD_RANK("3x3.vnl_svd().rank()", m33, 2);
   TEST("vnl_rank(3x3)", vnl_rank(m33), 2);
   TEST("vnl_rank(3x3, vnl_rank_row)", vnl_rank(m33, vnl_rank_row), 2);
   TEST("vnl_rank(3x3, vnl_rank_column)", vnl_rank(m33, vnl_rank_column), 2);
   m33[2][0] = 7.0;
-  TEST("3x3.vnl_svd().rank()", svd_rank(m33), 3);
+  TEST_SVD_RANK("3x3.vnl_svd().rank()", m33, 3);
   TEST("vnl_rank(3x3)", vnl_rank(m33), 3);
   TEST("vnl_rank(3x3, vnl_rank_row)", vnl_rank(m33, vnl_rank_row), 3);
   TEST("vnl_rank(3x3, vnl_rank_column)", vnl_rank(m33, vnl_rank_column), 3);
   m33[2][1] = 6.0;
   m33[2][2] = -3.0;
-  TEST("3x3.vnl_svd().rank()", svd_rank(m33), 2);
+  TEST_SVD_RANK("3x3.vnl_svd().rank()", m33, 2);
   TEST("vnl_rank(3x3)", vnl_rank(m33), 2);
   m33 *= 2.0;
-  TEST("3x3.vnl_svd().rank()", svd_rank(m33), 2);
+  TEST_SVD_RANK("3x3.vnl_svd().rank()", m33, 2);
   TEST("vnl_rank(3x3)", vnl_rank(m33), 2);
 
   // 3x3 int


### PR DESCRIPTION
`vnl_algo_test_all` fails to link under `ITK_FUTURE_LEGACY_REMOVE` because commit 232a2ad2d44 excluded the LINPACK-svdc-backed `vnl_svd` family and `vnl_solve_qp` from the library but left their tests. This gates those tests, which is the only build failure in that configuration.

This is the same defect 434a4202d22 fixed for the eispack `vnl_*_eigensystem` solvers, and it is what breaks all five RogueResearch Mac Debug nightlies.

<details>
<summary>Root cause — two mechanisms, not one</summary>

**1. Tests left behind for removed APIs.** `Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt` drops `vnl_svd{,_economy,_fixed}`, `vnl_solve_qp` and their `Templates/vnl_svd*+*` instantiations under `ITK_FUTURE_LEGACY_REMOVE`, but `tests/CMakeLists.txt` gated only the eigensystem tests. Six test objects still referenced the removed symbols:

| Object | Undefined symbols |
|---|---|
| `test_svd_fixed.cxx.o` | 31 |
| `test_svd.cxx.o` | 30 |
| `test_solve_qp.cxx.o` | 4 |
| `test_complex_algo.cxx.o` | 4 |
| `test_algo.cxx.o` | 4 |
| `test_rank.cxx.o` | 1 |

**2. Guards that never fired.** `test_algo.cxx` and `test_complex_algo.cxx` already guarded their removed-API use with `#ifndef ITK_FUTURE_LEGACY_REMOVE`. That macro is never defined in those translation units: `itkConfigure.h` is generated at `<build>/Modules/Core/Common/itkConfigure.h`, but it is not on the include path of the vendored VXL subtree. Verified from `compile_commands.json`:

| Translation unit | include dir containing `itkConfigure.h` |
|---|---|
| VXL library (`Templates/vnl_svd+double-.cxx`) | none |
| VXL test (`test_algo.cxx`) | none |
| ITK module (`ITKCommonHeaderTest1.cxx`) | `<build>/Modules/Core/Common` |

That asymmetry is correct for the headers — the `__has_include(<itkConfigure.h>)` guard is meant to stay inert for VXL's own compiles and for standalone VXL builds, while firing for ITK modules and downstream consumers. But it means any `#ifndef ITK_FUTURE_LEGACY_REMOVE` written *inside a VXL test source* is dead code. The removed-API state is therefore conveyed as `VNL_SVD_REMOVED` / `VNL_MATRIX_INVERSE_REMOVED` compile definitions, mirroring the existing `VNL_EISPACK_REMOVED`.

</details>

<details>
<summary>Verification</summary>

Debug, AppleClang, arm64, macOS 26.5 SDK.

| Configuration | Result |
|---|---|
| `ITK_LEGACY_REMOVE=ON` + `ITK_FUTURE_LEGACY_REMOVE=ON` | links; **17/17 vnl_algo tests pass**; 0 svd/solve_qp tests registered |
| default | builds; **23/23 vnl_algo tests pass**; 3 svd/solve_qp tests still registered — no coverage lost |

Full-tree build under `ITK_FUTURE_LEGACY_REMOVE`: **exactly one** of 5550 targets failed before this change (`vnl_algo_test_all`); **0 failures** after. No other failure class exists in that configuration.

Coverage is not silently dropped — `itkMathSVD.h` and `itkMathSVDGTest.cxx` already exercise the Eigen-backed replacement, so the deprecation policy's scavenge step was already complete; only the test gating was missing.

`test_rank.cxx` routes its SVD checks through a `TEST_SVD_RANK` macro that compiles away when removed; its `vnl_rank()` checks are untouched.

</details>

<details>
<summary>VXL fork carry-through</summary>

The identical change is already on the extraction branch so the next `UpdateFromUpstream.sh` does not revert it:

- `InsightSoftwareConsortium/vxl` `for/itk-vxl-master`: `c8c2e0555c..8d91974ab0` (fast-forward)
- tag `for/itk-vxl-master-8d91974`

All five files were byte-identical between ITK `main` and the fork before the change, and are byte-identical after it, so the two trees cannot drift. Standalone VXL is unaffected: with no `ITK_FUTURE_LEGACY_REMOVE` CMake variable, every test is built and the new macros are never defined, leaving all source guards inert.

`Modules/ThirdParty/VNL/UpdateFromUpstream.sh` still pins `for/itk-vxl-master-ae2f579` (2026-07-06), which predates both `c8c2e05` and this commit; bumping that pin is left to a separate change.

</details>

<!--
provenance: found 2026-07-18 while auditing RogueResearch nightly failures (builds 11425044, 11424695, 11424672, 11424494, 11424557)
root_cause_commit: 232a2ad2d44 (library-side svd exclusion), precedent fix 434a4202d22 (eigensystem)
repro: cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DITK_LEGACY_REMOVE=ON -DITK_FUTURE_LEGACY_REMOVE=ON
       (ITK_FUTURE_LEGACY_REMOVE is a cmake_dependent_option — forced OFF unless ITK_LEGACY_REMOVE=ON; setting it alone silently does nothing)
files: Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/tests/{CMakeLists.txt,test_driver.cxx,test_algo.cxx,test_complex_algo.cxx,test_rank.cxx}
vxl_fork: 8d91974ab0 on for/itk-vxl-master, tag for/itk-vxl-master-8d91974 (pushed 2026-07-18)
post_merge_action: consider bumping UpdateFromUpstream.sh tag pin from for/itk-vxl-master-ae2f579 to for/itk-vxl-master-8d91974
related_prs: #6659 (unrelated, Python 3.11 configure gate)
-->
