### PR TITLE
ENH: Add itk::Image::CreateInitialized(region), subclass-safe (completes #4599)

### DIFF
--- a/Modules/Core/Common/include/itkImage.h
+++ b/Modules/Core/Common/include/itkImage.h
@@ -189,6 +189,16 @@ public:
   void
   Allocate(bool initializePixels = false) override;
 
+  /** Creates an image with the specified region. Allocates its pixel buffer, zero-initializing its pixels. */
+  static Pointer
+  CreateInitialized(const RegionType & region)
+  {
+    const auto image = Image::New();
+    image->SetRegions(region);
+    image->AllocateInitialized();
+    return image;
+  }
+
   /** Restore the data object to its initial state. This means releasing
    * memory. */
   void

--- a/Modules/Core/Common/test/itkAdaptorComparisonGTest.cxx
+++ b/Modules/Core/Common/test/itkAdaptorComparisonGTest.cxx
@@ -164,11 +164,8 @@ TEST(AdaptorComparison, IteratorOperationsComplete)
   itk::ImageRegion<3>    region{ size };
 
   // Set up some images
-  auto scalar_image = ScalarImageType::New();
+  auto scalar_image = ScalarImageType::CreateInitialized(region);
   auto vector_image = VectorImageType::New();
-
-  scalar_image->SetRegions(region);
-  scalar_image->AllocateInitialized();
 
   vector_image->SetRegions(region);
   vector_image->Allocate();

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionGTest.cxx
@@ -275,11 +275,9 @@ DoBSplineInterpolationWeightFunctionTest(int, char *[])
     auto kernel = KernelType::New();
 
     using ImageType = itk::Image<signed char, SpaceDimension>;
-    auto                        image = ImageType::New();
     const ImageType::RegionType region{ startIndex, size };
 
-    image->SetRegions(region);
-    image->AllocateInitialized();
+    auto image = ImageType::CreateInitialized(region);
 
     using IteratorType = itk::ImageRegionConstIteratorWithIndex<ImageType>;
     IteratorType  iter(image, image->GetBufferedRegion());

--- a/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
+++ b/Modules/Core/Common/test/itkConnectedImageNeighborhoodShapeGTest.cxx
@@ -248,10 +248,8 @@ TEST(ConnectedImageNeighborhoodShape, SupportsConstShapedNeighborhoodIterator)
   using OffsetType = itk::Offset<ImageDimension>;
 
   // Create a "dummy" image.
-  const auto image = ImageType::New();
   auto       imageSize = SizeType::Filled(1);
-  image->SetRegions(imageSize);
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(imageSize);
 
   // Create a radius, (just) large enough for all offsets activated below here.
   auto radius = SizeType::Filled(1);

--- a/Modules/Core/Common/test/itkImageAlgorithmCopyGTest2.cxx
+++ b/Modules/Core/Common/test/itkImageAlgorithmCopyGTest2.cxx
@@ -66,14 +66,8 @@ TEST(ImageAlgorithmCopy, ConvertedLegacyTest2)
   image1->Allocate();
   image1->FillBuffer(13);
 
-  auto image2 = Short3DImageType::New();
-  image2->SetRegions(region);
-  image2->AllocateInitialized();
-
-
-  auto image3 = Float3DImageType::New();
-  image3->SetRegions(region);
-  image3->AllocateInitialized();
+  auto image2 = Short3DImageType::CreateInitialized(region);
+  auto image3 = Float3DImageType::CreateInitialized(region);
 
   // Copying two images of same type
   itk::ImageAlgorithm::Copy(image1.GetPointer(), image2.GetPointer(), region, region);

--- a/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
+++ b/Modules/Core/Common/test/itkImageDuplicatorTest.cxx
@@ -34,9 +34,7 @@ itkImageDuplicatorTest(int, char *[])
   {
     /** Create an image */
     std::cout << "Creating simulated image: ";
-    auto m_Image = ImageType::New();
-    m_Image->SetRegions(region);
-    m_Image->AllocateInitialized();
+    auto m_Image = ImageType::CreateInitialized(region);
 
     itk::ImageRegionIterator<ImageType> it(m_Image, region);
     it.GoToBegin();

--- a/Modules/Core/Common/test/itkImageGTest.cxx
+++ b/Modules/Core/Common/test/itkImageGTest.cxx
@@ -83,11 +83,7 @@ void
 Expect_allocated_initialized_image_equal_to_itself()
 {
   using SizeType = typename TImage::SizeType;
-
-  const auto image = TImage::New();
-  image->SetRegions(SizeType::Filled(2));
-  image->AllocateInitialized();
-
+  const auto image = TImage::CreateInitialized(SizeType::Filled(2));
   Expect_equal_to_itself(*image);
 }
 
@@ -98,13 +94,8 @@ Expect_unequal_when_sizes_differ()
 {
   using SizeType = typename TImage::SizeType;
 
-  const auto image1 = TImage::New();
-  image1->SetRegions(SizeType::Filled(2));
-  image1->AllocateInitialized();
-
-  const auto image2 = TImage::New();
-  image2->SetRegions(SizeType::Filled(3));
-  image2->AllocateInitialized();
+  const auto image1 = TImage::CreateInitialized(SizeType::Filled(2));
+  const auto image2 = TImage::CreateInitialized(SizeType::Filled(3));
 
   Expect_unequal(*image1, *image2);
 }

--- a/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
+++ b/Modules/Core/Common/test/itkImageRandomIteratorTest2.cxx
@@ -43,16 +43,13 @@ itkImageRandomIteratorTest2(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  auto image = ImageType::New();
-
   auto size = ImageType::SizeType::Filled(1000);
 
   const unsigned long numberOfSamples = size[0] * size[1];
 
   const ImageType::RegionType region{ size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   using RandomIteratorType = itk::ImageRandomIteratorWithIndex<ImageType>;
 

--- a/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkImageRegionRangeGTest.cxx
@@ -625,13 +625,10 @@ TEST(ImageRegionRange, ThrowsInReleaseWhenIterationRegionIsOutsideBufferedRegion
   using SizeType = ImageType::SizeType;
   using RegionType = ImageType::RegionType;
 
-  const auto image = ImageType::New();
-
   constexpr IndexType imageIndex{ -1, -2 };
   constexpr SizeType  imageSize{ 3, 4 };
 
-  image->SetRegions(RegionType{ imageIndex, imageSize });
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized({ imageIndex, imageSize });
 
   Check_Range_constructor_throws_ExceptionObject_when_iteration_region_is_outside_of_buffered_region(
     *image, RegionType{ imageIndex, imageSize + SizeType::Filled(1) });

--- a/Modules/Core/Common/test/itkLineIteratorTest.cxx
+++ b/Modules/Core/Common/test/itkLineIteratorTest.cxx
@@ -45,9 +45,7 @@ itkLineIteratorTest(int argc, char * argv[])
   auto                        size = ImageType::RegionType::SizeType::Filled(200);
   const ImageType::RegionType region{ size };
 
-  auto output = ImageType::New();
-  output->SetRegions(region);
-  output->AllocateInitialized();
+  auto output = ImageType::CreateInitialized(region);
 
   // First test: empty line
   IndexType startIndex;

--- a/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
+++ b/Modules/Core/Common/test/itkShapedImageNeighborhoodRangeGTest.cxx
@@ -1007,9 +1007,7 @@ TEST(ShapedImageNeighborhoodRange, SupportsArbitraryBufferedRegionIndex)
 
   const ImageType::RegionType bufferedRegion{ arbitraryIndex, imageSize };
 
-  const auto image = ImageType::New();
-  image->SetRegions(bufferedRegion);
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(bufferedRegion);
 
   // Set a 'magic value' at the begin of the buffered region.
   constexpr ImageType::PixelType magicPixelValue{ 42 };

--- a/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
@@ -63,9 +63,7 @@ DoConvolution(typename ImageType::Pointer inputImage, unsigned long int directio
 
   NeighborhoodIteratorType it(radius, inputImage, inputImage->GetRequestedRegion());
 
-  auto outputImage = ImageType::New();
-  outputImage->SetRegions(inputImage->GetRequestedRegion());
-  outputImage->AllocateInitialized();
+  auto outputImage = ImageType::CreateInitialized(inputImage->GetRequestedRegion());
 
   IteratorType                                   out(outputImage, inputImage->GetRequestedRegion());
   const itk::NeighborhoodInnerProduct<ImageType> innerProduct;

--- a/Modules/Core/GPUCommon/include/itkGPUImage.h
+++ b/Modules/Core/GPUCommon/include/itkGPUImage.h
@@ -74,6 +74,17 @@ public:
   using NeighborhoodAccessorFunctorType = NeighborhoodAccessorFunctor<Self>;
   // NeighborhoodAccessorFunctorType;
 
+  /** Creates an image with the specified region, allocating a zero-initialized pixel buffer.
+   * Reimplemented so the returned pointer has this derived GPU image type, not the base itk::Image type. */
+  static Pointer
+  CreateInitialized(const RegionType & region)
+  {
+    const auto image = Self::New();
+    image->SetRegions(region);
+    image->AllocateInitialized();
+    return image;
+  }
+
   //
   // Allocate CPU and GPU memory space
   //

--- a/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
+++ b/Modules/Core/GPUCommon/test/itkGPUImageTest.cxx
@@ -66,9 +66,7 @@ itkGPUImageTest(int argc, char * argv[])
   srcB->Allocate();
   srcB->FillBuffer(3.0f);
 
-  dest = ItkImage1f::New();
-  dest->SetRegions(region);
-  dest->AllocateInitialized();
+  dest = ItkImage1f::CreateInitialized(region);
 
   // check pixel value
   ItkImage1f::IndexType idx;

--- a/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBinaryThresholdImageFunctionTest.cxx
@@ -29,14 +29,12 @@ itkBinaryThresholdImageFunctionTest(int, char *[])
 
   using FloatImage = itk::Image<float, 3>;
 
-  auto                  image = FloatImage::New();
   auto                  size = FloatImage::SizeType::Filled(64);
   FloatImage::IndexType index{};
 
   FloatImage::RegionType region = { index, size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = FloatImage::CreateInitialized(region);
 
   for (unsigned int i = 0; i < FloatImage::ImageDimension; ++i)
   {

--- a/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianBlurImageFunctionTest.cxx
@@ -29,12 +29,10 @@ itkGaussianBlurImageFunctionTest(int, char *[])
   using GFunctionType = itk::GaussianBlurImageFunction<ImageType>;
 
   // Create and allocate the image
-  auto                          image = ImageType::New();
   constexpr ImageType::SizeType size{ 50, 50 };
   ImageType::RegionType         region = { size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Fill the image with a straight line
   for (unsigned int i = 0; i < 50; ++i)

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -29,13 +29,11 @@ TestGaussianDerivativeImageFunction()
   using ImageType = itk::Image<PixelType, Dimension>;
 
   // Create and allocate the image
-  auto                           image = ImageType::New();
   typename ImageType::SizeType   size{ 50, 50 };
   typename ImageType::IndexType  start{};
   typename ImageType::RegionType region = { start, size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Fill the image with a straight line
   for (unsigned int i = 0; i < 50; ++i)

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -56,9 +56,7 @@ template <typename TImage>
 void
 Expect_EvaluateAtIndex_returns_zero_when_all_pixels_are_zero(const typename TImage::SizeType & imageSize)
 {
-  const auto image = TImage::New();
-  image->SetRegions(imageSize);
-  image->AllocateInitialized();
+  const auto image = TImage::CreateInitialized(imageSize);
 
   const auto imageFunction = itk::SumOfSquaresImageFunction<TImage>::New();
 

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectGTest.cxx
@@ -51,10 +51,7 @@ void
 Expect_AxisAlignedBoundingBoxRegion_is_empty_when_all_pixel_values_are_zero(
   const itk::ImageRegion<VImageDimension> & imageRegion)
 {
-  const auto image = itk::Image<TPixel, VImageDimension>::New();
-
-  image->SetRegions(imageRegion);
-  image->AllocateInitialized();
+  const auto image = itk::Image<TPixel, VImageDimension>::CreateInitialized(imageRegion);
 
   EXPECT_EQ(ComputeAxisAlignedBoundingBoxRegionInImageGridSpace(*image).GetSize(), itk::Size<VImageDimension>{});
 }
@@ -86,10 +83,7 @@ void
 Expect_AxisAlignedBoundingBoxRegion_equals_region_of_single_pixel_when_it_is_the_only_non_zero_pixel(
   const itk::ImageRegion<VImageDimension> & imageRegion)
 {
-  const auto image = itk::Image<TPixel, VImageDimension>::New();
-
-  image->SetRegions(imageRegion);
-  image->AllocateInitialized();
+  const auto image = itk::Image<TPixel, VImageDimension>::CreateInitialized(imageRegion);
 
   // Expected size: the "region size" of a single pixel (1x1, in 2D, 1x1x1 in 3D).
   const itk::Size<VImageDimension> expectedSize = [] {
@@ -245,9 +239,7 @@ TEST(ImageMaskSpatialObject, IsInsideSingleNonZeroPixel)
   using PointType = ImageType::PointType;
 
   // Create an image filled with zero valued pixels.
-  const auto image = ImageType::New();
-  image->SetRegions(SizeType::Filled(8));
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(SizeType::Filled(8));
 
   constexpr itk::IndexValueType indexValue{ 4 };
   image->SetPixel({ { indexValue, indexValue } }, 1);
@@ -272,9 +264,7 @@ TEST(ImageMaskSpatialObject, IsInsideIndependentOfDistantPixels)
   using PointType = ImageType::PointType;
 
   // Create an image filled with zero valued pixels.
-  const auto image = ImageType::New();
-  image->SetRegions(SizeType::Filled(10));
-  image->AllocateInitialized();
+  const auto image = ImageType::CreateInitialized(SizeType::Filled(10));
 
   // Set the value of a pixel to non-zero.
   constexpr itk::IndexValueType indexValue{ 8 };
@@ -311,9 +301,7 @@ TEST(ImageMaskSpatialObject, IsInsideIndependentOfDistantPixels)
 TEST(ImageMaskSpatialObject, CornerPointIsNotInsideMaskOfZeroValues)
 {
   // Create a mask image, and fill the image with zero vales.
-  const auto image = itk::Image<unsigned char>::New();
-  image->SetRegions(itk::Size<>{ { 2, 2 } });
-  image->AllocateInitialized();
+  const auto image = itk::Image<unsigned char>::CreateInitialized(itk::Size<>{ { 2, 2 } });
 
   const auto imageMaskSpatialObject = itk::ImageMaskSpatialObject<2>::New();
   imageMaskSpatialObject->SetImage(image);
@@ -331,9 +319,7 @@ TEST(ImageMaskSpatialObject, IsInsideInWorldSpaceOverloads)
   using PointType = MaskImageType::PointType;
 
   // Create a mask image.
-  const auto maskImage = MaskImageType::New();
-  maskImage->SetRegions(itk::Size<imageDimension>::Filled(2));
-  maskImage->AllocateInitialized();
+  const auto maskImage = MaskImageType::CreateInitialized(itk::Size<imageDimension>::Filled(2));
   maskImage->SetPixel({}, MaskPixelType{ 1 });
   maskImage->SetSpacing(itk::MakeFilled<MaskImageType::SpacingType>(0.5));
 
@@ -367,9 +353,8 @@ TEST(ImageMaskSpatialObject, StoresRegionsFromMaskImage)
       using SizeType = MaskImageType::SizeType;
 
       // Create a mask image.
-      const auto maskImage = MaskImageType::New();
-      maskImage->SetRegions(RegionType{ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) });
-      maskImage->AllocateInitialized();
+      const auto maskImage =
+        MaskImageType::CreateInitialized({ IndexType::Filled(indexValue), SizeType::Filled(sizeValue) });
 
       const auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
       imageMaskSpatialObject->SetImage(maskImage);

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest.cxx
@@ -41,12 +41,10 @@ itkImageMaskSpatialObjectTest(int, char *[])
   using ImageType = ImageMaskSpatialObject::ImageType;
   using Iterator = itk::ImageRegionIterator<ImageType>;
 
-  auto                          image = ImageType::New();
   constexpr ImageType::SizeType size{ 50, 50, 50 };
   ImageType::RegionType         region{ size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   constexpr ImageType::SizeType  insideSize{ 30, 30, 30 };
   constexpr ImageType::IndexType insideIndex{ 10, 10, 10 };

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest2.cxx
@@ -51,7 +51,15 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   // Also explicitly uses nonzero origin, non identity scales
   // to fully test the commonly encountered cases from the real world
 
-  auto image = ImageType::New();
+  const ImageType::SizeType size = { { 50, 50, 50 } };
+
+  constexpr unsigned int     index_offset = 6543;
+  const ImageType::IndexType index = { { index_offset, index_offset, index_offset } };
+
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(index);
+  auto image = ImageType::CreateInitialized(region);
 
   // Set the direction for a non-oriented image
   // to better test the frequently encountered case
@@ -61,8 +69,7 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   const ImageType::DirectionType direction = tfm->GetMatrix();
   image->SetDirection(direction);
 
-  constexpr ImageType::SizeType size{ 50, 50, 50 };
-  ImageType::PointType          origin;
+  ImageType::PointType origin;
   origin[0] = 1.51;
   origin[1] = 2.10;
   origin[2] = -300;
@@ -73,12 +80,6 @@ itkImageMaskSpatialObjectTest2(int, char *[])
   spacing[1] = 0.7;
   spacing[2] = 1.1;
   image->SetSpacing(spacing);
-  constexpr unsigned int         index_offset{ 6543 };
-  constexpr ImageType::IndexType index{ index_offset, index_offset, index_offset };
-
-  const ImageType::RegionType region{ index, size };
-  image->SetRegions(region);
-  image->AllocateInitialized();
 
   ImageType::RegionType  insideRegion;
   constexpr unsigned int INSIDE_SIZE{ 30 };

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest3.cxx
@@ -42,8 +42,9 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   using PixelType = ImageMaskSpatialObjectType::PixelType;
   using ImageType = itk::Image<PixelType, VDimension>;
 
-  auto                           image = ImageType::New();
   constexpr ImageType::SizeType  size{ 5, 5, 5 };
+  const ImageType::RegionType    region{ size };
+  auto                           image = ImageType::CreateInitialized(region);
   constexpr ImageType::PointType origin{};
   image->SetOrigin(origin);
 
@@ -55,10 +56,6 @@ itkImageMaskSpatialObjectTest3(int, char *[])
   direction[1][0] = 1;
   direction[2][2] = 1;
   image->SetDirection(direction);
-
-  ImageType::RegionType region{ size };
-  image->SetRegions(region);
-  image->AllocateInitialized();
 
   auto imageMaskSpatialObject = ImageMaskSpatialObjectType::New();
   imageMaskSpatialObject->SetImage(image);

--- a/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
+++ b/Modules/Core/TestKernel/test/itkTestingExtractSliceImageFilterTest.cxx
@@ -37,15 +37,12 @@ itkTestingExtractSliceImageFilterTest(int, char *[])
 
   auto filter = FilterType::New();
 
-  auto inputImage = InputImageType::New();
-
   auto size = InputImageType::SizeType::Filled(20);
 
   InputImageType::RegionType region;
   region.SetSize(size);
 
-  inputImage->SetRegions(region);
-  inputImage->AllocateInitialized();
+  auto inputImage = InputImageType::CreateInitialized(region);
 
   InputImageType::DirectionType direction;
   direction[0][0] = 1.0;

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterDeltaFunctionTest.cxx
@@ -43,9 +43,7 @@ itkConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
 
   // Set up delta function image.
   const ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  auto                        deltaFunctionImage = ImageType::New();
-  deltaFunctionImage->SetRegions(region);
-  deltaFunctionImage->AllocateInitialized();
+  auto                        deltaFunctionImage = ImageType::CreateInitialized(region);
 
   // Set the middle pixel (rounded up) to 1.
   ImageType::IndexType middleIndex;

--- a/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkFFTConvolutionImageFilterDeltaFunctionTest.cxx
@@ -54,9 +54,7 @@ itkFFTConvolutionImageFilterDeltaFunctionTest(int argc, char * argv[])
 
   // Set up delta function image
   const ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-  auto                        deltaFunctionImage = ImageType::New();
-  deltaFunctionImage->SetRegions(region);
-  deltaFunctionImage->AllocateInitialized();
+  auto                        deltaFunctionImage = ImageType::CreateInitialized(region);
 
   // Set the middle pixel (rounded up) to 1
   ImageType::IndexType middleIndex;

--- a/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkDanielssonDistanceMapImageFilterGTest.cxx
@@ -42,9 +42,7 @@ TEST(DanielssonDistanceMapImageFilter, Test)
   myImageType2D1::IndexType          index2D = { { 0, 0 } };
   const myImageType2D1::RegionType   region2D{ index2D, size2D };
 
-  auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetRegions(region2D);
-  inputImage2D->AllocateInitialized();
+  auto inputImage2D = myImageType2D1::CreateInitialized(region2D);
 
   // Set pixel (4,4) with the value 1
   // and pixel (1,6) with the value 2

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterGTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterGTest.cxx
@@ -40,9 +40,7 @@ TEST(SignedDanielssonDistanceMapImageFilter, Test)
   myImageType2D1::IndexType          index2D = { { 0, 0 } };
   const myImageType2D1::RegionType   region2D{ index2D, size2D };
 
-  auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetRegions(region2D);
-  inputImage2D->AllocateInitialized();
+  auto inputImage2D = myImageType2D1::CreateInitialized(region2D);
 
   /* Set pixel (4,4) with the value 1
    * The SignedDanielsson Distance is performed for each pixel with a value > 0

--- a/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
+++ b/Modules/Filtering/DistanceMap/test/itkSignedDanielssonDistanceMapImageFilterTest.cxx
@@ -58,9 +58,7 @@ test(int testIdx)
 
   const myImageType2D1::RegionType region2D{ index2D, size2D };
 
-  auto inputImage2D = myImageType2D1::New();
-  inputImage2D->SetRegions(region2D);
-  inputImage2D->AllocateInitialized();
+  auto inputImage2D = myImageType2D1::CreateInitialized(region2D);
 
   if (!testIdx)
   {

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DCirclesImageTest.cxx
@@ -55,12 +55,10 @@ Test_GetCircles_should_return_empty_list_when_NumberOfCircles_is_set_to_zero()
   using ImageType = itk::Image<PixelType>;
 
   // Create an image that has at least one circle.
-  const auto                    image = ImageType::New();
   constexpr ImageType::SizeType size{ 64, 64 };
-  image->SetRegions(size);
-  image->AllocateInitialized();
-  constexpr unsigned int center[]{ 16, 16 };
-  constexpr double       radius{ 7.0 };
+  const auto                    image = ImageType::CreateInitialized(size);
+  constexpr unsigned int        center[]{ 16, 16 };
+  constexpr double              radius{ 7.0 };
   CreateCircle<ImageType>(image, center, radius);
 
   using FilterType = itk::HoughTransform2DCirclesImageFilter<PixelType, PixelType, PixelType>;
@@ -256,12 +254,10 @@ Test_Center_IsInside_SpatialObject_from_GetCircles()
 {
   using PixelType = unsigned int;
   using ImageType = itk::Image<PixelType>;
-  const auto                    image = ImageType::New();
   constexpr ImageType::SizeType imageSize{ 16, 32 };
-  image->SetRegions(imageSize);
-  image->AllocateInitialized();
-  constexpr double center[]{ 6.0, 9.0 };
-  constexpr double radius{ 1.0 };
+  const auto                    image = ImageType::CreateInitialized(imageSize);
+  constexpr double              center[]{ 6.0, 9.0 };
+  constexpr double              radius{ 1.0 };
   CreateCircle<ImageType>(image, center, radius);
 
   using FilterType = itk::HoughTransform2DCirclesImageFilter<PixelType, unsigned int, double>;
@@ -312,14 +308,11 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   // Create a black image
-  auto image = ImageType::New();
-
   auto                  size = ImageType::SizeType::Filled(100);
   ImageType::IndexType  index{};
   ImageType::RegionType region = { index, size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Create 3 circles
   constexpr unsigned int circles{ 3 };
@@ -345,9 +338,7 @@ itkHoughTransform2DCirclesImageTest(int, char *[])
   }
 
   // Allocate Hough Space image (accumulator)
-  auto m_HoughSpaceImage = ImageType::New();
-  m_HoughSpaceImage->SetRegions(region);
-  m_HoughSpaceImage->AllocateInitialized();
+  auto m_HoughSpaceImage = ImageType::CreateInitialized(region);
 
   // Apply gradient filter to the input image
   using CastingFilterType = itk::CastImageFilter<ImageType, HoughImageType>;

--- a/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkHoughTransform2DLinesImageTest.cxx
@@ -47,10 +47,8 @@ Test_GetLines_should_return_empty_list_when_input_image_is_entirely_black()
   using FilterType = itk::HoughTransform2DLinesImageFilter<PixelType, double>;
 
   // Create a black input image for the filter.
-  const auto                    image = ImageType::New();
   constexpr ImageType::SizeType size{ 32, 32 };
-  image->SetRegions(size);
-  image->AllocateInitialized();
+  const auto                    image = ImageType::CreateInitialized(size);
 
   const auto filter = FilterType::New();
   filter->SetInput(image);
@@ -73,15 +71,13 @@ Test_GetLines_should_return_empty_list_when_NumberOfLines_is_set_to_zero()
   using ImageType = itk::Image<PixelType>;
 
   // Create an image.
-  const auto image = ImageType::New();
   enum
   {
     sizeX = 32,
     sizeY = 32
   };
   constexpr ImageType::SizeType size{ sizeX, sizeY };
-  image->SetRegions(size);
-  image->AllocateInitialized();
+  const auto                    image = ImageType::CreateInitialized(size);
 
   // Place some line segment in the image.
   for (itk::IndexValueType x = 1; x < (sizeX - 1); ++x)
@@ -136,14 +132,11 @@ itkHoughTransform2DLinesImageTest(int, char *[])
 
 
   // Create a line image with one line
-  auto image = ImageType::New();
-
   auto                  size = ImageType::SizeType::Filled(100);
   ImageType::IndexType  index{};
   ImageType::RegionType region = { index, size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   // Create a line
   constexpr unsigned int lines{ 1 };

--- a/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFilterBase/test/itkMaskNeighborhoodOperatorImageFilterTest.cxx
@@ -49,15 +49,10 @@ itkMaskNeighborhoodOperatorImageFilterTest(int argc, char * argv[])
 
   // create a mask the size of the input file
   using MaskImageType = itk::Image<unsigned char, Dimension>;
-  auto mask1 = MaskImageType::New();
-  auto mask2 = MaskImageType::New();
 
   MaskImageType::RegionType region = input->GetOutput()->GetBufferedRegion();
-  mask1->SetRegions(region);
-  mask1->AllocateInitialized();
-
-  mask2->SetRegions(region);
-  mask2->AllocateInitialized();
+  auto                      mask1 = MaskImageType::CreateInitialized(region);
+  auto                      mask2 = MaskImageType::CreateInitialized(region);
 
   MaskImageType::SizeType  size = region.GetSize();
   MaskImageType::IndexType index = region.GetIndex();

--- a/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientMagnitudeRecursiveGaussianFilterTest.cxx
@@ -60,16 +60,13 @@ itkGradientMagnitudeRecursiveGaussianFilterTest(int argc, char * argv[])
   using mySizeType = itk::Size<myDimension>;
   using myRegionType = itk::ImageRegion<myDimension>;
 
-  auto inputImage = myImageType::New();
-
   auto size = mySizeType::Filled(8);
 
   myIndexType start{};
 
   myRegionType region{ start, size };
 
-  inputImage->SetRegions(region);
-  inputImage->AllocateInitialized();
+  auto inputImage = myImageType::CreateInitialized(region);
 
   // Set the metadata for the image
   myImageType::PointType     origin{ { 1.0, 2.0, 3.0 } };

--- a/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkSliceBySliceImageFilterTest.cxx
@@ -164,13 +164,9 @@ itkSliceBySliceImageFilterTest(int argc, char * argv[])
   // spacing. We are setting the input image to have a non-zero
   // starting index.
   //
-  auto image = ImageType::New();
-  {
-    ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
-    region.SetIndex(0, 10);
-    image->SetRegions(region);
-    image->AllocateInitialized();
-  }
+  ImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
+  region.SetIndex(0, 10);
+  auto image = ImageType::CreateInitialized(region);
 
   ImageType::SpacingType spacing;
   ImageType::PointType   origin;

--- a/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
+++ b/Modules/IO/ImageBase/test/itkImageFileWriterTest2.cxx
@@ -33,14 +33,11 @@ itkImageFileWriterTest2(int argc, char * argv[])
   using WriterType = itk::ImageFileWriter<ImageNDType>;
   using ReaderType = itk::ImageFileReader<ImageNDType>;
 
-  auto image = ImageNDType::New();
-
   auto                          size = itk::MakeFilled<ImageNDType::SizeType>(5);
   auto                          index = itk::MakeFilled<ImageNDType::IndexType>(1);
   const ImageNDType::RegionType region{ index, size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageNDType::CreateInitialized(region);
 
   ImageNDType::PointType originalPoint;
   image->TransformIndexToPhysicalPoint(index, originalPoint);

--- a/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
+++ b/Modules/IO/ImageBase/test/itkWriteImageFunctionGTest.cxx
@@ -44,14 +44,7 @@ struct ITKWriteImageFunctionTest : public ::testing::Test
   ImageType::Pointer
   MakeImage()
   {
-    auto image = ImageType::New();
-
-    const RegionType region(SizeType{ { 3, 2 } });
-
-    image->SetRegions(region);
-
-    image->AllocateInitialized();
-    return image;
+    return ImageType::CreateInitialized(SizeType{ 3, 2 });
   }
 };
 

--- a/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
+++ b/Modules/IO/JPEG/test/itkJPEGImageIOTest2.cxx
@@ -36,13 +36,10 @@ itkJPEGImageIOTest2(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-
   constexpr ImageType::SizeType size{ 157, 129 };
   ImageType::RegionType         region = { size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   ImageType::SpacingType spacing;
 

--- a/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiLargeImageRegionReadTest.cxx
@@ -53,9 +53,7 @@ itkNiftiLargeImageRegionReadTest(int argc, char * argv[])
   region.SetSize(size);
 
   {
-    auto image = ImageType::New();
-    image->SetRegions(region);
-    image->AllocateInitialized();
+    auto image = ImageType::CreateInitialized(region);
     itk::WriteImage(image, fname);
   }
 

--- a/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiWriteCoerceOrthogonalDirectionTest.cxx
@@ -40,9 +40,7 @@ itkNiftiWriteCoerceOrthogonalDirectionTest(int argc, char * argv[])
 
   constexpr ImageType::SizeType imageSize{ 2, 2 };
   const ImageType::RegionType   region{ imageSize };
-  auto                          image1 = ImageType::New();
-  image1->SetRegions(region);
-  image1->AllocateInitialized();
+  auto                          image1 = ImageType::CreateInitialized(region);
 
   ImageType::DirectionType mat1;
   mat1.SetIdentity();

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest2.cxx
@@ -35,14 +35,11 @@ itkTIFFImageIOTest2(int argc, char * argv[])
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-
   ImageType::IndexType  start{};
   ImageType::SizeType   size{ 157, 129 };
   ImageType::RegionType region = { start, size };
 
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   ImageType::SpacingType spacing;
 

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1.cxx
@@ -78,9 +78,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest1(int argc, char * 
   }
   std::cout << std::endl;
 
-  auto visitedImage = ImageType::New();
-  visitedImage->SetRegions(region);
-  visitedImage->AllocateInitialized();
+  auto visitedImage = ImageType::CreateInitialized(region);
 
   for (; !shapedFloodIt.IsAtEnd(); ++shapedFloodIt)
   {

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2.cxx
@@ -49,9 +49,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest2(int, char *[])
     region.SetIndex(0, 0);
     region.SetIndex(1, 0);
 
-    auto inputImage = ImageType::New();
-    inputImage->SetRegions(region);
-    inputImage->AllocateInitialized();
+    auto inputImage = ImageType::CreateInitialized(region);
 
     itk::ImageLinearIteratorWithIndex<ImageType> it(inputImage, region);
 

--- a/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
+++ b/Modules/Nonunit/Review/test/itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3.cxx
@@ -51,9 +51,7 @@ itkShapedFloodFilledImageFunctionConditionalConstIteratorTest3(int, char *[])
     region.SetIndex(1, 0);
     region.SetIndex(2, 0);
 
-    auto inputImage = ImageType::New();
-    inputImage->SetRegions(region);
-    inputImage->AllocateInitialized();
+    auto inputImage = ImageType::CreateInitialized(region);
 
     itk::ImageLinearIteratorWithIndex<ImageType> it(inputImage, region);
 

--- a/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkGaussianRandomSpatialNeighborSubsamplerTest.cxx
@@ -47,12 +47,10 @@ itkGaussianRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   using SamplerType = itk::Statistics::GaussianRandomSpatialNeighborSubsampler<AdaptorType, RegionType>;
   using WriterType = itk::ImageFileWriter<FloatImage>;
 
-  auto             inImage = FloatImage::New();
   auto             sz = SizeType::Filled(35);
   const RegionType region{ sz };
 
-  inImage->SetRegions(region);
-  inImage->AllocateInitialized();
+  auto inImage = FloatImage::CreateInitialized(region);
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest.cxx
@@ -62,14 +62,12 @@ CreateImage()
 static MaskImageType::Pointer
 CreateMaskImage()
 {
-  auto                     image = MaskImageType::New();
   MaskImageType::IndexType start{};
   auto                     size = itk::MakeFilled<MaskImageType::SizeType>(10);
 
 
   const MaskImageType::RegionType region(start, size);
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto                            image = MaskImageType::CreateInitialized(region);
 
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;
@@ -97,8 +95,6 @@ CreateMaskImage()
 static MaskImageType::Pointer
 CreateLargerMaskImage()
 {
-  auto image = MaskImageType::New();
-
   MaskImageType::IndexType start;
   MaskImageType::SizeType  size;
 
@@ -109,9 +105,7 @@ CreateLargerMaskImage()
   size[1] = 17;
 
   const MaskImageType::RegionType region(start, size);
-  image->SetRegions(region);
-  image->AllocateInitialized();
-  return image;
+  return MaskImageType::CreateInitialized(region);
 }
 
 

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest2.cxx
@@ -57,9 +57,7 @@ itkImageToListSampleFilterTest2(int, char *[])
     ++it;
   }
 
-  auto maskImage = MaskImageType::New();
-  maskImage->SetRegions(region);
-  maskImage->AllocateInitialized();
+  auto                     maskImage = MaskImageType::CreateInitialized(region);
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;
 

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleFilterTest3.cxx
@@ -65,9 +65,7 @@ itkImageToListSampleFilterTest3(int, char *[])
     ++it;
   }
 
-  auto maskImage = MaskImageType::New();
-  maskImage->SetRegions(region);
-  maskImage->AllocateInitialized();
+  auto maskImage = MaskImageType::CreateInitialized(region);
 
   MaskImageType::IndexType startMask;
   MaskImageType::SizeType  sizeMask;

--- a/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkSpatialNeighborSubsamplerTest.cxx
@@ -77,12 +77,10 @@ itkSpatialNeighborSubsamplerTest(int, char *[])
   using SamplerType = itk::Statistics::SpatialNeighborSubsampler<AdaptorType, RegionType>;
   using IteratorType = itk::ImageRegionConstIteratorWithIndex<ImageType>;
 
-  auto             inImage = ImageType::New();
   constexpr auto   sz = SizeType::Filled(25);
   const RegionType region{ sz };
 
-  inImage->SetRegions(region);
-  inImage->AllocateInitialized();
+  auto inImage = ImageType::CreateInitialized(region);
 
   SizeType szConstraint;
   szConstraint[0] = 23;

--- a/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkUniformRandomSpatialNeighborSubsamplerTest.cxx
@@ -48,13 +48,11 @@ itkUniformRandomSpatialNeighborSubsamplerTest(int argc, char * argv[])
   using SamplerType = itk::Statistics::UniformRandomSpatialNeighborSubsampler<AdaptorType, RegionType>;
   using WriterType = itk::ImageFileWriter<FloatImage>;
 
-  auto                                    inImage = FloatImage::New();
   constexpr typename SizeType::value_type regionSizeVal = 35;
   constexpr auto                          sz = SizeType::Filled(regionSizeVal);
   const RegionType                        region{ sz };
 
-  inImage->SetRegions(region);
-  inImage->AllocateInitialized();
+  auto inImage = FloatImage::CreateInitialized(region);
 
   auto sample = AdaptorType::New();
   sample->SetImage(inImage);

--- a/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkKappaStatisticImageToImageMetricTest.cxx
@@ -64,10 +64,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   auto fixedImageSize = FixedImageType::SizeType::Filled(128);
 
   // Create fixed image
-  auto fixedImage = FixedImageType::New();
-  fixedImage->SetRegions(fixedImageSize);
-  fixedImage->AllocateInitialized();
-  fixedImage->Update();
+  auto fixedImage = FixedImageType::CreateInitialized(fixedImageSize);
 
   FixedImageIteratorType fixedIt(fixedImage, fixedImage->GetBufferedRegion());
   for (fixedIt.GoToBegin(); !fixedIt.IsAtEnd(); ++fixedIt)
@@ -82,10 +79,7 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   auto movingImageSize = MovingImageType::SizeType::Filled(128);
 
   // Create moving image
-  auto movingImage = MovingImageType::New();
-  movingImage->SetRegions(movingImageSize);
-  movingImage->AllocateInitialized();
-  movingImage->Update();
+  auto movingImage = MovingImageType::CreateInitialized(movingImageSize);
 
   MovingImageIteratorType movingIt(movingImage, movingImage->GetBufferedRegion());
   for (movingIt.GoToBegin(); !movingIt.IsAtEnd(); ++movingIt)
@@ -158,15 +152,8 @@ itkKappaStatisticImageToImageMetricTest(int, char *[])
   //
   metric->ComputeGradient();
 
-  auto xGradImage = GradientImageType::New();
-  xGradImage->SetRegions(movingImageSize);
-  xGradImage->AllocateInitialized();
-  xGradImage->Update();
-
-  auto yGradImage = GradientImageType::New();
-  yGradImage->SetRegions(movingImageSize);
-  yGradImage->AllocateInitialized();
-  yGradImage->Update();
+  auto xGradImage = GradientImageType::CreateInitialized(movingImageSize);
+  auto yGradImage = GradientImageType::CreateInitialized(movingImageSize);
 
   GradientImageIteratorType xGradIt(xGradImage, xGradImage->GetBufferedRegion());
   GradientImageIteratorType yGradIt(yGradImage, yGradImage->GetBufferedRegion());

--- a/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkScalarImageKmeansImageFilter3DTest.cxx
@@ -253,12 +253,10 @@ itkScalarImageKmeansImageFilter3DTest(int argc, char * argv[])
 
   /* Now remap the labels - background first followed by brain */
   using LabelImageType = KMeansFilterType::OutputImageType;
-  auto kmeansLabelImage = LabelImageType::New();
-  kmeansLabelImage->SetRegions(maskReader->GetOutput()->GetLargestPossibleRegion());
+  auto kmeansLabelImage = LabelImageType::CreateInitialized(maskReader->GetOutput()->GetLargestPossibleRegion());
   kmeansLabelImage->SetSpacing(maskReader->GetOutput()->GetSpacing());
   kmeansLabelImage->SetDirection(maskReader->GetOutput()->GetDirection());
   kmeansLabelImage->SetOrigin(maskReader->GetOutput()->GetOrigin());
-  kmeansLabelImage->AllocateInitialized();
 
   using LabelMapStatisticsFilterType = itk::LabelStatisticsImageFilter<LabelImageType, LabelImageType>;
   auto statisticsNonBrainFilter = LabelMapStatisticsFilterType::New();

--- a/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkConnectedComponentImageFilterGTest.cxx
@@ -38,9 +38,7 @@ CreateTestImageA()
   using PixelType = unsigned char;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto image = ImageType::New();
-  image->SetRegions(ImageType::RegionType(itk::MakeSize(2u, 2u, 2u)));
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(itk::MakeSize(2u, 2u, 2u));
 
   for (size_t i = 0; i < 8; ++i)
   {

--- a/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkRelabelComponentImageFilterGTest.cxx
@@ -136,11 +136,9 @@ TEST(RelabelComponentImageFilter, BigZero)
   using PixelType = unsigned short;
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  auto                  image = ImageType::New();
   ImageType::RegionType region;
   region.SetSize({ { 512, 512, 512 } });
-  image->SetRegions(region);
-  image->AllocateInitialized();
+  auto image = ImageType::CreateInitialized(region);
 
   auto filter = itk::RelabelComponentImageFilter<ImageType, ImageType>::New();
   filter->SetInput(image);

--- a/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
+++ b/Modules/Segmentation/LevelSets/test/itkBinaryMaskToNarrowBandPointSetFilterTest.cxx
@@ -42,13 +42,10 @@ itkBinaryMaskToNarrowBandPointSetFilterTest(int argc, char * argv[])
   //
   //  Initialize an image with a white square in a black background
   //
-  auto binaryMask = BinaryMaskImageType::New();
-
   BinaryMaskImageType::SizeType   size{ 100, 100 };
   BinaryMaskImageType::IndexType  index{};
   BinaryMaskImageType::RegionType region = { index, size };
-  binaryMask->SetRegions(region);
-  binaryMask->AllocateInitialized();
+  auto                            binaryMask = BinaryMaskImageType::CreateInitialized(region);
 
   size[0] = 60;
   size[1] = 60;

--- a/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
+++ b/Modules/Segmentation/Watersheds/test/itkWatershedImageFilterTest.cxx
@@ -41,9 +41,7 @@ itkWatershedImageFilterTest(int, char *[])
   image2D->SetRegions(region);
   image2D->Allocate();
 
-  auto longimage2D = LongImageType2D::New();
-  longimage2D->SetRegions(region);
-  longimage2D->AllocateInitialized();
+  auto longimage2D = LongImageType2D::CreateInitialized(region);
 
   itk::ImageRegionIterator<ImageType2D> it2D(image2D, image2D->GetRequestedRegion());
 


### PR DESCRIPTION
Completes @N-Dekker's `itk::Image::CreateInitialized(const RegionType &)` from #4599, rebuilt on current `main`, resolving the one issue that kept it in WIP: the factory did not work for `itk::Image` subclasses. Design credit is @N-Dekker's — his API commit is preserved as-authored.

`CreateInitialized(region)` collapses the ubiquitous `New()` + `SetRegions()` + `AllocateInitialized()` idiom into a single call; this migrates 52 test files (net −172 lines).

<details>
<summary>Commit structure (authorship)</summary>

| Commit | Author | Purpose |
|---|---|---|
| `ENH: Add static member, Image::CreateInitialized` | **Niels Dekker** | the API + doc, exactly as designed in #4599 |
| `ENH: Make CreateInitialized subclass-safe for itk::GPUImage` | Hans Johnson | the fix (below) |
| `STYLE: Use itk::Image::CreateInitialized(region) in tests` | Hans Johnson (Co-Authored-By: Niels Dekker) | the 52-file mechanical migration |

</details>

<details>
<summary>The GPU issue this resolves</summary>

`itk::Image::CreateInitialized` hard-codes `Image::New()` and returns `itk::Image::Pointer`. A `GPUImage<T,D>` subclass inherits it unchanged, so `GPUImage::CreateInitialized(...)` returns a base `SmartPointer<Image>` that cannot be assigned to a `GPUImage::Pointer` (the converting assignment is SFINAE-disabled for base→derived), breaking `itkGPUImageTest.cxx` under `ITK_USE_GPU=ON` — a configuration the default CI does not build.

Fix: give `GPUImage` its own correctly-typed `CreateInitialized` (using `Self::New()`), exactly the way every ITK class provides its own `New()`. Any future subclass that wants the factory adds the same one-liner; the base `itk::Image` API is unchanged from @N-Dekker's design.

</details>

<details>
<summary>Local validation</summary>

- **Real GPU build + run:** configured with `ITK_USE_GPU=ON` + `Module_ITKGPUCommon=ON`, compiled and linked `ITKGPUCommonTestDriver`, and ran `itkGPUImageTest` on real OpenCL hardware (Intel OpenCL, multiple devices) — **Passed** (0.74 s). This exercises the migrated `ItkImage1f::CreateInitialized(region)` at line 73 that was the original `ITK_USE_GPU=ON` build break.
- All 51 migrated test files that have a compile-database entry compile clean (51/51), checked with the modified `itkImage.h`.
- `pre-commit run --all-files` clean.

</details>

<details>
<summary>Also folded in (from an xhigh review of #4599)</summary>

- `itkSliceBySliceImageFilterTest.cxx`: replaced an immediately-invoked capturing lambda with two plain statements.
- `itkKappaStatisticImageToImageMetricTest.cxx`: dropped two asymmetric no-op `Update()` calls.

</details>

<!--
provenance: claude-code session 2026-07-21
supersedes: #4599 (N-Dekker, WIP since 2024; stalled on API-name/scope consensus, then forgotten)
design_author: N-Dekker (base itk::Image::CreateInitialized API)
gpu_fix: GPUImage::CreateInitialized returns Self::Pointer (itkGPUImage.h)
built_on: origin/main ec46d0c28a
validation: OpenCL present; itkGPUImageTest.cxx + 51/51 migrated files compile-checked with modified itkImage.h prepended
-->

