### PR TITLE
DOC: Displacement-field/warp/demons quirk dispositions Q25-Q38 (split of #6669)

### DIFF
--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.h
@@ -78,7 +78,9 @@ namespace itk
  * SetDerivativeWeights method.  Note that if UseImageSpacing is set to TRUE
  * (ON), then these weights will be overridden by weights derived from the
  * image spacing when the filter is updated.  The argument to this method is a
- * C array of TRealValue type.
+ * C array of TRealValue type.  SetDerivativeWeights turns UseImageSpacing
+ * OFF, so the effective precedence between the two parameters is
+ * last-writer-wins.
  *
  * \par Constraints
  * The vector dimension of the input image values must equal the image

--- a/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
+++ b/Modules/Filtering/DisplacementField/include/itkIterativeInverseDisplacementFieldImageFilter.h
@@ -43,6 +43,10 @@ namespace itk
  *
  * This method was discussed in the users-list during February 2004.
  *
+ * The coordinate-descent probe step starts at the spacing of axis 0 on every
+ * axis and is halved whenever no probe improves the residual; the annealing
+ * makes the starting scale benign even for anisotropic fields.
+ *
  * \author  Corinne Mattmann
  *
  * \ingroup ITKDisplacementField

--- a/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
+++ b/Modules/Filtering/FastMarching/include/itkFastMarchingImageFilterBase.hxx
@@ -798,7 +798,7 @@ FastMarchingImageFilterBase<TInput, TOutput>::IsChangeWellComposed3D(const NodeT
 
   constexpr auto radius = MakeFilled<NeighborhoodRadiusType>(1);
 
-  NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetRequestedRegion());
+  NeighborhoodIteratorType It(radius, this->m_LabelImage, this->m_LabelImage->GetBufferedRegion());
 
   It.SetLocation(idx);
 

--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.h
@@ -190,7 +190,8 @@ public:
   /** Get the start index of the output largest possible region. */
   itkGetConstReferenceMacro(OutputStartIndex, IndexType);
 
-  /** Set the size of the output image. */
+  /** Set the size of the output image. A first element of zero leaves the size
+   * unset, taking the output region from the displacement field. */
   itkSetMacro(OutputSize, SizeType);
 
   /** Get the size of the output image. */

--- a/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
+++ b/Modules/Filtering/ImageGrid/include/itkWarpVectorImageFilter.h
@@ -187,6 +187,8 @@ public:
   itkGetConstReferenceMacro(OutputDirection, DirectionType);
   /** @ITKEndGrouping */
   /** Set the edge padding value */
+  /** Only used when the interpolator reports points outside its buffer; an
+   * extrapolating interpolator never does, making this value unused. */
   itkSetMacro(EdgePaddingValue, PixelType);
 
   /** Get the edge padding value */

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.h
@@ -104,7 +104,9 @@ public:
   void
   SetCovariance(const CovarianceMatrixType & cov);
 
-  /** Get the covariance matrix. Covariance matrix is a
+  /** Get the covariance matrix. Returns the matrix passed to SetCovariance
+   * even when it is singular and evaluation uses a diagonal substitute for
+   * the (non-invertible) inverse covariance. Covariance matrix is a
    * VariableSizeMatrix of doubles. */
   itkGetConstReferenceMacro(Covariance, CovarianceMatrixType);
 

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
@@ -100,11 +100,6 @@ MahalanobisDistanceMembershipFunction<TVector>::SetCovariance(const CovarianceMa
   // the determinant is then costless this way
   const double det = inv_cov.DeterminantMagnitude();
 
-  if (det < 0.)
-  {
-    itkExceptionStringMacro("det( m_Covariance ) < 0");
-  }
-
   // 1e-6 is an arbitrary value!!!
   constexpr double singularThreshold{ 1.0e-6 };
   m_CovarianceNonsingular = (det > singularThreshold);

--- a/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkESMDemonsRegistrationFunction.h
@@ -62,7 +62,9 @@ operator<<(std::ostream & out, const ESMDemonsRegistrationFunctionEnums::Gradien
  * image.
  *
  * Note that this class also enables the use of fixed, mapped moving
- * and warped moving images forces by using a call to SetUseGradientType
+ * and warped moving images forces by using a call to SetUseGradientType.
+ * The WarpedMoving and MappedMoving gradients coincide wherever the
+ * displacement field is zero.
  *
  * The moving image should not be saturated. We indeed use
  * NumericTraits<MovingPixelType>::Max() as a special value.

--- a/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkFastSymmetricForcesDemonsRegistrationFunction.h
@@ -34,6 +34,9 @@ namespace itk
  * symmetric demons registration force. Speed is improved by keeping
  * a deformed copy of the moving image for gradient evaluation.
  *
+ * Note that FastSymmetricForcesDemonsRegistrationFilter does not use this
+ * class; it uses ESMDemonsRegistrationFunction.
+ *
  * \sa SymmetricForcesDemonsRegistrationFunction
  * \sa SymmetricForcesDemonsRegistrationFilter
  * \sa DemonsRegistrationFilter

--- a/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
+++ b/Modules/Registration/PDEDeformable/include/itkLevelSetMotionRegistrationFunction.h
@@ -47,6 +47,15 @@ namespace itk
  * \warning This filter assumes that the fixed image type, moving image type
  * and deformation field type all have the same number of dimensions.
  *
+ * Implementation caveats:
+ * \li The time step 1/max(|grad|*speed) makes the governing-pixel update
+ *     independent of Alpha.
+ * \li Gradient differences step by index-axis spacing, exact only for
+ *     identity direction cosines.
+ * \li The moving image is smoothed in its own pixel type, so integer inputs
+ *     are re-quantized before gradient evaluation.
+ * \li Every axis must be at least 4 pixels long.
+ *
  * \sa LevelSetMotionRegistrationFilter
  * \ingroup FiniteDifferenceFunctions
  * \ingroup ITKPDEDeformableRegistration

--- a/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
+++ b/Modules/Registration/PDEDeformable/include/itkPDEDeformableRegistrationFilter.h
@@ -48,6 +48,9 @@ namespace itk
  * The output displacement field can be obtained via methods GetOutput
  * or GetDisplacementField.
  *
+ * A run configured for zero iterations reports a RMS change of zero
+ * while the metric keeps its NumericTraits max initialization.
+ *
  * The PDE algorithm is run for a user defined number of iterations.
  * Typically the PDE algorithm requires period Gaussian smoothing of the
  * displacement field to enforce an elastic-like condition. The amount

--- a/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
+++ b/Modules/Segmentation/ConnectedComponents/include/itkVectorConnectedComponentImageFilter.h
@@ -97,6 +97,8 @@ protected:
  *         similar directions if one minus their dot product is less than a
  *         threshold.  Vectors that are 180 degrees out of phase
  *         are similar.  Assumes that vectors are normalized.
+ *         A zero vector is similar to every neighbor under the default
+ *         threshold; mask out such regions if that is not intended.
  * \ingroup ITKConnectedComponents
  */
 template <typename TInputImage, typename TOutputImage, typename TMaskImage = TInputImage>
@@ -140,7 +142,7 @@ public:
   }
 
   itkConceptMacro(InputValueHasNumericTraitsCheck, (Concept::HasNumericTraits<InputValueType>));
-  itkConceptMacro(InputValyeTypeIsFloatingCheck, (Concept::IsFloatingPoint<InputValueType>));
+  itkConceptMacro(InputValueTypeIsFloatingCheck, (Concept::IsFloatingPoint<InputValueType>));
 
 protected:
   VectorConnectedComponentImageFilter() = default;


### PR DESCRIPTION
Documentation/style-only dispositions of quirks Q25–Q38 from the displacement-field / warp / demons audit in #6575. Split out of #6669 so the DOC/STYLE changes land independently of the two bug fixes (#6669 is being closed in favor of three focused PRs).

<details>
<summary>Contents (7 commits, no behavior change)</summary>

- DOC: IterativeInverseDisplacementField probe-step policy.
- DOC: DerivativeWeights / UseImageSpacing precedence (DisplacementFieldJacobianDeterminant).
- DOC: WarpImageFilter output-size sentinel and field-sampling behavior.
- STYLE: concept-macro typo fix + zero-vector similarity note (VectorConnectedComponent).
- STYLE: remove an unreachable negative-determinant check (MahalanobisDistanceMembershipFunction).
- STYLE: use the buffered region in the 3D well-composed check (FastMarchingImageFilterBase).
- DOC: demons-family and level-set-motion caveats.

</details>

Companion bug PRs split from #6669: WarpImageFilter fast path (B34) and ExponentialDisplacementField scale (B35).

<!--
provenance: claude-code session 2026-07-21; split of #6669 (STYLE/DOC group)
ledger: issue #6575 quirks Q25–Q38
base: upstream/main 37ecafc52ab
-->
