### PR TITLE
DOC: Document ITK 6 minimum wrapped Python is 3.11

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -640,6 +640,14 @@ target_link_libraries(MyExample ITK::MyModuleModule)
 
 For backward compatibility, non-namespaced aliases are created with deprecation warnings. However, new code should use the namespaced `ITK::` targets exclusively.
 
+## Minimum wrapped Python raised to 3.11
+
+ITK 6 requires Python 3.11 or newer for Python wrapping; the previous floor was 3.10. Configuring the wrapping against an older interpreter now fails early.
+
+### What you need to do
+
+Use Python 3.11+ when building or installing the ITK Python wrapping. The prebuilt `itk` wheels already target 3.11 and newer.
+
 ## NumPy bridge: `image_from_array(arr.T)` is no longer transpose-equivalent to `image_from_array(arr)`
 
 ### Rationale


### PR DESCRIPTION
Adds a migration-guide entry noting ITK 6 raised the wrapped-Python floor from 3.10 to 3.11.

The floor is already enforced in code (`ITK_WRAP_PYTHON_MINIMUM_VERSION 3.11` in `CMake/ITKSetPython3Vars.cmake`, which fails configure early on an older interpreter); this just documents it for downstream users. Salvaged from the now-closed #6667, where it had accumulated unrelated to that PR's topic.

<!--
provenance: claude-code session 2026-07-21
origin: orphaned note from closed #6667; ITK_WRAP_PYTHON_MINIMUM_VERSION 3.11 + pyupgrade --py311-plus
head: 3c7145d69f
-->
