### PR TITLE
COMP: Advance remote-module pins to upstream default-branch HEAD

### DIFF
--- a/Modules/Remote/BioCell.remote.cmake
+++ b/Modules/Remote/BioCell.remote.cmake
@@ -49,5 +49,5 @@ It also has classes to represent a cell genome,
 whose expression is modeled by differential equations."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBioCell.git
-  GIT_TAG af317fbb92e8233fc00ba90f40d5f7b3eefd1560
+  GIT_TAG 5f8f4f8ec146991aac3a224e49aac7fc5ccd61a5
   )

--- a/Modules/Remote/CudaCommon.remote.cmake
+++ b/Modules/Remote/CudaCommon.remote.cmake
@@ -42,5 +42,5 @@ itk_fetch_module(
   "Framework for processing images with Cuda."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/RTKConsortium/ITKCudaCommon.git
-  GIT_TAG 558216d521e042aece0f37f1df65c4f94fc6778a
+  GIT_TAG 77a87cbf3db4b3dd3510406bb484b5ca070917ee
   )

--- a/Modules/Remote/HASI.remote.cmake
+++ b/Modules/Remote/HASI.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "High-throughput Applications for Skeletal Imaging."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/HASI.git
-  GIT_TAG 5d0e471320ce637b1894734b65e5447340ae7539
+  GIT_TAG 4e1e49ea3daf25300d4c035931aa867f1dbd2bf5
   )

--- a/Modules/Remote/IOOpenSlide.remote.cmake
+++ b/Modules/Remote/IOOpenSlide.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "ITK ImageIO for OpenSlide library supported file formats. These are generally TIFF-based microscopy formats."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOOpenSlide.git
-  GIT_TAG f568b480f1789e88fd64e5b54cc3a860b6824108
+  GIT_TAG 368a7d6e05939100efb069a36f6f61c316735320
   )

--- a/Modules/Remote/PerformanceBenchmarking.remote.cmake
+++ b/Modules/Remote/PerformanceBenchmarking.remote.cmake
@@ -59,5 +59,5 @@ For more information, see::
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking.git
-  GIT_TAG 63fec3013cccfe7e8b1b88a1d2d889f7e64e4469
+  GIT_TAG bcf9c92ec4e8fc1af323658231f81e008eb671e2
   )

--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/scifio/scifio-imageio.git
-  GIT_TAG a26cd493b433e24d16493c449a5c82ba9eeb58ae
+  GIT_TAG 247ada6ab94a2fd2f7ef4519358abd951ddb3649
   )

--- a/Modules/Remote/Shape.remote.cmake
+++ b/Modules/Remote/Shape.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   ITK external module for libraries originally developed in SPHARM-PDM 3D Slicer extension (https://github.com/NIRALUser/SPHARM-PDM)."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SlicerSALT/ITKShape.git
-  GIT_TAG 769fcefa7bca1f7ecad97fa5ce771869b807d482
+  GIT_TAG f11edc58c5a0bc6586972df74da6f3666541ac86
   )

--- a/Modules/Remote/SkullStrip.remote.cmake
+++ b/Modules/Remote/SkullStrip.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "A class to perform automatic skull-stripping for neuroimage analysis."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSkullStrip.git
-  GIT_TAG d3390ce7eb9884c9143420d4acf7a53f9031d931
+  GIT_TAG 1dab60549eb1a0a830d1b7af92546fa369afd12f
   )

--- a/Modules/Remote/Ultrasound.remote.cmake
+++ b/Modules/Remote/Ultrasound.remote.cmake
@@ -63,5 +63,5 @@ https://dx.doi.org/10.1109/ISBI.2016.7493437
 https://pdfs.semanticscholar.org/6bcd/1e7adbc24e15c928a7ad5af77bbd5da29c30.pdf"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKUltrasound.git
-  GIT_TAG b752d72b49da196d36440d643faf579cdc155884
+  GIT_TAG c666ccc3aa0cd0efa778ab840c73b81001bb2626
   )

--- a/Modules/Remote/VkFFTBackend.remote.cmake
+++ b/Modules/Remote/VkFFTBackend.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK FFT accelerated backends using the VkFFT library for Vulkan/CUDA/HIP/OpenCL compatibility."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend.git
-  GIT_TAG 46d2e3580e12c978ea3271365bf639e6065d4733
+  GIT_TAG 4d292493942db6757b11aa3ac0b8ca7887af2eef
   )

--- a/Modules/Remote/WebAssemblyInterface.remote.cmake
+++ b/Modules/Remote/WebAssemblyInterface.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "The ITK-Wasm WebAssemblyInterface module provides tools to a) build C/C++ code to WebAssembly-compatible processing pipelines, b) bridge local filesystems, JavaScript/Typescript data structures, and traditional file formats, c) transfer data efficiently in and out of the WebAssembly runtime."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITK-Wasm.git
-  GIT_TAG c853d6b1217ce47ac78e816ca1b6270b1cec448f
+  GIT_TAG 5284514a4f0f2dc8e15dfe6f2c5750bb87385075
   )


### PR DESCRIPTION
Advance 11 remote-module `GIT_TAG` pins to their upstream default-branch HEAD to reduce drift and pick up maintenance since the last bump.

**Local verification:** a clean Release build of the 8 buildable updated modules completed with zero build failures on macOS/arm64 (Apple clang). CudaCommon, IOOpenSlide, and Ultrasound are advanced but only exercisable in CI (no CUDA / OpenSlide / compatible VTK locally).

<details>
<summary>Per-module disposition</summary>

Built green locally: BioCell, HASI, PerformanceBenchmarking, SCIFIO, Shape, SkullStrip, VkFFTBackend, WebAssemblyInterface.

Advanced, CI-verified only: CudaCommon, IOOpenSlide, Ultrasound.

Left at existing pins (not advanced):
- **RTK** — HEAD has an ill-formed `std::abs<double>` (fix in RTKConsortium/RTK#975).
- **TractographyTRX** — HEAD's `trx_cpp` sub-build cannot resolve ITK's Eigen/ZLIB (fix in tee-ar-ex/ITKTractographyTRX#30).
- **TubeTK** — upstream header/implementation mismatch (`GetKernelMedialness`) present at all pins.
- **SphinxExamples** — verifiable only via its standalone build, not in-tree.
- **Cleaver** — bundled GoogleTest collides with ITK's when `BUILD_TESTING=ON`.
</details>

<!--
provenance: claude-code session 2026-07-22
verified-build: ITK-main-final-verify, fresh Release tree, 0 FAILED, ninja no-work-to-do
deferred-pins: RTK->RTKConsortium/RTK#975, TractographyTRX->tee-ar-ex#30 (head 72c1a18b)
-->
