### PR TITLE
BUG: Include region in WarpImageFilter same-information fast path (B34, split of #6669)

### DIFF
--- a/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkWarpImageFilter.hxx
@@ -384,6 +384,7 @@ WarpImageFilter<TInputImage, TOutputImage, TDisplacementField>::GenerateInputReq
       this->GetCoordinateTolerance() * outputPtr->GetSpacing()[0]; // use first dimension spacing
 
     this->m_DefFieldSameInformation =
+      (outputPtr->GetLargestPossibleRegion() == fieldPtr->GetLargestPossibleRegion()) &&
       (outputPtr->GetOrigin().GetVnlVector().is_equal(fieldPtr->GetOrigin().GetVnlVector(), coordinateTol)) &&
       (outputPtr->GetSpacing().GetVnlVector().is_equal(fieldPtr->GetSpacing().GetVnlVector(), coordinateTol)) &&
       (outputPtr->GetDirection().GetVnlMatrix().is_equal(fieldPtr->GetDirection().GetVnlMatrix(),

--- a/Modules/Filtering/ImageGrid/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGrid/test/CMakeLists.txt
@@ -747,6 +747,7 @@ itk_add_test(
 set(
   ITKImageGridGTests
   itkChangeInformationImageFilterGTest.cxx
+  itkWarpImageFilterGTest.cxx
   itkPasteImageFilterGTest.cxx
   itkResampleImageFilterGTest.cxx
   itkSliceImageFilterTest.cxx

--- a/Modules/Filtering/ImageGrid/test/itkWarpImageFilterGTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkWarpImageFilterGTest.cxx
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkWarpImageFilter.h"
+#include "itkGTest.h"
+
+// An output grid sharing origin/spacing/direction with a smaller displacement field must
+// take the general (clamped) path instead of iterating the field over the larger output
+// region, which throws an internal iterator error (issue #6575, B34).
+TEST(WarpImageFilter, LargerOutputThanFieldDoesNotThrow)
+{
+  using ImageType = itk::Image<float, 2>;
+  using VectorType = itk::Vector<float, 2>;
+  using FieldType = itk::Image<VectorType, 2>;
+
+  auto image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(16) });
+  image->Allocate();
+  image->FillBuffer(5.0F);
+
+  auto field = FieldType::New();
+  field->SetRegions(FieldType::RegionType{ FieldType::IndexType{}, FieldType::SizeType::Filled(16) });
+  field->Allocate();
+  field->FillBuffer(itk::MakeVector(0.0F, 0.0F));
+
+  using FilterType = itk::WarpImageFilter<ImageType, ImageType, FieldType>;
+  auto filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetDisplacementField(field);
+  filter->SetOutputParametersFromImage(field.GetPointer());
+  filter->SetOutputSize(ImageType::SizeType::Filled(20));
+  ASSERT_NO_THROW(filter->UpdateLargestPossibleRegion());
+
+  const ImageType * output = filter->GetOutput();
+  EXPECT_EQ(output->GetBufferedRegion().GetSize(), ImageType::SizeType::Filled(20));
+  // Inside the field and input domains the identity warp reproduces the input.
+  EXPECT_EQ(output->GetPixel(itk::MakeIndex(4, 4)), 5.0F);
+}


### PR DESCRIPTION
**B34** — `WarpImageFilter` same-information fast path ignored the region. Split out of #6669 as an independent bug fix (#6669 closed in favor of focused PRs).

The "same information" test compared origin/spacing/direction but not size, so a valid larger-output configuration took the fast path and died in an iterator-containment check instead of the general resampling path. The region is now part of the test.

New GTest `WarpImageFilter.LargerOutputThanFieldDoesNotThrow` fails before / passes after.

<details>
<summary>Local testing</summary>

Cherry-picked onto current `upstream/main` (37ecafc52ab); built `ITKImageGridGTestDriver` and ran the new test — **PASSED**. `pre-commit run --all-files` clean.

</details>

Fixes item B34 from the #6575 audit. Companion PRs (split from #6669): STYLE/DOC dispositions and the ExponentialDisplacementField B35 fix.

<!--
provenance: claude-code session 2026-07-21; split of #6669 (bug B34)
ledger: issue #6575 item B34
base: upstream/main 37ecafc52ab
-->
