### PR TITLE
BUG: Dispatch NRRD reserved metadata keys by exact match

### DIFF
--- a/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
+++ b/Modules/IO/NRRD/src/itkNrrdImageIO.cxx
@@ -284,10 +284,10 @@ constexpr NrrdReservedField kNrrdReservedFields[] = {
 
 // Look up `keyField` (the text after the "NRRD_" prefix) in the reserved
 // field table and invoke the matching handler.  Returns true if `keyField`
-// began with the name of any known reserved field (even if a per-axis index
-// was out of range -- that mirrors the original behavior: the key is
-// considered "consumed" as a reserved field and must not leak into the
-// custom key/value fallback).
+// named a known reserved field: scalar fields require an exact name match,
+// per-axis fields require the name followed by an "[axis]" suffix (even if
+// the axis index is out of range -- the key is considered "consumed" as a
+// reserved field and must not leak into the custom key/value fallback).
 bool
 TryDispatchNrrdReservedField(NrrdWriteReservedFieldCtx & ctx, const char * keyField)
 {
@@ -301,12 +301,25 @@ TryDispatchNrrdReservedField(NrrdWriteReservedFieldCtx & ctx, const char * keyFi
     }
     if (rf.perAxis != nullptr)
     {
+      if (keyField[nameLen] != '[')
+      {
+        continue;
+      }
       unsigned int axi{ 0 };
-      if (std::sscanf(keyField + nameLen, "[%u]", &axi) == 1 && axi + ctx.numberOfPixelAxis_nrrd < ctx.nrrd->dim)
+      int          consumed{ 0 };
+      if (std::sscanf(keyField + nameLen, "[%u]%n", &axi, &consumed) != 1 || keyField[nameLen + consumed] != '\0')
+      {
+        continue;
+      }
+      if (axi + ctx.numberOfPixelAxis_nrrd < ctx.nrrd->dim)
       {
         rf.perAxis(ctx, axi);
       }
       return true;
+    }
+    if (keyField[nameLen] != '\0')
+    {
+      continue;
     }
     rf.scalar(ctx);
     return true;
@@ -783,6 +796,11 @@ NrrdImageIO::ReadImageInformation()
       default:
         // we're not coming from a space for which the conversion
         // to LPS is well-defined
+        if (nrrd->space != nrrdSpaceUnknown)
+        {
+          itkWarningMacro("NRRD space \"" << airEnumStr(nrrdSpace, nrrd->space)
+                                          << "\" is not converted to LPS; using its geometry verbatim.");
+        }
         break;
     }
 
@@ -1375,13 +1393,14 @@ NrrdImageIO::Write(const void * buffer)
   const std::vector<std::string> keys = thisDic.GetKeys();
   for (const std::string & metaKey : keys)
   {
+    bool consumedAsReservedField = false;
     if (!std::strncmp(NRRD_KEY_PREFIX.c_str(), metaKey.c_str(), NRRD_KEY_PREFIX.size()))
     {
       const char *              keyField = metaKey.c_str() + NRRD_KEY_PREFIX.size();
       NrrdWriteReservedFieldCtx ctx{ thisDic, metaKey, nrrd, numberOfPixelAxis_nrrd };
-      TryDispatchNrrdReservedField(ctx, keyField);
+      consumedAsReservedField = TryDispatchNrrdReservedField(ctx, keyField);
     }
-    else
+    if (!consumedAsReservedField)
     {
       // not a NRRD field packed into meta data; just a regular key/value
       // convert to string and dump to the file

--- a/Modules/IO/NRRD/test/CMakeLists.txt
+++ b/Modules/IO/NRRD/test/CMakeLists.txt
@@ -420,3 +420,6 @@ itk_add_test(
     itkNrrdLocaleTest
     ${ITK_TEST_OUTPUT_DIR}
 )
+
+set(ITKIONRRDGTests itkNrrdImageIOGTest.cxx)
+creategoogletestdriver(ITKIONRRD "${ITKIONRRD-Test_LIBRARIES}" "${ITKIONRRDGTests}")

--- a/Modules/IO/NRRD/test/itkNrrdImageIOGTest.cxx
+++ b/Modules/IO/NRRD/test/itkNrrdImageIOGTest.cxx
@@ -1,0 +1,167 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkNrrdImageIO.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkMetaDataObject.h"
+#include "itkGTest.h"
+#include <fstream>
+
+namespace
+{
+using ImageType = itk::Image<unsigned char, 3>;
+
+std::string
+WriteFile(const std::string & path, const std::string & content)
+{
+  std::ofstream file(path, std::ios::binary);
+  file << content;
+  return path;
+}
+
+ImageType::Pointer
+ReadNrrd(const std::string & path)
+{
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetFileName(path);
+  reader->SetImageIO(itk::NrrdImageIO::New());
+  reader->Update();
+  return reader->GetOutput();
+}
+
+std::string
+WriteRaw(const std::string & path, const std::size_t numberOfBytes)
+{
+  std::ofstream     file(path, std::ios::binary);
+  const std::string zeros(numberOfBytes, '\0');
+  file << zeros;
+  return path;
+}
+} // namespace
+
+// A 16-dimensional header whose sizes line holds a 17th token previously wrote one
+// element past a 16-element stack array in the vendored parser (issue #6575, B67).
+TEST(NrrdImageIO, RejectsExcessSizesAtMaximumDimension)
+{
+  const std::string dir = ::testing::TempDir();
+  const std::string header = WriteFile(dir + "/b67.nhdr",
+                                       "NRRD0004\n"
+                                       "type: uchar\n"
+                                       "dimension: 16\n"
+                                       "sizes: 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1\n"
+                                       "encoding: raw\n"
+                                       "data file: b67.raw\n");
+  WriteRaw(dir + "/b67.raw", 1);
+
+  auto io = itk::NrrdImageIO::New();
+  io->SetFileName(header);
+  EXPECT_THROW(io->ReadImageInformation(), itk::ExceptionObject);
+}
+
+// nrrdOriginCalculate tested axis 0's min for every axis, so a usable first-axis min
+// with NaN mins elsewhere produced a NaN origin (issue #6575, B68).
+TEST(NrrdImageIO, PartialAxisMinsYieldFiniteOrigin)
+{
+  const std::string dir = ::testing::TempDir();
+  const std::string header = WriteFile(dir + "/b68.nhdr",
+                                       "NRRD0004\n"
+                                       "type: uchar\n"
+                                       "dimension: 3\n"
+                                       "sizes: 2 2 2\n"
+                                       "spacings: 1 1 1\n"
+                                       "axis mins: 0 nan nan\n"
+                                       "encoding: raw\n"
+                                       "data file: b68.raw\n");
+  WriteRaw(dir + "/b68.raw", 8);
+
+  const auto image = ReadNrrd(header);
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+    EXPECT_TRUE(std::isfinite(image->GetOrigin()[i])) << " axis " << i;
+  }
+}
+
+// The `none` arm of the kinds parser assigned the axis's centering instead of its kind,
+// clobbering a previously parsed centers line (issue #6575, B69).
+TEST(NrrdImageIO, KindsNoneDoesNotClobberCentering)
+{
+  const std::string dir = ::testing::TempDir();
+  const std::string header = WriteFile(dir + "/b69.nhdr",
+                                       "NRRD0004\n"
+                                       "type: uchar\n"
+                                       "dimension: 3\n"
+                                       "sizes: 2 2 2\n"
+                                       "centerings: cell cell cell\n"
+                                       "kinds: none domain domain\n"
+                                       "encoding: raw\n"
+                                       "data file: b69.raw\n");
+  WriteRaw(dir + "/b69.raw", 8);
+
+  const auto  image = ReadNrrd(header);
+  std::string centering;
+  ASSERT_TRUE(itk::ExposeMetaData(image->GetMetaDataDictionary(), "NRRD_centerings[0]", centering));
+  EXPECT_EQ(centering, "cell");
+}
+
+// Reserved-key dispatch matched by prefix and ignored its result: an unmatched NRRD_
+// key was silently dropped on a read-write round trip (issue #6575, B63).
+TEST(NrrdImageIO, UnmatchedReservedKeySurvivesRoundTrip)
+{
+  const std::string dir = ::testing::TempDir();
+  auto              image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(2) });
+  image->Allocate();
+  image->FillBuffer(0);
+  itk::EncapsulateMetaData<int>(image->GetMetaDataDictionary(), "NRRD_pixel_original_axis", 2);
+
+  const std::string file = dir + "/b63.nrrd";
+  auto              writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetFileName(file);
+  writer->SetInput(image);
+  writer->SetImageIO(itk::NrrdImageIO::New());
+  writer->Update();
+  const auto restored = ReadNrrd(file);
+
+  std::string value;
+  EXPECT_TRUE(itk::ExposeMetaData(restored->GetMetaDataDictionary(), "NRRD_pixel_original_axis", value));
+}
+
+// A custom key whose prefix is a per-axis reserved field followed by a valid "[axis]"
+// suffix plus trailing text (e.g. NRRD_kinds[0]_vendor) was consumed as reserved and
+// silently dropped; exact-suffix dispatch must let it survive the round trip (B63).
+TEST(NrrdImageIO, PerAxisPrefixedCustomKeySurvivesRoundTrip)
+{
+  const std::string dir = ::testing::TempDir();
+  auto              image = ImageType::New();
+  image->SetRegions(ImageType::RegionType{ ImageType::IndexType{}, ImageType::SizeType::Filled(2) });
+  image->Allocate();
+  image->FillBuffer(0);
+  itk::EncapsulateMetaData<std::string>(image->GetMetaDataDictionary(), "NRRD_kinds[0]_vendor", "acme");
+
+  const std::string file = dir + "/b63-peraxis.nrrd";
+  auto              writer = itk::ImageFileWriter<ImageType>::New();
+  writer->SetFileName(file);
+  writer->SetInput(image);
+  writer->SetImageIO(itk::NrrdImageIO::New());
+  writer->Update();
+  const auto restored = ReadNrrd(file);
+
+  std::string value;
+  EXPECT_TRUE(itk::ExposeMetaData(restored->GetMetaDataDictionary(), "NRRD_kinds[0]_vendor", value));
+}


### PR DESCRIPTION
Fixes the `NrrdImageIO` writer's reserved-key dispatch (#6575, items B63 and Q82), the last non-vendored NrrdIO item from the audit ledger. Follows the merged #6674 snapshot import.

`NRRD_`-prefixed metadata keys were matched against reserved field names by prefix of the candidate's length, so `NRRD_space directions` was swallowed by the `space` handler and any unmatched `NRRD_` key (including the reader's own `NRRD_pixel_original_axis`) was silently dropped. Dispatch now requires an exact scalar match or an `[axis]` suffix, and unmatched keys fall back to the key/value writer. Also warns when a NRRD space is used verbatim because no LPS conversion is defined (Q82).

<details>
<summary>Tests and validation</summary>

New `Modules/IO/NRRD/test/itkNrrdImageIOGTest.cxx` with 4 tests:

- `NrrdImageIO.UnmatchedReservedKeySurvivesRoundTrip` — B63 fail-before/pass-after regression.
- `NrrdImageIO.RejectsExcessSizesAtMaximumDimension`, `NrrdImageIO.PartialAxisMinsYieldFiniteOrigin`, `NrrdImageIO.KindsNoneDoesNotClobberCentering` — ITK-side regression coverage for the vendored B67/B68/B69 fixes that landed via #6674.

Local: 74/75 NRRD-related tests pass (the exception is `ITKIONRRDKWStyleTest`, Not Run because KWStyle is not configured in the local build tree); `pre-commit run --all-files` clean.

</details>

<!--
provenance: claude-code session 2026-07-21
branch: bug-nrrdio-b63-6575 (cherry-pick of 261bf77c67b from bug-nrrdio-6575-rebased onto post-#6674 main)
dropped: vendored commits (superseded by #6674 snapshot) and 0-ITK-LOCAL-PATCHES.md DOC commit (obsolete under fork workflow)
post_merge_action: update issue #6575 status tables (B63/Q82 -> merged; branch bucket empties)
-->
