### PR TITLE
COMP: Fix deprecated-copy-with-dtor via rule of zero + rule of five (cf. #6538)

### DIFF
--- a/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
+++ b/Modules/Core/Common/include/itkDefaultVectorPixelAccessor.h
@@ -123,8 +123,6 @@ public:
     , m_OffsetMultiplier(l - 1)
   {}
 
-  ~DefaultVectorPixelAccessor() = default;
-
 private:
   VectorLengthType m_VectorLength{ 0 };
   VectorLengthType m_OffsetMultiplier{ 0 };

--- a/Modules/Core/Common/include/itkPriorityQueueContainer.h
+++ b/Modules/Core/Common/include/itkPriorityQueueContainer.h
@@ -43,6 +43,7 @@ public:
 
   ElementWrapperInterface() = default;
   virtual ~ElementWrapperInterface() = default;
+  ITK_DEFAULT_COPY_AND_MOVE(ElementWrapperInterface);
 
   [[nodiscard]] virtual ElementIdentifierType
   GetLocation(const ElementType & element) const = 0;
@@ -76,6 +77,7 @@ public:
 
   ElementWrapperPointerInterface() = default;
   virtual ~ElementWrapperPointerInterface() = default;
+  ITK_DEFAULT_COPY_AND_MOVE(ElementWrapperPointerInterface);
 
   TElementIdentifier
   GetLocation(const ElementWrapperPointerType & element) const;
@@ -118,8 +120,6 @@ public:
   MinPriorityQueueElementWrapper() = default;
 
   MinPriorityQueueElementWrapper(ElementType element, ElementPriorityType priority);
-
-  ~MinPriorityQueueElementWrapper() override = default;
 
   bool
   operator>(const MinPriorityQueueElementWrapper & other) const;
@@ -165,8 +165,6 @@ public:
   MaxPriorityQueueElementWrapper() = default;
 
   MaxPriorityQueueElementWrapper(ElementType element, ElementPriorityType priority);
-
-  ~MaxPriorityQueueElementWrapper() override = default;
 
   virtual bool
   is_less(const MaxPriorityQueueElementWrapper & element1, const MaxPriorityQueueElementWrapper & element2) const;


### PR DESCRIPTION
Silences all `-Wdeprecated-copy-with-dtor` warnings on five `Core/Common` classes, choosing the fix per class kind: **rule of zero** for the value/leaf types, **rule of five** for the polymorphic bases. Compare with #6538 (rule of five for all five).

| Class | Kind | Fix here |
|---|---|---|
| `DefaultVectorPixelAccessor` | value | remove `~=default` (rule of zero) |
| `MinPriorityQueueElementWrapper` | leaf (inherits virtual dtor) | remove `~=default` (rule of zero) |
| `MaxPriorityQueueElementWrapper` | leaf | remove `~=default` (rule of zero) |
| `ElementWrapperInterface` | polymorphic base | keep `virtual ~=default` + `ITK_DEFAULT_COPY_AND_MOVE` |
| `ElementWrapperPointerInterface` | polymorphic base | keep `virtual ~=default` + `ITK_DEFAULT_COPY_AND_MOVE` |

<details>
<summary>Why the two treatments</summary>

`ElementWrapperInterface`/`ElementWrapperPointerInterface` are documented public extension points ("you can use this wrapper … it follows the ElementWrapperInterface and thus can be used in the queue") with virtual members. Removing their virtual destructor would break `delete` through `ElementWrapperInterface*` for downstream custom wrappers (C++ Core Guideline C.35) — so those keep the virtual destructor and get `ITK_DEFAULT_COPY_AND_MOVE` (same as #6538). The three value/leaf classes are never a polymorphic-delete base, so rule of zero is safe and lighter.

This split was prompted by a Greptile P1 on an earlier revision that removed the interface virtual destructors; see the resolved thread.

</details>

<details>
<summary>Warnings fixed (CDash build 11383687, Mac14.x-AppleClang-dbg)</summary>

Fixes all **33** ITK-proper `-Wdeprecated-copy-with-dtor` warnings (28 `DefaultVectorPixelAccessor`, 4 `Min`, 2 `ElementWrapperInterface`, 1 `Max`). The only 2 remaining of this type are `ThirdParty/GDCM/gdcmFile.h` (vendored upstream), which #6538 also excludes.

</details>

<details>
<summary>Local validation</summary>

- Instantiation harness over all five templates (forced full instantiation) + queue push/pop + copy/move → compiles and runs clean.
- Polymorphic-destruction check: `delete` of a custom wrapper through `ElementWrapperInterface*` runs the derived destructor (count = 1).
- `pre-commit run --all-files` clean.

</details>

Relative to #6538: identical on the two interfaces (virtual dtor + `ITK_DEFAULT_COPY_AND_MOVE`), differs only on the three value/leaf classes (rule of zero vs the macro). The two PRs touch the same lines, so only one should merge. Follows #6664 (rule of zero for `LogicOpBase`) and #5849 (rule of zero for `NthElementPixelAccessor`).

<!--
provenance: claude-code session 2026-07-21; hybrid after Greptile P1 r3623228906
approach: rule-of-zero on DefaultVectorPixelAccessor/Min/Max; rule-of-five (virtual dtor + ITK_DEFAULT_COPY_AND_MOVE) on ElementWrapperInterface/ElementWrapperPointerInterface
head: c24ab3c7195
related: #6538 (rule-of-five-all), #6664, #5849, #6592, #6430 (root cause)
-->
