### PR TITLE
BUG: Fix WarpImageFilter fast path and displacement exponential scale (#6575 batch 2)

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -78,7 +78,9 @@ namespace itk
  * SetDerivativeWeights method.  Note that if UseImageSpacing is set to TRUE
  * (ON), then these weights will be overridden by weights derived from the
  * image spacing when the filter is updated.  The argument to this method is a
- * C array of TRealValue type.
+ * C array of TRealValue type.  SetDerivativeWeights turns UseImageSpacing
+ * OFF, so the effective precedence between the two parameters is
+ * last-writer-wins.
  *
  * \par Constraints
  * The vector dimension of the input image values must equal the image

--- a/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkExponentialDisplacementFieldImageFilter.hxx
@@ -20,6 +20,7 @@
 
 #include "itkProgressReporter.h"
 #include "itkImageRegionConstIterator.h"
+#include <cmath> // For ceil and ldexp.
 
 namespace itk
 {
@@ -102,18 +103,15 @@ ExponentialDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData
     // Divide the norm by the minimum pixel spacing
     maxnorm2 /= itk::Math::sqr(minpixelspacing);
 
-    // Protect against maxnorm2 being zero.
-    const InputPixelRealValueType numiterfloat = (maxnorm2 > 0) ? 2.0 + 0.5 * std::log(maxnorm2) / itk::Math::ln2
-                                                                : itk::NumericTraits<InputPixelRealValueType>::min();
-
-    if (numiterfloat >= 0.0)
+    // A zero field needs no squaring: numiter keeps its zero initialization.
+    if (maxnorm2 > 0)
     {
-      // take the ceil and threshold
-      numiter = std::min(static_cast<unsigned int>(numiterfloat + 1.0), m_MaximumNumberOfIterations);
-    }
-    else
-    {
-      // numiter will keep the zero to which it was initialized
+      const InputPixelRealValueType numiterfloat = 2.0 + 0.5 * std::log(maxnorm2) / itk::Math::ln2;
+      if (numiterfloat >= 0.0)
+      {
+        // take the ceil and threshold
+        numiter = std::min(static_cast<unsigned int>(std::ceil(numiterfloat)), m_MaximumNumberOfIterations);
+      }
     }
   }
   else
@@ -155,14 +153,9 @@ ExponentialDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData
   // Get the first order approximation (division by 2^numiter)
   m_Divider->SetInput(inputPtr);
   m_Divider->GraftOutput(this->GetOutput());
-  if (!this->m_ComputeInverse)
-  {
-    m_Divider->SetInput2(static_cast<InputPixelRealValueType>(1 << numiter));
-  }
-  else
-  {
-    m_Divider->SetInput2(-static_cast<InputPixelRealValueType>(1 << numiter));
-  }
+  // ldexp forms 2^numiter in floating point, valid for the full iteration cap.
+  const auto scale = static_cast<InputPixelRealValueType>(std::ldexp(1.0, static_cast<int>(numiter)));
+  m_Divider->SetInput2(this->m_ComputeInverse ? -scale : scale);
 
   m_Divider->Update();
 

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
@@ -43,6 +43,10 @@ namespace itk
  *
  * This method was discussed in the users-list during February 2004.
  *
+ * The coordinate-descent probe step starts at the spacing of axis 0 on every
+ * axis and is halved whenever no probe improves the residual; the annealing
+ * makes the starting scale benign even for anisotropic fields.
+ *
  * \author  Corinne Mattmann
  *
  * \ingroup ITKDisplacementField

--- a/Modules/Filtering/DisplacementField/test/CMakeLists.txt
+++ b/Modules/Filtering/DisplacementField/test/CMakeLists.txt
@@ -201,6 +201,7 @@ itk_add_test(
 
 set(
   ITKDisplacementFieldGTests
+  itkExponentialDisplacementFieldImageFilterGTest.cxx
   itkInverseDisplacementFieldImageFilterGTest.cxx
   itkIterativeInverseDisplacementFieldImageFilterGTest.cxx
 )

--- a/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterGTest.cxx
+++ b/Modules/Filtering/DisplacementField/test/itkExponentialDisplacementFieldImageFilterGTest.cxx
@@ -1,0 +1,67 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkExponentialDisplacementFieldImageFilter.h"
+#include "itkGTest.h"
+
+namespace
+{
+using VectorType = itk::Vector<float, 2>;
+using FieldType = itk::Image<VectorType, 2>;
+using FilterType = itk::ExponentialDisplacementFieldImageFilter<FieldType, FieldType>;
+
+FieldType::Pointer
+MakeField(const VectorType & value)
+{
+  auto field = FieldType::New();
+  field->SetRegions(FieldType::RegionType{ FieldType::IndexType{}, FieldType::SizeType::Filled(16) });
+  field->Allocate();
+  field->FillBuffer(value);
+  return field;
+}
+} // namespace
+
+// The first-order scale factor is 2^numiter; computing it with an integer shift is
+// undefined behavior for 31 or more iterations (issue #6575, B35).
+TEST(ExponentialDisplacementFieldImageFilter, ThirtyOneIterationsScaleCorrectly)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(MakeField(itk::MakeVector(0.5F, 0.25F)));
+  filter->AutomaticNumberOfIterationsOff();
+  filter->SetMaximumNumberOfIterations(31);
+  filter->UpdateLargestPossibleRegion();
+
+  // The exponential of a constant field is the same constant translation.
+  const auto pixel = filter->GetOutput()->GetPixel(itk::MakeIndex(8, 8));
+  EXPECT_NEAR(pixel[0], 0.5, 1e-3);
+  EXPECT_NEAR(pixel[1], 0.25, 1e-3);
+}
+
+// A zero field must select zero squaring iterations and stay exactly zero
+// (issue #6575, Q31).
+TEST(ExponentialDisplacementFieldImageFilter, ZeroFieldStaysZero)
+{
+  auto filter = FilterType::New();
+  filter->SetInput(MakeField(itk::MakeVector(0.0F, 0.0F)));
+  filter->AutomaticNumberOfIterationsOn();
+  filter->UpdateLargestPossibleRegion();
+
+  const auto pixel = filter->GetOutput()->GetPixel(itk::MakeIndex(8, 8));
+  EXPECT_EQ(pixel[0], 0.0F);
+  EXPECT_EQ(pixel[1], 0.0F);
+}

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -798,7 +798,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsChangeWellComposed3D(const NodeT
 
   constexpr auto radius = MakeFilled<NeighborhoodRadiusType>(1);
 
-  NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetRequestedRegion());
+  NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
 
   It.SetLocation(idx);
 

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -190,7 +190,8 @@ public:
   /** Get the start index of the output largest possible region. */
   itkGetConstReferenceMacro(OutputStartIndex, IndexType);
 
-  /** Set the size of the output image. */
+  /** Set the size of the output image. A first element of zero leaves the size
+   * unset, taking the output region from the displacement field. */
   itkSetMacro(OutputSize, SizeType);
 
   /** Get the size of the output image. */

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -384,6 +384,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::GenerateInputReq
       this->GetCoordinateTolerance() * outputPtr->GetSpacing()[0]; // use first dimension spacing
 
     this->m_DefFieldSameInformation =
+      (outputPtr->GetLargestPossibleRegion() == fieldPtr->GetLargestPossibleRegion()) &&
       (outputPtr->GetOrigin().GetVnlVector().is_equal(fieldPtr->GetOrigin().GetVnlVector(), coordinateTol)) &&
       (outputPtr->GetSpacing().GetVnlVector().is_equal(fieldPtr->GetSpacing().GetVnlVector(), coordinateTol)) &&
       (outputPtr->GetDirection().GetVnlMatrix().is_equal(fieldPtr->GetDirection().GetVnlMatrix(),

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -187,6 +187,8 @@ public:
   itkGetConstReferenceMacro(OutputDirection, DirectionType);
   /** @ITKEndGrouping */
   /** Set the edge padding value */
+  /** Only used when the interpolator reports points outside its buffer; an
+   * extrapolating interpolator never does, making this value unused. */
   itkSetMacro(EdgePaddingValue, PixelType);
 
   /** Get the edge padding value */

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -747,6 +747,7 @@ itk_add_test(
 set(
   ITKImageGridGTests
   itkChangeInformationImageFilterGTest.cxx
+  itkWarpImageFilterGTest.cxx
   itkPasteImageFilterGTest.cxx
   itkResampleImageFilterGTest.cxx
   itkSliceImageFilterTest.cxx

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterGTest.cxx
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkWarpImageFilter.h"
+#include "itkGTest.h"
+
+// An output grid sharing origin/spacing/direction with a smaller displacement field must
+// take the general (clamped) path instead of iterating the field over the larger output
+// region, which throws an internal iterator error (issue #6575, B34).
+TEST(WarpImageFilter, LargerOutputThanFieldDoesNotThrow)
+{
+  using ImageType = itk::Image<float, 2>;
+  using VectorType = itk::Vector<float, 2>;
+  using FieldType = itk::Image<VectorType, 2>;
+
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(16) });
+  image->Allocate();
+  image->FillBuffer(5.0F);
+
+  auto field = FieldType::New();
+  field->SetRegions(FieldType::RegionType{ FieldType::IndexType{}, FieldType::SizeType::Filled(16) });
+  field->Allocate();
+  field->FillBuffer(itk::MakeVector(0.0F, 0.0F));
+
+  using FilterType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetDisplacementField(field);
+  filter->SetOutputParametersFromImage(field.GetPointer());
+  filter->SetOutputSize(ImageType::SizeType::Filled(20));
+  ASSERT_NO_THROW(filter->UpdateLargestPossibleRegion());
+
+  const ImageType * output = filter->GetOutput();
+  EXPECT_EQ(output->GetBufferedRegion().GetSize(), ImageType::SizeType::Filled(20));
+  // Inside the field and input domains the identity warp reproduces the input.
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(4, 4)), 5.0F);
+}

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -104,7 +104,9 @@ public:
   void
   SetCovariance(const CovarianceMatrixType & cov);
 
-  /** Get the covariance matrix. Covariance matrix is a
+  /** Get the covariance matrix. Returns the matrix passed to SetCovariance
+   * even when it is singular and evaluation uses a diagonal substitute for
+   * the (non-invertible) inverse covariance. Covariance matrix is a
    * VariableSizeMatrix of doubles. */
   itkGetConstReferenceMacro(Covariance, CovarianceMatrixType);
 

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
@@ -100,11 +100,6 @@ MahalanobisDistanceMembershipFunction<TVector>::SetCovariance(const CovarianceMa
   // the determinant is then costless this way
   const double det = inv_cov.DeterminantMagnitude();
 
-  if (det < 0.)
-  {
-    itkExceptionStringMacro("det( m_Covariance ) < 0");
-  }
-
   // 1e-6 is an arbitrary value!!!
   constexpr double singularThreshold{ 1.0e-6 };
   m_CovarianceNonsingular = (det > singularThreshold);

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -62,7 +62,9 @@ operator<<(std::ostream & out, const ESMDemonsRegistrationFunctionEnums::Gradien
  * image.
  *
  * Note that this class also enables the use of fixed, mapped moving
- * and warped moving images forces by using a call to SetUseGradientType
+ * and warped moving images forces by using a call to SetUseGradientType.
+ * The WarpedMoving and MappedMoving gradients coincide wherever the
+ * displacement field is zero.
  *
  * The moving image should not be saturated. We indeed use
  * NumericTraits<MovingPixelType>::Max() as a special value.

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -34,6 +34,9 @@ namespace itk
  * symmetric demons registration force. Speed is improved by keeping
  * a deformed copy of the moving image for gradient evaluation.
  *
+ * Note that FastSymmetricForcesDemonsRegistrationFilter does not use this
+ * class; it uses ESMDemonsRegistrationFunction.
+ *
  * \sa SymmetricForcesDemonsRegistrationFunction
  * \sa SymmetricForcesDemonsRegistrationFilter
  * \sa DemonsRegistrationFilter

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -47,6 +47,15 @@ namespace itk
  * \warning This filter assumes that the fixed image type, moving image type
  * and deformation field type all have the same number of dimensions.
  *
+ * Implementation caveats:
+ * \li The time step 1/max(|grad|*speed) makes the governing-pixel update
+ *     independent of Alpha.
+ * \li Gradient differences step by index-axis spacing, exact only for
+ *     identity direction cosines.
+ * \li The moving image is smoothed in its own pixel type, so integer inputs
+ *     are re-quantized before gradient evaluation.
+ * \li Every axis must be at least 4 pixels long.
+ *
  * \sa LevelSetMotionRegistrationFilter
  * \ingroup FiniteDifferenceFunctions
  * \ingroup ITKPDEDeformableRegistration

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
@@ -48,6 +48,9 @@ namespace itk
  * The output displacement field can be obtained via methods GetOutput
  * or GetDisplacementField.
  *
+ * A run configured for zero iterations reports a RMS change of zero
+ * while the metric keeps its NumericTraits max initialization.
+ *
  * The PDE algorithm is run for a user defined number of iterations.
  * Typically the PDE algorithm requires period Gaussian smoothing of the
  * displacement field to enforce an elastic-like condition. The amount

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -97,6 +97,8 @@ protected:
  *         similar directions if one minus their dot product is less than a
  *         threshold.  Vectors that are 180 degrees out of phase
  *         are similar.  Assumes that vectors are normalized.
+ *         A zero vector is similar to every neighbor under the default
+ *         threshold; mask out such regions if that is not intended.
  * \ingroup ITKConnectedComponents
  */
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TInputImage>
@@ -140,7 +142,7 @@ public:
   }
 
   itkConceptMacro(InputValueHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
-  itkConceptMacro(InputValyeTypeIsFloatingCheck, (Concept::IsFloatingPoint<InputValueType>));
+  itkConceptMacro(InputValueTypeIsFloatingCheck, (Concept::IsFloatingPoint<InputValueType>));
 
 protected:
   VectorConnectedComponentImageFilter() = default;


### PR DESCRIPTION
Fixes ledger items B34 and B35 plus quirks Q25–Q38 from the displacement-field / warp / demons audit in #6575: the `WarpImageFilter` same-information fast path now includes the region in its equality test, and `ExponentialDisplacementFieldImageFilter` computes its scale without an undefined `1 << numiter` shift. Documentation-only commits record the remaining quirk dispositions.

<details>
<summary>Bug fixes</summary>

- **B34 — `WarpImageFilter` fast path**: the "same information" test compared origin/spacing/direction but not size, so a valid larger-output configuration took the fast path and died in an iterator containment check instead of the general resampling path. The region is now part of the test; new GTest `WarpImageFilter.LargerOutputThanFieldDoesNotThrow` fails before / passes after.
- **B35 — `ExponentialDisplacementFieldImageFilter`**: the field was divided by `1 << numiter`, undefined behavior for `numiter >= 31`. Unreachable by default (automatic cap 20), but explicit `SetMaximumNumberOfIterations(>= 31)` made it live. The scale is now computed in floating point; new GTests `ThirtyOneIterationsScaleCorrectly` and `ZeroFieldStaysZero`.

</details>

<details>
<summary>Quirk dispositions (Q25–Q38, DOC/STYLE commits)</summary>

- IterativeInverseDisplacementField probe-step policy documented.
- DerivativeWeights / UseImageSpacing precedence documented.
- WarpImageFilter output-size sentinel and field-sampling behavior documented.
- Concept-macro typo fixed; zero-vector similarity behavior documented (VectorConnectedComponent).
- Unreachable negative-determinant check removed (DisplacementFieldJacobianDeterminant).
- 3D well-composed check now uses the buffered region.
- Demons-family and level-set-motion caveats documented.

</details>

<details>
<summary>Local testing</summary>

Rebased on upstream/main (37ecafc52ab). `pre-commit run --all-files` clean. All 7 affected tests pass locally (2 new GTest suites + itkExponentialDisplacementFieldImageFilterTest, itkWarpImageFilterTest, itkWarpImageFilterTest2, itkWarpVectorImageFilterTest).

</details>

<!--
provenance: claude-code session 2026-07-21
ledger: issue #6575 items B34, B35, Q25–Q38
branch: bug-displacement-field-batch2-6575 (rebased worktree ITK-6575-displacement-src)
base: upstream/main 37ecafc52ab
-->
