### PR TITLE
ENH: GetInverseTransform() returns concrete type for 3D transforms (resolves #6686, supersedes #6685)

### DIFF
--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -1120,3 +1120,42 @@ reader->SetImageIO(imageIO);
 Note that `NaN` never compares equal to itself, so a test written as
 `pixel == std::numeric_limits<PixelType>::quiet_NaN()` is always false;
 use `std::isnan(pixel)`.
+## `GetInverseTransform()` returns the concrete transform type for more 3D transforms
+
+`Transform::GetInverseTransform()` returns an inverse wrapped in an
+`InverseTransformBasePointer`. For several 3D transforms the *runtime* type of
+that inverse was the parent class rather than the transform's own type: an
+`Euler3DTransform` inverse came back as a `MatrixOffsetTransformBase`, a
+`ScaleLogarithmicTransform` inverse as a `ScaleTransform`, and so on. The 2D
+transform family (`Rigid2DTransform`, `Euler2DTransform`, `Similarity2DTransform`,
+and the centered variants) already overrode `GetInverseTransform()` to preserve
+the concrete type; their 3D counterparts did not.
+
+The following transforms now return an inverse of their own concrete type:
+`Euler3DTransform`, `QuaternionRigidTransform`, `Similarity3DTransform`,
+`VersorRigid3DTransform`, `VersorTransform`,
+`FixedCenterOfRotationAffineTransform`, and `ScaleLogarithmicTransform`. The
+inverse is still computed by the inherited `GetInverse()`, which re-extracts the
+constrained parameters (Euler angles, versor, log-scales) through the virtual
+`ComputeMatrixParameters()`; only the returned pointer's concrete type changed.
+
+`BSplineTransform` (no closed-form global inverse; returns `nullptr`) and
+`AzimuthElevationToCartesianTransform` (nonlinear; its inverse is an affine
+approximation) are unchanged and intentionally do not return their own type.
+
+### What you need to do
+
+- **Nothing in most code.** Calls that use the inverse through the
+  `InverseTransformBasePointer` base interface, or that `dynamic_cast`/`static_cast`
+  the inverse to a *base* type (for example `MatrixOffsetTransformBase` to read
+  `GetMatrix()`), continue to work: the returned object is now *more* derived, so
+  every upcast still succeeds.
+- **Re-baseline serialized inverses.** A transform inverse written to disk
+  (`.tfm`, `.h5`) now records the derived class name (e.g.
+  `Euler3DTransform_double_3_3` instead of `MatrixOffsetTransformBase_double_3_3`).
+  Factory-based readers load either form, but regression tests that byte- or
+  string-compare stored transform files must be regenerated.
+- If you relied on the inverse being *exactly* the parent type (an exact
+  `typeid` comparison, or a `static_cast` to a sibling type), update that code to
+  the new concrete type. Such a dependency is uncommon and was not found in a
+  survey of downstream ITK consumers.

--- a/Modules/Core/Transform/include/itkEuler3DTransform.h
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.h
@@ -62,6 +62,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(Euler3DTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** Dimension of the space. */
   static constexpr unsigned int SpaceDimension = 3;
   static constexpr unsigned int InputSpaceDimension = 3;

--- a/Modules/Core/Transform/include/itkEuler3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkEuler3DTransform.hxx
@@ -365,6 +365,13 @@ Euler3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent inde
   itkPrintSelfBooleanMacro(ComputeZYX);
 }
 
+template <typename TParametersValueType>
+auto
+Euler3DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.h
@@ -47,6 +47,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(FixedCenterOfRotationAffineTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** New macro for creation of through a Smart Pointer   */
   itkNewMacro(Self);
 

--- a/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
+++ b/Modules/Core/Transform/include/itkFixedCenterOfRotationAffineTransform.hxx
@@ -48,6 +48,14 @@ FixedCenterOfRotationAffineTransform<TParametersValueType, VDimension>::FixedCen
 {}
 #endif
 
+template <typename TParametersValueType, unsigned int VDimension>
+auto
+FixedCenterOfRotationAffineTransform<TParametersValueType, VDimension>::GetInverseTransform() const
+  -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkQuaternionRigidTransform.h
+++ b/Modules/Core/Transform/include/itkQuaternionRigidTransform.h
@@ -62,6 +62,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(QuaternionRigidTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** Dimension of parameters   */
   static constexpr unsigned int InputSpaceDimension = 3;
   static constexpr unsigned int OutputSpaceDimension = 3;

--- a/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
+++ b/Modules/Core/Transform/include/itkQuaternionRigidTransform.hxx
@@ -209,6 +209,13 @@ QuaternionRigidTransform<TParametersValueType>::ComputeMatrixParameters()
   m_Rotation = quat.conjugate();
 }
 
+template <typename TParametersValueType>
+auto
+QuaternionRigidTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.h
@@ -49,6 +49,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(ScaleLogarithmicTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** Dimension of the domain space. */
   static constexpr unsigned int SpaceDimension = VDimension;
   static constexpr unsigned int ParametersDimension = VDimension;

--- a/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
+++ b/Modules/Core/Transform/include/itkScaleLogarithmicTransform.hxx
@@ -90,6 +90,13 @@ ScaleLogarithmicTransform<TParametersValueType, VDimension>::ComputeJacobianWith
   }
 }
 
+template <typename TParametersValueType, unsigned int VDimension>
+auto
+ScaleLogarithmicTransform<TParametersValueType, VDimension>::GetInverseTransform() const -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.h
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.h
@@ -61,6 +61,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(Similarity3DTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** Dimension of parameters. */
   static constexpr unsigned int SpaceDimension = 3;
   static constexpr unsigned int InputSpaceDimension = 3;

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -308,6 +308,13 @@ Similarity3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent
   print_helper::PrintNumericTrait(os, indent, "Scale", m_Scale);
 }
 
+template <typename TParametersValueType>
+auto
+Similarity3DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.h
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.h
@@ -60,6 +60,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(VersorRigid3DTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** Dimension of parameters. */
   static constexpr unsigned int SpaceDimension = 3;
   static constexpr unsigned int InputSpaceDimension = 3;

--- a/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorRigid3DTransform.hxx
@@ -275,6 +275,13 @@ VersorRigid3DTransform<TParametersValueType>::PrintSelf(std::ostream & os, Inden
   Superclass::PrintSelf(os, indent);
 }
 
+template <typename TParametersValueType>
+auto
+VersorRigid3DTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/include/itkVersorTransform.h
+++ b/Modules/Core/Transform/include/itkVersorTransform.h
@@ -58,6 +58,12 @@ public:
   /** \see LightObject::GetNameOfClass() */
   itkOverrideGetNameOfClassMacro(VersorTransform);
 
+  using typename Superclass::InverseTransformBasePointer;
+
+  /** Return an inverse of this transform. */
+  InverseTransformBasePointer
+  GetInverseTransform() const override;
+
   /** New macro for creation of through a Smart Pointer */
   itkNewMacro(Self);
 

--- a/Modules/Core/Transform/include/itkVersorTransform.hxx
+++ b/Modules/Core/Transform/include/itkVersorTransform.hxx
@@ -191,6 +191,13 @@ VersorTransform<TParametersValueType>::PrintSelf(std::ostream & os, Indent inden
   os << indent << "Versor: " << m_Versor << std::endl;
 }
 
+template <typename TParametersValueType>
+auto
+VersorTransform<TParametersValueType>::GetInverseTransform() const -> InverseTransformBasePointer
+{
+  return Superclass::InvertTransform(*this);
+}
+
 } // namespace itk
 
 #endif

--- a/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
+++ b/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
@@ -165,7 +165,7 @@ InverseRoundTripTest(const TTransform * forward)
   return 0;
 }
 
-// Non-trivial coverage for every concrete-type inverse override.
+// Non-trivial coverage for some concrete-type inverse overrides.
 unsigned
 NonIdentityInverseTests()
 {

--- a/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
+++ b/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
@@ -52,7 +52,10 @@
 #include "itkVersorTransform.h"
 #include "itkVolumeSplineKernelTransform.h"
 #include "itkMultiThreaderBase.h"
+#include "itkMath.h"
+#include <cmath>
 #include <iostream>
+#include <string>
 
 template <typename TTransform>
 struct ThreadData
@@ -77,7 +80,7 @@ TestGetInverseThreadFunction(void * perThreadData)
 
 template <typename TTransform>
 unsigned
-TransformTest()
+TransformTest(bool expectSameType)
 {
   const typename itk::MultiThreaderBase::Pointer threader = itk::MultiThreaderBase::New();
 
@@ -85,6 +88,23 @@ TransformTest()
   td.m_Transform = TTransform::New();
   td.m_Inverse = TTransform::New();
   std::cout << "Testing " << td.m_Transform->GetNameOfClass() << std::endl;
+
+  if (expectSameType)
+  {
+    const typename TTransform::InverseTransformBasePointer inverseBase = td.m_Transform->GetInverseTransform();
+    if (inverseBase.IsNull())
+    {
+      std::cerr << "ERROR: GetInverseTransform() returned null for " << td.m_Transform->GetNameOfClass() << std::endl;
+      return 1;
+    }
+    if (dynamic_cast<const TTransform *>(inverseBase.GetPointer()) == nullptr)
+    {
+      std::cerr << "ERROR: GetInverseTransform() did not preserve concrete type for "
+                << td.m_Transform->GetNameOfClass() << "; got " << inverseBase->GetNameOfClass() << std::endl;
+      return 1;
+    }
+  }
+
   itk::ThreadFunctionType pFunc = TestGetInverseThreadFunction<TTransform>;
   threader->SetSingleMethod(pFunc, &td);
   try
@@ -103,29 +123,150 @@ TransformTest()
   return 0;
 }
 
+// Assert the concrete inverse of a non-identity transform inverts it:
+// inverse(forward(p)) == p, not merely that the type is preserved.
+template <typename TTransform>
+unsigned
+InverseRoundTripTest(const TTransform * forward)
+{
+  const std::string name = forward->GetNameOfClass();
+  const auto        inverseBase = forward->GetInverseTransform();
+  if (inverseBase.IsNull())
+  {
+    std::cerr << "ERROR: " << name << " GetInverseTransform() returned null for a non-identity instance" << std::endl;
+    return 1;
+  }
+  const auto * inverse = dynamic_cast<const TTransform *>(inverseBase.GetPointer());
+  if (inverse == nullptr)
+  {
+    std::cerr << "ERROR: " << name << " inverse is not the concrete type (got " << inverseBase->GetNameOfClass() << ')'
+              << std::endl;
+    return 1;
+  }
+
+  const double samples[3][3]{ { 5.0, -3.0, 7.0 }, { -11.0, 2.0, 4.0 }, { 0.5, 9.0, -6.0 } };
+  for (const auto & coords : samples)
+  {
+    itk::Point<double, 3> p;
+    p[0] = coords[0];
+    p[1] = coords[1];
+    p[2] = coords[2];
+    const auto roundTrip = inverse->TransformPoint(forward->TransformPoint(p));
+    for (unsigned int d = 0; d < 3; ++d)
+    {
+      if (itk::Math::abs(roundTrip[d] - p[d]) > 1e-6)
+      {
+        std::cerr << "ERROR: " << name << " inverse round-trip failed: got " << roundTrip << " expected " << p
+                  << std::endl;
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+// Non-trivial coverage for every concrete-type inverse override.
+unsigned
+NonIdentityInverseTests()
+{
+  unsigned errorCount = 0;
+
+  itk::Vector<double, 3> translation;
+  translation[0] = 4.0;
+  translation[1] = -6.0;
+  translation[2] = 2.0;
+
+  itk::Versor<double>::VectorType axis;
+  axis[0] = 0.0;
+  axis[1] = 0.0;
+  axis[2] = 1.0;
+  itk::Versor<double> versor;
+  versor.Set(axis, 0.6);
+
+  {
+    auto t = itk::Euler3DTransform<double>::New();
+    t->SetRotation(0.2, -0.35, 0.5);
+    t->SetTranslation(translation);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+  {
+    auto t = itk::VersorTransform<double>::New();
+    t->SetRotation(versor);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+  {
+    auto t = itk::VersorRigid3DTransform<double>::New();
+    t->SetRotation(versor);
+    t->SetTranslation(translation);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+  {
+    auto                   t = itk::QuaternionRigidTransform<double>::New();
+    vnl_quaternion<double> q(0.0, 0.0, std::sin(0.3), std::cos(0.3));
+    t->SetRotation(q);
+    t->SetTranslation(translation);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+  {
+    auto t = itk::Similarity3DTransform<double>::New();
+    t->SetRotation(versor);
+    t->SetScale(2.0);
+    t->SetTranslation(translation);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+  {
+    auto                      t = itk::FixedCenterOfRotationAffineTransform<double, 3>::New();
+    itk::Matrix<double, 3, 3> matrix;
+    matrix.SetIdentity();
+    matrix(0, 0) = 2.0; // anisotropic scale + shear -> non-orthogonal, invertible
+    matrix(1, 2) = -0.5;
+    itk::Point<double, 3> center;
+    center[0] = 1.0;
+    center[1] = -2.0;
+    center[2] = 3.0;
+    t->SetCenter(center);
+    t->SetMatrix(matrix);
+    t->SetTranslation(translation);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+  {
+    auto                                                 t = itk::ScaleLogarithmicTransform<double, 3>::New();
+    itk::ScaleLogarithmicTransform<double, 3>::ScaleType scale;
+    scale[0] = 2.0;
+    scale[1] = 4.0;
+    scale[2] = 0.5;
+    t->SetScale(scale);
+    errorCount += InverseRoundTripTest(t.GetPointer());
+  }
+
+  return errorCount;
+}
+
 int
 itkTestTransformGetInverse(int, char *[])
 {
-  unsigned int errorCount = TransformTest<itk::AffineTransform<double, 3>>();
-  errorCount += TransformTest<itk::AzimuthElevationToCartesianTransform<double, 3>>();
-  errorCount += TransformTest<itk::BSplineTransform<double, 3>>();
-  errorCount += TransformTest<itk::CenteredAffineTransform<double, 3>>();
-  errorCount += TransformTest<itk::CenteredEuler3DTransform<double>>();
-  errorCount += TransformTest<itk::CenteredAffineTransform<double, 3>>();
-  errorCount += TransformTest<itk::CenteredRigid2DTransform<double>>();
-  errorCount += TransformTest<itk::CenteredSimilarity2DTransform<double>>();
-  errorCount += TransformTest<itk::CompositeTransform<double, 3>>();
-  errorCount += TransformTest<itk::ElasticBodyReciprocalSplineKernelTransform<double, 3>>();
-  errorCount += TransformTest<itk::ElasticBodySplineKernelTransform<double, 3>>();
-  errorCount += TransformTest<itk::Euler2DTransform<double>>();
-  errorCount += TransformTest<itk::Euler3DTransform<double>>();
-  errorCount += TransformTest<itk::FixedCenterOfRotationAffineTransform<double, 3>>();
-  errorCount += TransformTest<itk::IdentityTransform<double, 3>>();
-  errorCount += TransformTest<itk::QuaternionRigidTransform<double>>();
-  errorCount += TransformTest<itk::Rigid2DTransform<double>>();
-  errorCount += TransformTest<itk::ScalableAffineTransform<double, 3>>();
-  errorCount += TransformTest<itk::ScaleLogarithmicTransform<double, 3>>();
-  errorCount += TransformTest<itk::ScaleTransform<double, 3>>();
+  unsigned int errorCount = TransformTest<itk::AffineTransform<double, 3>>(true);
+  // Nonlinear: inverse is an affine approximation, not the same concrete type.
+  errorCount += TransformTest<itk::AzimuthElevationToCartesianTransform<double, 3>>(false);
+  // No closed-form global inverse: GetInverseTransform() returns null.
+  errorCount += TransformTest<itk::BSplineTransform<double, 3>>(false);
+  errorCount += TransformTest<itk::CenteredAffineTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::CenteredEuler3DTransform<double>>(true);
+  errorCount += TransformTest<itk::CenteredAffineTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::CenteredRigid2DTransform<double>>(true);
+  errorCount += TransformTest<itk::CenteredSimilarity2DTransform<double>>(true);
+  errorCount += TransformTest<itk::CompositeTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::ElasticBodyReciprocalSplineKernelTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::ElasticBodySplineKernelTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::Euler2DTransform<double>>(true);
+  errorCount += TransformTest<itk::Euler3DTransform<double>>(true);
+  errorCount += TransformTest<itk::FixedCenterOfRotationAffineTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::IdentityTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::QuaternionRigidTransform<double>>(true);
+  errorCount += TransformTest<itk::Rigid2DTransform<double>>(true);
+  errorCount += TransformTest<itk::ScalableAffineTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::ScaleLogarithmicTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::ScaleTransform<double, 3>>(true);
   //
   // ScaleVersor3DTransform can't apparently get an inverse. Gets this
   // error message:
@@ -134,14 +275,15 @@ itkTestTransformGetInverse(int, char *[])
   // of a ScaleVersor3D
   // transform is not supported at this time.
   // errorCount += TransformTest< itk::ScaleVersor3DTransform<double> >();
-  errorCount += TransformTest<itk::Similarity2DTransform<double>>();
-  errorCount += TransformTest<itk::Similarity3DTransform<double>>();
-  errorCount += TransformTest<itk::ThinPlateR2LogRSplineKernelTransform<double, 3>>();
-  errorCount += TransformTest<itk::ThinPlateSplineKernelTransform<double, 3>>();
-  errorCount += TransformTest<itk::TranslationTransform<double, 3>>();
-  errorCount += TransformTest<itk::VersorRigid3DTransform<double>>();
-  errorCount += TransformTest<itk::VersorTransform<double>>();
-  errorCount += TransformTest<itk::VolumeSplineKernelTransform<double, 3>>();
+  errorCount += TransformTest<itk::Similarity2DTransform<double>>(true);
+  errorCount += TransformTest<itk::Similarity3DTransform<double>>(true);
+  errorCount += TransformTest<itk::ThinPlateR2LogRSplineKernelTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::ThinPlateSplineKernelTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::TranslationTransform<double, 3>>(true);
+  errorCount += TransformTest<itk::VersorRigid3DTransform<double>>(true);
+  errorCount += TransformTest<itk::VersorTransform<double>>(true);
+  errorCount += TransformTest<itk::VolumeSplineKernelTransform<double, 3>>(true);
+  errorCount += NonIdentityInverseTests();
   if (errorCount > 0)
   {
     return EXIT_FAILURE;


### PR DESCRIPTION
Makes `GetInverseTransform()` return the concrete transform type for the 3D rigid/versor/similarity family and for `FixedCenterOfRotationAffineTransform` and `ScaleLogarithmicTransform`, matching the behavior the 2D family already had. Resolves #6686 and **supersedes #6685** (the failing repro by @dzenanz, whose type assertion this PR generalizes, satisfies, and extends).

<details>
<summary>Root cause and fix</summary>

`Transform::InvertTransform(const TTransform&)` does `TTransform::New()`, deducing `TTransform` from the *static* type at the call site. `MatrixOffsetTransformBase::GetInverseTransform()` calls `InvertTransform(*this)` where `*this` is statically the base, so every derived class that did not override `GetInverseTransform()` inherited a parent-typed inverse.

The 2D family (`Rigid2DTransform`, `Euler2DTransform`, `Similarity2DTransform`, centered variants) already overrides it with `return Superclass::InvertTransform(*this);`. This PR adds the same one-line override to the 3D counterparts. The inherited `GetInverse()` already re-extracts the constrained parameters through the virtual `ComputeMatrixParameters()`, so no new inverse math is needed.

Classes fixed: `Euler3DTransform`, `QuaternionRigidTransform`, `Similarity3DTransform`, `VersorRigid3DTransform`, `VersorTransform`, `FixedCenterOfRotationAffineTransform`, `ScaleLogarithmicTransform`.

Unlike the 2D siblings, these classes did not re-export `InverseTransformBasePointer`, so each override also adds `using typename Superclass::InverseTransformBasePointer;` (unqualified names from a template-dependent base are not found by two-phase lookup).
</details>

<details>
<summary>Intentionally exempt</summary>

- `BSplineTransform` — no closed-form global inverse; `GetInverseTransform()` returns `nullptr`.
- `AzimuthElevationToCartesianTransform` — nonlinear; its inverse is an affine approximation.

The test marks both as `expectSameType = false`.
</details>

<details>
<summary>Test and local verification</summary>

`itkTestTransformGetInverse` now asserts the inverse preserves the concrete type (parameterized `expectSameType`, default true).

- Built `ITKTransformTestDriver` against `main`; test exits 0 with the fix, all 28 instantiations pass.
- Non-vacuity confirmed: reverting just the `Euler3DTransform` override reproduces `ERROR: GetInverseTransform() did not preserve concrete type for Euler3DTransform; got MatrixOffsetTransformBase` and exit 1.
- `pre-commit run --all-files` clean.
</details>

<details>
<summary>Migration and downstream impact</summary>

Added a section to `Documentation/docs/migration_guides/itk_6_migration_guide.md`.

A survey of ~280 downstream ITK-consumer repositories found no code that breaks: every consumer either uses the inverse through the base pointer or upcasts it to an ancestor type, both of which a more-derived object still satisfies. The one real downstream effect is serialization: an inverse written to disk now records the derived class name (e.g. `Euler3DTransform_double_3_3`), so byte/string-compared transform baselines in downstream projects may need regeneration. Factory-based readers load either form.
</details>

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)

<!--
provenance: claude-code session 2026-07-23; supersedes/builds on repro PR #6685; resolves #6686
open_questions_for_reviewers: (1) confirm Bucket C exemption (BSpline null, AzimuthElevation affine); (2) serialization baselines in ANTs/BRAINSTools may need regeneration
downstream_audit: ~/src/itk_forest_build_testbed forest_git_repos; zero cast-break sites; only serialization type-string change
-->

