### PR TITLE
Inverse transform should be the same type as the original

### DIFF
--- a/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
+++ b/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
@@ -85,6 +85,24 @@ TransformTest()
   td.m_Transform = TTransform::New();
   td.m_Inverse = TTransform::New();
   std::cout << "Testing " << td.m_Transform->GetNameOfClass() << std::endl;
+
+  // Test that GetInverseTransform() preserves the concrete transform type
+  auto inverseBase = td.m_Transform->GetInverseTransform();
+  if (inverseBase.IsNull())
+  {
+    std::cerr << "GetInverseTransform() returned null for " << td.m_Transform->GetNameOfClass() << std::endl;
+    return 1;
+  }
+  const auto * inverseConcrete = dynamic_cast<const TTransform *>(inverseBase.GetPointer());
+  if (inverseConcrete == nullptr)
+  {
+    std::cerr << "ERROR: GetInverseTransform() did not preserve concrete type for " << td.m_Transform->GetNameOfClass()
+              << std::endl;
+    std::cerr << "  Expected type: " << td.m_Transform->GetNameOfClass() << std::endl;
+    std::cerr << "  Actual type: " << inverseBase->GetNameOfClass() << std::endl;
+    return 1;
+  }
+
   itk::ThreadFunctionType pFunc = TestGetInverseThreadFunction<TTransform>;
   threader->SetSingleMethod(pFunc, &td);
   try


### PR DESCRIPTION
This reveals that a number of transforms provide parent type as inverse. I assume this is incorrect in at least most cases, and possibly even in all cases. Here are the problematic cases:
```log
ERROR: GetInverseTransform() did not preserve concrete type for AzimuthElevationToCartesianTransform
  Expected type: AzimuthElevationToCartesianTransform
  Actual type: AffineTransform
GetInverseTransform() returned null for BSplineTransform 
ERROR: GetInverseTransform() did not preserve concrete type for Euler3DTransform
  Expected type: Euler3DTransform
  Actual type: MatrixOffsetTransformBase
ERROR: GetInverseTransform() did not preserve concrete type for FixedCenterOfRotationAffineTransform
  Expected type: FixedCenterOfRotationAffineTransform
  Actual type: ScalableAffineTransform
ERROR: GetInverseTransform() did not preserve concrete type for QuaternionRigidTransform
  Expected type: QuaternionRigidTransform
  Actual type: MatrixOffsetTransformBase
ERROR: GetInverseTransform() did not preserve concrete type for ScaleLogarithmicTransform
  Expected type: ScaleLogarithmicTransform
  Actual type: ScaleTransform
ERROR: GetInverseTransform() did not preserve concrete type for Similarity3DTransform
  Expected type: Similarity3DTransform
  Actual type: MatrixOffsetTransformBase
ERROR: GetInverseTransform() did not preserve concrete type for VersorRigid3DTransform
  Expected type: VersorRigid3DTransform
  Actual type: MatrixOffsetTransformBase
ERROR: GetInverseTransform() did not preserve concrete type for VersorTransform
  Expected type: VersorTransform
  Actual type: MatrixOffsetTransformBase
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
