### PR TITLE
COMP: Update LesionSizingToolkit remote module pin

### DIFF
--- a/Modules/Remote/LesionSizingToolkit.remote.cmake
+++ b/Modules/Remote/LesionSizingToolkit.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Framework for determining the sizes of lesions in medical images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/LesionSizingToolkit.git
-  GIT_TAG affbf7b0958205e2aab388bf0c3b7b1d5b0089de
+  GIT_TAG 29ae0f95a2ffd3cc65d50305a141b5c5f9bebb3e
   )


### PR DESCRIPTION
Update the pinned LesionSizingToolkit commit to pick up two fixes: the test-name renames that clear the duplicate-test-name `AUTHOR_WARNING`s on the nightly dashboards, and a missing `#include` without which the module does not compile against current ITK.

**Note for dashboard maintainers:** `Module_LesionSizingToolkit_GIT_TAG` is cached per build tree and shadows this file's default, so a persistent build tree will keep fetching the old commit after this merges until that cache entry is cleared (`cmake -UModule_LesionSizingToolkit_GIT_TAG <build>`) or the tree is wiped.

<details>
<summary>What the bump picks up</summary>

`affbf7b095…` → `29ae0f95a2ffd3cc65d50305a141b5c5f9bebb3e` (5 commits):

```
29ae0f9 COMP: Include itkImageRegionIteratorWithIndex.h where the type is used
8a02cdb COMP: Rename test names that collide with ITK core tests
97f8358 ENH: Use modern ITK interface libraries for executables
8d5cba9 BUG: Fix IsotropicResamplerImageFilter wrapping template arguments
28d74fd COMP: Update CI to ITKRemoteModuleBuildTestPackageAction v5.4.6 and Python 3.10+
```

The first two are the reason for this bump:

- **`8a02cdb`** renames `itkGradientMagnitudeImageFilterTest1` and `itkCannyEdgeDetectionImageFilterTest2`, which ITK core already registers in `Filtering/ImageGradient` and `Filtering/ImageFeature`. Beyond the warning, duplicate names share ITK's `Cleanup_<name>` fixture and race under `ctest -j`.
- **`29ae0f9`** adds `#include "itkImageRegionIteratorWithIndex.h"` to two files that used the type but relied on transitive inclusion current ITK no longer provides. Without it, 8 translation units fail to compile.

</details>

<details>
<summary>Verification</summary>

Release, AppleClang, arm64, macOS 26.5 SDK, `-DModule_LesionSizingToolkit=ON`, against this branch.

| Stage | Before (old pin) | After (new pin) |
|---|---|---|
| `Duplicate test name` warnings at configure | 2 | **0** |
| `LesionSizingToolkit-all` (library + test driver) | 10 failing targets | **0** |
| 10 `src/` executables | — | **0 failures** |
| `ctest` over the module's test directory | not reachable (module did not build) | **41/41 passed**, exit 0 |

Resulting test registrations — four distinct names where two collided:

```
#1792 itkCannyEdgeDetectionImageFilterTest2                   (ITK core)
#1933 itkGradientMagnitudeImageFilterTest1                    (ITK core)
#3722 LesionSizingToolkitGradientMagnitudeImageFilterTest1    (remote module)
#3729 LesionSizingToolkitCannyEdgeDetectionImageFilterTest2   (remote module)
```

The module's `src/` executables are not part of the `LesionSizingToolkit-all` target group and were built explicitly, since `97f8358` changes exactly their link libraries.

</details>

<!--
provenance: 2026-07-18; found via ITK nightly CDash configure output, build 11424939 (Linux-Ubuntu-GCC-Doxygen, blaster.kitware)
upstream_prs: InsightSoftwareConsortium/LesionSizingToolkit#56 (test renames), #57 (missing include)
old_pin: affbf7b0958205e2aab388bf0c3b7b1d5b0089de
new_pin: 29ae0f95a2ffd3cc65d50305a141b5c5f9bebb3e
verified: configure 2->0 duplicate warnings; LesionSizingToolkit-all 10->0 failures; 10 src executables clean; ctest 41/41
gotcha: Module_LesionSizingToolkit_GIT_TAG cached per build tree shadows the .remote.cmake default; produced a false pass during this work until cleared with -U
masked_on_cdash: the compile breakage was invisible — Doxygen nightly never compiles the test driver, Favorite-Remotes nightly dies at configure first
-->
