### PR TITLE
COMP: Apply rule of zero to LogicOpBase

### DIFF
--- a/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
+++ b/Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h
@@ -63,8 +63,6 @@ public:
     , m_BackgroundValue(TOutput{})
   {}
 
-  ~LogicOpBase() = default;
-
   bool
   operator==(const Self &) const
   {


### PR DESCRIPTION
Remove the defaulted destructor from `LogicOpBase` so the implicit copy and move members come back, silencing the last `-Wdeprecated-copy-with-dtor` warning on the nightly dashboards.

Follows #6592, which applied the same rule-of-zero treatment to `MaskInput`, `SimilarPixelsFunctor`, and `SimilarVectorsFunctor`. #6538 covers the two remaining files, where the classes have `virtual` destructors and `ITK_DEFAULT_COPY_AND_MOVE` remains the right fix.

<details>
<summary>The warning</summary>

`LogicOpBase` declared `~LogicOpBase() = default;` and nothing else, so the implicit copy members were deprecated:

```
Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h:66:3: warning:
  definition of implicit copy constructor for 'LogicOpBase<float, float, unsigned char>'
  is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]

Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h:66:3: warning:
  definition of implicit copy assignment operator for ... [-Wdeprecated-copy-with-dtor]
```

One declaration accounted for the whole functor family — `Equal`, `NotEqual`, `Greater`, `GreaterEqual`, `Less`, `LessEqual`, and `NOT` all derive from `LogicOpBase`.

The destructor was non-virtual, nothing deletes through a `LogicOpBase*`, and both members are trivially copyable, so removing it is behavior-preserving. It had also been suppressing move construction and assignment outright, so removing it restores all four special members rather than the two that warned.

Distribution of the flag across the nightly builds, for reference:

| File | Warnings | Covered by |
|---|---|---|
| `itkDefaultVectorPixelAccessor.h` | 81 | #6538 |
| `itkPriorityQueueContainer.h` | 30 | #6538 |
| `itkLogicOpsFunctors.h` | 1 | this PR |

</details>

<details>
<summary>Verification</summary>

Compiled a probe exercising copy-construct, copy-assign, move-construct, and move-assign on `Equal<float, float, unsigned char>` and `NOT`, against the real include set of a configured build tree:

| Compiler / flag | Before | After |
|---|---|---|
| clang++ 18.1.3, `-Wdeprecated-copy-with-dtor` | 2 | **0** |
| g++ 13.3.0, `-Wdeprecated-copy-dtor` | 0 | 0 |

The two "before" diagnostics are exactly the copy-constructor and copy-assignment warnings quoted above. g++ reports nothing either way — this is a clang-only diagnostic, consistent with it surfacing on the AppleClang nightlies. The move lines in the probe compile after the change, confirming the moves the destructor had suppressed are back.

Full rebuild (Linux x86_64, GCC 13.3.0, Release): 4148 of 4148 edges built, no errors, and `itkLogicOpsFunctors.h` appears zero times in the build log, so nothing downstream is disturbed. `pre-commit run --all-files` passes.

</details>

<!--
provenance: claude-code session 2026-07-19; revised from the earlier ITK_DEFAULT_COPY_AND_MOVE approach after review precedent
superseded_approach: ITK_DEFAULT_COPY_AND_MOVE(LogicOpBase) with the defaulted dtor retained (+1 line); replaced by dtor removal (-2 lines)
precedent: #6592 merged 2026-07-14 (rule of zero on three functors); #6538 inline review comments recommend the same on itkDefaultVectorPixelAccessor.h
file: Modules/Filtering/ImageIntensity/include/itkLogicOpsFunctors.h, LogicOpBase at L57
blocker_note: LogicOpBase() cannot be constexpr because NumericTraits<T>::OneValue() (itkNumericTraits.h:158) is not constexpr, though the underlying One is; Math::ExactlyEquals/NotExactlyEquals already are. TernaryOperator (no base, no members) could take constexpr operator() standalone.
-->
