### PR TITLE
COMP: Update remote-module pins toward buildable convergence with main

### DIFF
--- a/Modules/Remote/AdaptiveDenoising.remote.cmake
+++ b/Modules/Remote/AdaptiveDenoising.remote.cmake
@@ -57,5 +57,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/ntustison/ITKAdaptiveDenoising.git
-  GIT_TAG 24825c8d246e941334f47968553f0ae388851f0c
+  GIT_TAG 1d8aa47ca9e023d4f0c4c2930628e1da22a90c9d
   )

--- a/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
+++ b/Modules/Remote/AnalyzeObjectLabelMap.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   "AnalyzeObjectLabelMap plugin for ITK. From Insight Journal article with handle: https://www.insight-journal.org/browse/publication/178"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkAnalyzeObjectMap.git
-  GIT_TAG e6a8291f6066c4f0e732d422c3cdb0a5644f2ce6
+  GIT_TAG 7b3eb672e3dbd39b47926498a73a9ca0ef5fb3ca
   )

--- a/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
+++ b/Modules/Remote/AnisotropicDiffusionLBR.remote.cmake
@@ -64,5 +64,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR.git
-  GIT_TAG d46aab0e0c8f02b89eaa0420e61970559177683f
+  GIT_TAG 3dfe200b2253c08ee6ef0807c2e0f67a425ed901
   )

--- a/Modules/Remote/BSplineGradient.remote.cmake
+++ b/Modules/Remote/BSplineGradient.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Approximate an image's gradient from a b-spline fit to its intensity."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBSplineGradient.git
-  GIT_TAG 827b708f912b57519e9b1eec3551aea837e0cf7a
+  GIT_TAG 567e8ee2ade0fdcf113db510aee97ed265bebada
   )

--- a/Modules/Remote/BioCell.remote.cmake
+++ b/Modules/Remote/BioCell.remote.cmake
@@ -49,5 +49,5 @@ It also has classes to represent a cell genome,
 whose expression is modeled by differential equations."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBioCell.git
-  GIT_TAG 5a6ee6c0cef727d8a6c39b3333af0fced0611dee
+  GIT_TAG 5f8f4f8ec146991aac3a224e49aac7fc5ccd61a5
   )

--- a/Modules/Remote/BoneEnhancement.remote.cmake
+++ b/Modules/Remote/BoneEnhancement.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Various filters for enhancing cortical bones in quantitative computed tomography."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBoneEnhancement.git
-  GIT_TAG 658b9cb31f7216f604dfd35b187bd1ae80fd7506
+  GIT_TAG 479604dbc883e25a2147c436237b9ac35fc77c2c
   )

--- a/Modules/Remote/BoneMorphometry.remote.cmake
+++ b/Modules/Remote/BoneMorphometry.remote.cmake
@@ -52,5 +52,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKBoneMorphometry.git
-  GIT_TAG 47b8f352fb2cb7204d7a8b332847da438f268b35
+  GIT_TAG bbd753fe1977319783ffa6b1cef5ecf061873ca5
   )

--- a/Modules/Remote/Cleaver.remote.cmake
+++ b/Modules/Remote/Cleaver.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK module wrapping Cleaver functionalities used for MultiMaterial Tetrahedral Meshing."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SCIInstitute/ITKCleaver.git
-  GIT_TAG 249b2710c093a8f62c5e0cdbab728eebaba5b693
+  GIT_TAG 8ef9b6da475c8102a06bf54e5cb4cb6db251f229
   )

--- a/Modules/Remote/Cuberille.remote.cmake
+++ b/Modules/Remote/Cuberille.remote.cmake
@@ -68,5 +68,5 @@ And the related:
 "
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKCuberille.git
-  GIT_TAG 2b8509ad31beab7314146c19404ff0b49dcba6dc
+  GIT_TAG 4ba447f256a93428e56507178f92124bb91e3f3c
   )

--- a/Modules/Remote/CudaCommon.remote.cmake
+++ b/Modules/Remote/CudaCommon.remote.cmake
@@ -42,5 +42,5 @@ itk_fetch_module(
   "Framework for processing images with Cuda."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/RTKConsortium/ITKCudaCommon.git
-  GIT_TAG 0c20c4ef10d81910c8b2ac4e8446a1544fce3b60
+  GIT_TAG 77a87cbf3db4b3dd3510406bb484b5ca070917ee
   )

--- a/Modules/Remote/FPFH.remote.cmake
+++ b/Modules/Remote/FPFH.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/InsightSoftwareConsortium/ITKFPFH
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFPFH.git
-  GIT_TAG c2c86b2b1e457e1d99c038aec38e2dea9e67f2e9
+  GIT_TAG 08b59a4e51e4e248da1ddef535634db12285b9f1
   )

--- a/Modules/Remote/FastBilateral.remote.cmake
+++ b/Modules/Remote/FastBilateral.remote.cmake
@@ -50,5 +50,5 @@ Insight Journal article:
 https://insight-journal.org/browse/publication/692"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFastBilateral.git
-  GIT_TAG f524fcf4bbb574ed2554aa6e993b0d9946fa8b79
+  GIT_TAG 82a7180a49e939010043fc560de1a3020aa5ab8e
   )

--- a/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
+++ b/Modules/Remote/FixedPointInverseDisplacementField.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Computes the inverse of a displacement field."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKFixedPointInverseDisplacementField.git
-  GIT_TAG e38e8a3c5af0ffc6ee208e44b805b817d9836ab2
+  GIT_TAG 76525fe4cbd5eda9075107eede3c1d09deed4a4f
   )

--- a/Modules/Remote/GenericLabelInterpolator.remote.cmake
+++ b/Modules/Remote/GenericLabelInterpolator.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "A generic interpolator for multi-label images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKGenericLabelInterpolator.git
-  GIT_TAG ebf2436469ccf82c08fab54b7446f699ad0eae01
+  GIT_TAG 081575cdcc26b1a542d4c90feaf9250df5e104d9
   )

--- a/Modules/Remote/GrowCut.remote.cmake
+++ b/Modules/Remote/GrowCut.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITKGrowCut segments a 3D image from user-provided foreground and background seeds."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKGrowCut.git
-  GIT_TAG cbf93ab65117abfbf5798745117e34f22ff04728
+  GIT_TAG 56e4eae7d92496ec7d0bd023d033b8ddf22cbc0e
   )

--- a/Modules/Remote/HASI.remote.cmake
+++ b/Modules/Remote/HASI.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "High-throughput Applications for Skeletal Imaging."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/HASI.git
-  GIT_TAG d58acf4cda836bdedd1b7531dddc8ca7b20b396a
+  GIT_TAG 4e1e49ea3daf25300d4c035931aa867f1dbd2bf5
   )

--- a/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
+++ b/Modules/Remote/HigherOrderAccurateGradient.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   https://www.insight-journal.org/browse/publication/775"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKHigherOrderAccurateGradient.git
-  GIT_TAG 692f6b7416c05c2a0b1dc2ed952ac69081c44abc
+  GIT_TAG 60c060a49ac3a87ebf24eb407f1170112e22d88d
   )

--- a/Modules/Remote/IOFDF.remote.cmake
+++ b/Modules/Remote/IOFDF.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "FDFImageIO plugin for ITK. Authors Gleen Pierce/Nick Tustison/Kent Williams"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOFDF.git
-  GIT_TAG 79695870f4d2416b257db733624a3e8bfc38391d
+  GIT_TAG 3a3ff84c803d4226176078d32ddd0760c71a5b2c
   )

--- a/Modules/Remote/IOMeshSTL.remote.cmake
+++ b/Modules/Remote/IOMeshSTL.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   the STL (STereoLithography) file format. https://www.insight-journal.org/browse/publication/913"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOMeshSTL.git
-  GIT_TAG 31594eb088ef35897e7ce0f02077e8ce50454e01
+  GIT_TAG fb18e5d83415603d977279e0546bb55c1ece623d
   )

--- a/Modules/Remote/IOMeshSWC.remote.cmake
+++ b/Modules/Remote/IOMeshSWC.remote.cmake
@@ -47,6 +47,6 @@ itk_fetch_module(
   "Read meshes from SWC files, a format for representing neuron morphology."
   MODULE_COMPLIANCE_LEVEL 4
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOMeshSWC.git
-  GIT_TAG 6375295e7802c6a064c90d11f48b3ea238ac8d76
+  GIT_TAG 8ad2115be0661509d10922c9b9dbd9085f6b6091
   )
 mark_as_advanced(FORCE Module_IOMeshSWC)

--- a/Modules/Remote/IOOpenSlide.remote.cmake
+++ b/Modules/Remote/IOOpenSlide.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "ITK ImageIO for OpenSlide library supported file formats. These are generally TIFF-based microscopy formats."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOOpenSlide.git
-  GIT_TAG fb654552e240e50bd4121d431d88536d2c84e937
+  GIT_TAG 368a7d6e05939100efb069a36f6f61c316735320
   )

--- a/Modules/Remote/IOScanco.remote.cmake
+++ b/Modules/Remote/IOScanco.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "An ITK module to read and write Scanco microCT .isq files."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKIOScanco.git
-  GIT_TAG 10b80f69048e79ab3069e89635822a6851099278
+  GIT_TAG 2a6ac86c5af5dbcdc61b1e28067737e5a912c3a9
   )

--- a/Modules/Remote/IOTransformDCMTK.remote.cmake
+++ b/Modules/Remote/IOTransformDCMTK.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   files. See https://www.insight-journal.org/browse/publication/923"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIOTransformDCMTK.git
-  GIT_TAG e97e0e8c27809eea1834dd534a47fc06168e3e45
+  GIT_TAG acc3378f1d5207ae5bbc8d590616ceb70fe3c1c9
   )

--- a/Modules/Remote/IsotropicWavelets.remote.cmake
+++ b/Modules/Remote/IsotropicWavelets.remote.cmake
@@ -54,5 +54,5 @@ Cerdan, P.H. \"Steerable Isotropic Wavelets for Multiscale and Phase Analysis\".
   # Upstream repository was transferred from phcerdan to InsightSoftwareConsortium
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKIsotropicWavelets.git
-  GIT_TAG da594e25a7629568aca901a5e0fd435cc81cc601
+  GIT_TAG d3304e2addcfa1b8175d8b93c3e62c4dff81b738
   )

--- a/Modules/Remote/LabelErodeDilate.remote.cmake
+++ b/Modules/Remote/LabelErodeDilate.remote.cmake
@@ -53,5 +53,5 @@ itk_fetch_module(
   MODULE_COMPLIANCE_LEVEL 3
   #UPSTREAM_GIT_REPOSITORY
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate.git
-  GIT_TAG 22d8846dbe4368312aa3aa95ecfe3542ab894e15
+  GIT_TAG 535848354f8a58cde85dee0fef76619ce7eed38e
   )

--- a/Modules/Remote/LesionSizingToolkit.remote.cmake
+++ b/Modules/Remote/LesionSizingToolkit.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "Framework for determining the sizes of lesions in medical images."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/LesionSizingToolkit.git
-  GIT_TAG 58b95e8f54e8f270b2b221c519f7a49c2086bb11
+  GIT_TAG 8d5cba94e71dc24203dce077242943f81acfdcc9
   )

--- a/Modules/Remote/MGHIO.remote.cmake
+++ b/Modules/Remote/MGHIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "MGHIO ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkMGHImageIO.git
-  GIT_TAG 0adac35fa22945c7a5f3a63dd8d01454577c24d3
+  GIT_TAG af74507c1ddc82722637c37d1f5d169e3000553a
   )

--- a/Modules/Remote/MeshNoise.remote.cmake
+++ b/Modules/Remote/MeshNoise.remote.cmake
@@ -51,5 +51,5 @@ itk_fetch_module(
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMeshNoise.git
-  GIT_TAG a01fae4f1d637eb6d4a183d940b9ce79970db14e
+  GIT_TAG d1932b3487918a7c931f67430d33dd4b5ede427e
   )

--- a/Modules/Remote/MeshToPolyData.remote.cmake
+++ b/Modules/Remote/MeshToPolyData.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Convert an ITK Mesh to a data structure compatible with vtkPolyData."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMeshToPolyData.git
-  GIT_TAG 45454052790b9f01bc1e1baf0e9400f68a3f1363
+  GIT_TAG 000ca8267ae4adcef07fdd308ef69de6e6100548
   )

--- a/Modules/Remote/MinimalPathExtraction.remote.cmake
+++ b/Modules/Remote/MinimalPathExtraction.remote.cmake
@@ -48,6 +48,6 @@ itk_fetch_module(
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction.git
-  GIT_TAG 35dd8e83b7df2059876e6835a5741eb3d45973bf
+  GIT_TAG 72c32b00761c94bf45bc1a8e62493fd4a0d4b4b5
   )
 # Release v1.2.6

--- a/Modules/Remote/Montage.remote.cmake
+++ b/Modules/Remote/Montage.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Reconstruction of 3D volumetric dataset from a collection of 2D slices"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKMontage.git
-  GIT_TAG f310be543baf7b233d231c6040a2d509d62bacba
+  GIT_TAG f2ba56b24c81a0ac61639d349688d26673a65f73
   )

--- a/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
+++ b/Modules/Remote/MorphologicalContourInterpolation.remote.cmake
@@ -58,5 +58,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKMorphologicalContourInterpolation.git
-  GIT_TAG 821bf9b3ef8eaaab10391ed060dc9ca5e4d37b39
+  GIT_TAG c438c41e52dbc1f5b80b32de17aaec8fa48f6f5d
   )

--- a/Modules/Remote/MultipleImageIterator.remote.cmake
+++ b/Modules/Remote/MultipleImageIterator.remote.cmake
@@ -57,5 +57,5 @@ Schaerer J. \"A MultipleImageIterator for iterating over multiple images simulta
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/MultipleImageIterator.git
-  GIT_TAG 046e70f43f56ac1a0e32e083fb1fe1d1379a1f73
+  GIT_TAG 32f67c75cce9be0ceac7876428930be64d99a57b
   )

--- a/Modules/Remote/ParabolicMorphology.remote.cmake
+++ b/Modules/Remote/ParabolicMorphology.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   https://www.insight-journal.org/browse/publication/228"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKParabolicMorphology.git
-  GIT_TAG 4cfb99d9688184f579bf4fae4c8cf99ea61bb8e5
+  GIT_TAG a983b191ca9b81a3100a4b8943e89a004a08eb14
   )

--- a/Modules/Remote/PerformanceBenchmarking.remote.cmake
+++ b/Modules/Remote/PerformanceBenchmarking.remote.cmake
@@ -59,5 +59,5 @@ For more information, see::
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPerformanceBenchmarking.git
-  GIT_TAG 950921a642a720867c00c92c548312a4939da917
+  GIT_TAG bcf9c92ec4e8fc1af323658231f81e008eb671e2
   )

--- a/Modules/Remote/PhaseSymmetry.remote.cmake
+++ b/Modules/Remote/PhaseSymmetry.remote.cmake
@@ -55,5 +55,5 @@ https://www.insight-journal.org/browse/publication/846
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKPhaseSymmetry.git
-  GIT_TAG 4d9cba2d0529e29500c11fd25ac9c4c808a0279b
+  GIT_TAG 6d3ba9ff7a4f9d334f979e548c346a8234250d78
   )

--- a/Modules/Remote/PolarTransform.remote.cmake
+++ b/Modules/Remote/PolarTransform.remote.cmake
@@ -55,5 +55,5 @@ For more information, see the Insight Journal article:
   "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPolarTransform.git
-  GIT_TAG 930d44ac91d2994e4d604be67714f1ffb9cd065c
+  GIT_TAG 65b3c9509a8c8570a262e02ca283e412f77bafaa
   )

--- a/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
+++ b/Modules/Remote/PrincipalComponentsAnalysis.remote.cmake
@@ -52,5 +52,5 @@ A more detailed description can be found in the Insight Journal article:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKPrincipalComponentsAnalysis.git
-  GIT_TAG 2f8d8bffb37fca8875a674465af5e3d902432f30
+  GIT_TAG 2e713d887d52153399700c02874774fe5bee3c20
   )

--- a/Modules/Remote/RANSAC.remote.cmake
+++ b/Modules/Remote/RANSAC.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/InsightSoftwareConsortium/ITKRANSAC
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKRANSAC.git
-  GIT_TAG ed350fbabaf82c81167f41c6996e779425e87de4
+  GIT_TAG 0a5b2273b34ee4e94c8ff6a3bda37c6c9e0bd943
   )

--- a/Modules/Remote/RLEImage.remote.cmake
+++ b/Modules/Remote/RLEImage.remote.cmake
@@ -53,5 +53,5 @@ This work is supported by NIH grant R01 EB014346
 'Continued development and maintenance of the ITK-SNAP 3D image segmentation software'."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKRLEImage.git
-  GIT_TAG 85559c99ece93d695889dbc908c52efbc2bf50a9
+  GIT_TAG 03d1d9b5868d9f43bb4066637034cd667922cab9
   )

--- a/Modules/Remote/SCIFIO.remote.cmake
+++ b/Modules/Remote/SCIFIO.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "SCIFIO (Bioformats) ImageIO plugin for ITK"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/scifio/scifio-imageio.git
-  GIT_TAG 1054ece893ee072bdb8124c45ce207de00af280f
+  GIT_TAG 247ada6ab94a2fd2f7ef4519358abd951ddb3649
   )

--- a/Modules/Remote/Shape.remote.cmake
+++ b/Modules/Remote/Shape.remote.cmake
@@ -49,5 +49,5 @@ itk_fetch_module(
   ITK external module for libraries originally developed in SPHARM-PDM 3D Slicer extension (https://github.com/NIRALUser/SPHARM-PDM)."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/SlicerSALT/ITKShape.git
-  GIT_TAG eb38c9603e78f03e7ed085e3bdac450ad8000dcb
+  GIT_TAG f11edc58c5a0bc6586972df74da6f3666541ac86
   )

--- a/Modules/Remote/SimpleITKFilters.remote.cmake
+++ b/Modules/Remote/SimpleITKFilters.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   contains a discrete hessian, and a composite filter to compute objectness."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSimpleITKFilters.git
-  GIT_TAG bb896868fc6480835495d0da4356d5db009592a6
+  GIT_TAG 372ab10343df104063ca6a55eb72f7d5fe830d7b
   )

--- a/Modules/Remote/SkullStrip.remote.cmake
+++ b/Modules/Remote/SkullStrip.remote.cmake
@@ -46,5 +46,5 @@ itk_fetch_module(
   "A class to perform automatic skull-stripping for neuroimage analysis."
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSkullStrip.git
-  GIT_TAG da5821af3e2fe8f4c2d881d4fd961b17d0684b3e
+  GIT_TAG 1dab60549eb1a0a830d1b7af92546fa369afd12f
   )

--- a/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
+++ b/Modules/Remote/SmoothingRecursiveYvvGaussianFilter.remote.cmake
@@ -48,5 +48,5 @@ itk_fetch_module(
   MODULE_COMPLIANCE_LEVEL 2
   #UPSTREAM_REPO GIT_REPOSITORY https://github.com/Inria-Asclepios/SmoothingRecursiveYvvGaussianFilter
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter.git
-  GIT_TAG f6bd553266aa1c1c3cdebc9033fd3b21f1f734c4
+  GIT_TAG 8cfb58e73158d6ab779d2171b624c73929c0b35d
   )

--- a/Modules/Remote/SplitComponents.remote.cmake
+++ b/Modules/Remote/SplitComponents.remote.cmake
@@ -50,5 +50,5 @@ itk::Image of, for example, itk::Vector, itk::CovariantVector, or
 itk::SymmetricSecondRankTensor. https://www.insight-journal.org/browse/publication/774"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSplitComponents.git
-  GIT_TAG 18058073604ff6f5a5e878edc494e2aa3522d6ca
+  GIT_TAG 94fde65cae6883c9a0f1508c37c501c2ad989cdd
   )

--- a/Modules/Remote/Strain.remote.cmake
+++ b/Modules/Remote/Strain.remote.cmake
@@ -56,5 +56,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKStrain.git
-  GIT_TAG 461e2a1deef3e12d54b75784398eccb3475d8e5c
+  GIT_TAG 7bf4af4726b255d5569e5d44067f38594d3dfd0a
   )

--- a/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
+++ b/Modules/Remote/SubdivisionQuadEdgeMeshFilter.remote.cmake
@@ -51,5 +51,5 @@ See the following Insight Journal's publication:
   https://www.insight-journal.org/browse/publication/831"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/itkSubdivisionQuadEdgeMeshFilter
-  GIT_TAG 6e30c49f7ef9a5b4854bff39834f9d7e181130aa
+  GIT_TAG a8f6a68d5c1339b7727e053103cf678adfa77f50
   )

--- a/Modules/Remote/TextureFeatures.remote.cmake
+++ b/Modules/Remote/TextureFeatures.remote.cmake
@@ -57,5 +57,5 @@ For more information, see:
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTextureFeatures.git
-  GIT_TAG e8a9020eddc0310ed490dfe5afc61e065dc95831
+  GIT_TAG 06571a93cfed79930cba30920e5fa0c665b05049
   )

--- a/Modules/Remote/Thickness3D.remote.cmake
+++ b/Modules/Remote/Thickness3D.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "Tools for 3D thickness measurement"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKThickness3D.git
-  GIT_TAG 36b2c7a229be70c5b5afbba1b7d65fe26c9cbaeb
+  GIT_TAG 9120b22127fa3a5009ef6b5d420f9a256ec4ad30
   )

--- a/Modules/Remote/TotalVariation.remote.cmake
+++ b/Modules/Remote/TotalVariation.remote.cmake
@@ -52,5 +52,5 @@ https://github.com/albarji/proxTV
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTotalVariation.git
-  GIT_TAG 0b4f9450f7c98b8db6dee5990bbd9be5d6e6c4d2
+  GIT_TAG 97ea40c4ad99a6846a6a30fff6e136847811a579
   )

--- a/Modules/Remote/TwoProjectionRegistration.remote.cmake
+++ b/Modules/Remote/TwoProjectionRegistration.remote.cmake
@@ -62,5 +62,5 @@ Wu, J. \"ITK-Based Implementation of Two-Projection 2D/3D Registration Method wi
 "
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKTwoProjectionRegistration.git
-  GIT_TAG 2cf7d9522031c613a3edcdcd76aee2896536672e
+  GIT_TAG 28bde5b8d1050493fa391c4d8e82274cac690f3a
   )

--- a/Modules/Remote/Ultrasound.remote.cmake
+++ b/Modules/Remote/Ultrasound.remote.cmake
@@ -63,5 +63,5 @@ https://dx.doi.org/10.1109/ISBI.2016.7493437
 https://pdfs.semanticscholar.org/6bcd/1e7adbc24e15c928a7ad5af77bbd5da29c30.pdf"
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/KitwareMedical/ITKUltrasound.git
-  GIT_TAG b351ac104616b715b06e83aeec7fd793e126460b
+  GIT_TAG c666ccc3aa0cd0efa778ab840c73b81001bb2626
   )

--- a/Modules/Remote/VariationalRegistration.remote.cmake
+++ b/Modules/Remote/VariationalRegistration.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   "A module to perform variational image registration. https://www.insight-journal.org/browse/publication/917"
   MODULE_COMPLIANCE_LEVEL 2
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKVariationalRegistration.git
-  GIT_TAG 7634013fa2b661eda81d79e52b804f669ec0ce79
+  GIT_TAG 1941db6bec69fe9332fe6cbec8b0256941facaa9
   )

--- a/Modules/Remote/VkFFTBackend.remote.cmake
+++ b/Modules/Remote/VkFFTBackend.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "ITK FFT accelerated backends using the VkFFT library for Vulkan/CUDA/HIP/OpenCL compatibility."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKVkFFTBackend.git
-  GIT_TAG 4574a6106f75c72146a2a358d0eea39e451de86b
+  GIT_TAG 4d292493942db6757b11aa3ac0b8ca7887af2eef
   )

--- a/Modules/Remote/WebAssemblyInterface.remote.cmake
+++ b/Modules/Remote/WebAssemblyInterface.remote.cmake
@@ -47,5 +47,5 @@ itk_fetch_module(
   "The ITK-Wasm WebAssemblyInterface module provides tools to a) build C/C++ code to WebAssembly-compatible processing pipelines, b) bridge local filesystems, JavaScript/Typescript data structures, and traditional file formats, c) transfer data efficiently in and out of the WebAssembly runtime."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITK-Wasm.git
-  GIT_TAG 982daf8ea91d5ecb052c3bf707542dbc43a4d1ef
+  GIT_TAG 5284514a4f0f2dc8e15dfe6f2c5750bb87385075
   )


### PR DESCRIPTION
Advance release-5.4 remote-module `GIT_TAG` pins to reduce drift from `main` while keeping the branch buildable on release-5.4's module system (56 pins).

For the 41 modules already ingested into `main` and archived upstream, the pin is the **last commit before large-scale code removal** — the archival commit rewrites `README.rst` to `info.rst` and deletes sources, which breaks `itk-module.cmake`'s `file(READ README.rst)`. Live modules advance to their upstream default-branch HEAD.

**Local verification:** a clean Release build of the 53 buildable updated modules completed with zero build failures on macOS/arm64. CudaCommon, IOOpenSlide, and Ultrasound are advanced but only exercisable in CI.

<details>
<summary>Special-case pins</summary>

- **TotalVariation** `97ea40c4` — the newest commit before it adopts the ITK-6-only `itk_module_target(NAMESPACE)`.
- **LesionSizingToolkit** `8d5cba94` — the newest commit before its ITK-6 `ITK::` namespaced-target migration.
- **Archived (41)** — pinned before README.rst→info.rst / source deletion, so the module still configures under ITK 5.4.
</details>

<details>
<summary>Left at existing pins (not advanced)</summary>

- **RTK** — `std::abs<double>` (RTKConsortium/RTK#975), plus a 5.4-incompatible lp_solve target-usage refactor.
- **SphinxExamples** — bumping regressed the in-tree build; verifiable only standalone.
- **TubeTK** — upstream `GetKernelMedialness` header/impl mismatch at all pins.
- **TractographyTRX** — not added on 5.4 pending tee-ar-ex/ITKTractographyTRX#30.
</details>

<!--
provenance: claude-code session 2026-07-22
verified-build: ITK-rel54-final-verify, fresh Release tree, 53 modules, 0 FAILED (TubeTK reverted out)
archived-pin-rule: last commit before large-scale code removal (pre-archival-tombstone)
deferred-pins: RTK->RTKConsortium/RTK#975 (+lp_solve f31ee2ad), TractographyTRX->tee-ar-ex#30
-->
