### PR TITLE
BUG: Recognize native big-endian single-precision MATLAB headers

### DIFF
--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1487,6 +1487,7 @@ set(
   itkMathSVDGTest.cxx
   itkMathLDLTGTest.cxx
   itkVnlCholeskyEngineGTest.cxx
+  itkVnlMatlabReadGTest.cxx
   itkMathDeterminantGTest.cxx
   itkVnlSVDEngineGTest.cxx
   itkMatrixExponentialGTest.cxx

--- a/Modules/Core/Common/test/itkVnlMatlabReadGTest.cxx
+++ b/Modules/Core/Common/test/itkVnlMatlabReadGTest.cxx
@@ -1,0 +1,103 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "vnl/vnl_matlab_read.h"
+#include "vnl/vnl_matlab_header.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+#include <sstream>
+
+namespace
+{
+// The writer emits the header in native byte order, so any legal type code read
+// back verbatim means the file is same-endian as the reader.
+std::stringstream
+MakeNativeStream(const vxl_int_32 typeCode, const std::array<float, 4> & values)
+{
+  vnl_matlab_header hdr;
+  std::memset(&hdr, 0, sizeof(hdr));
+  hdr.type = typeCode;
+  hdr.rows = 1;
+  hdr.cols = static_cast<vxl_int_32>(values.size());
+  hdr.imag = 0;
+  hdr.namlen = 2;
+
+  std::stringstream ss;
+  ss.write(reinterpret_cast<const char *>(&hdr), sizeof(hdr));
+  ss.write("x", 2);
+  ss.write(reinterpret_cast<const char *>(values.data()), sizeof(float) * values.size());
+  return ss;
+}
+} // namespace
+
+// All 8 legal single-precision/double-precision code combinations of
+// { little/big endian, column/row wise } must be recognized as native.
+TEST(VnlMatlabRead, NativeSinglePrecisionCodesAreNotSwapped)
+{
+  const std::array<float, 4> expected{ 1.5F, -2.25F, 3.0F, 0.125F };
+
+  for (const vxl_int_32 typeCode : { 10, 110, 1010, 1110 })
+  {
+    std::stringstream  ss = MakeNativeStream(typeCode, expected);
+    vnl_matlab_readhdr reader(ss);
+
+    ASSERT_TRUE(static_cast<bool>(reader)) << "type code " << typeCode;
+    EXPECT_TRUE(reader.is_single()) << "type code " << typeCode;
+    EXPECT_EQ(reader.rows(), 1) << "type code " << typeCode;
+    EXPECT_EQ(reader.cols(), 4) << "type code " << typeCode;
+    EXPECT_STREQ(reader.name(), "x") << "type code " << typeCode;
+
+    std::array<float, 4> actual{};
+    ASSERT_TRUE(reader.read_data(actual.data())) << "type code " << typeCode;
+    EXPECT_EQ(actual, expected) << "type code " << typeCode;
+  }
+}
+
+// A foreign-endian header must still be detected and byte-swapped.
+TEST(VnlMatlabRead, ForeignEndianHeaderIsSwapped)
+{
+  const std::array<float, 4> expected{ 1.5F, -2.25F, 3.0F, 0.125F };
+
+  std::stringstream native = MakeNativeStream(1010, expected);
+  std::string       bytes = native.str();
+
+  for (const size_t offset : { size_t{ 0 }, size_t{ 4 }, size_t{ 8 }, size_t{ 12 }, size_t{ 16 } })
+  {
+    byteswap::swap32(&bytes[offset]);
+  }
+  const size_t dataOffset = sizeof(vnl_matlab_header) + 2;
+  for (size_t offset = dataOffset; offset < bytes.size(); offset += 4)
+  {
+    byteswap::swap32(&bytes[offset]);
+  }
+
+  std::stringstream  ss(bytes);
+  vnl_matlab_readhdr reader(ss);
+
+  ASSERT_TRUE(static_cast<bool>(reader));
+  EXPECT_TRUE(reader.is_single());
+  EXPECT_EQ(reader.rows(), 1);
+  EXPECT_EQ(reader.cols(), 4);
+
+  std::array<float, 4> actual{};
+  ASSERT_TRUE(reader.read_data(actual.data()));
+  EXPECT_EQ(actual, expected);
+}

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matlab_read.cxx
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_matlab_read.cxx
@@ -138,6 +138,7 @@ vnl_matlab_readhdr::read_hdr()
     case 100:
     case 110:
     case 1000:
+    case 1010:
     case 1100:
     case 1110:
       need_swap = false;


### PR DESCRIPTION
Fixes #6575 item B91: the no-swap `switch` in `vnl_matlab_readhdr::read_hdr()` listed 7 of the 8 legal native MATLAB header type codes, omitting `1010` (big-endian, column-wise, single-precision) — the code vnl's own writer emits for float data on a big-endian host. Reading such a file on the host that wrote it byte-swapped the header and payload as though foreign. Reachable in ITK through `itkMatlabTransformIO` and `itkTxtTransformIO`.

Vendored-only change by maintainer decision — no upstream vxl submission planned.

<details>
<summary>Tests and validation</summary>

New `Modules/Core/Common/test/itkVnlMatlabReadGTest.cxx`:

- `VnlMatlabRead.NativeSinglePrecisionCodesAreNotSwapped` — all four native single-precision codes (10, 110, 1010, 1110) round-trip; fails before the fix on code 1010 (the swapped `namlen` field breaks the stream), passes after. Runs identically on either endianness because the crafted streams use native byte order.
- `VnlMatlabRead.ForeignEndianHeaderIsSwapped` — guards the foreign-endian swap path.

Local: fail-before/pass-after verified; `pre-commit run --all-files` clean.

</details>

<!--
provenance: claude-code session 2026-07-21
branch: bug-vnl-matlab-readhdr-6575 (worktree ITK-bug-vnl-matlab-readhdr-6575-src), commit 4071c0de26c
decision: user declined upstream vxl/vxl submission (vendored fix only)
post_merge_action: update issue #6575 tables (B91 -> merged; unclaimed bucket 5 -> 4)
-->
