### PR TITLE
COMP: Make SmoothingRecursiveYvvGaussianFilter build with ITK_USE_GPU

### DIFF
--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/CMakeLists.txt
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/CMakeLists.txt
@@ -13,7 +13,6 @@ if(ITK_USE_GPU)
   endif()
 
   include_directories("${${itk-module}_SOURCE_DIR}/include")
-  include_directories("${${itk-module}KernelDir}")
 
   set(
     ${itk-module}TestSRC
@@ -37,6 +36,12 @@ endif()
 #set(ITK_TEST_DRIVER itkTestDriver)
 
 createtestdriver(${itk-module} "${${itk-module}-Test_LIBRARIES}" "${${itk-module}TestSRC}")
+
+if(ITK_USE_GPU)
+  # The GPU kernel library is absent from this header-only module's
+  # Test_LIBRARIES; link it so GetOpenCLSource() resolves.
+  target_link_libraries(${itk-module}TestDriver PRIVATE ${itk-module})
+endif()
 
 #Common tests for CPU and/or GPU
 itk_add_test(

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/yvvFilter.hxx
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/yvvFilter.hxx
@@ -279,7 +279,11 @@ testImage(std::string inputFilename, float sigma, itk::TimeProbesCollectorBase *
       gpuYvvLabel, inputFilename, size, sigma, parameterStream.str(), timeCollector, true);
     /* Stress tests (e.g. high ntests) may cause CL_MEM_OBJECT_ALLOCATION_FAILURE,
      * even when re-instantiating input _and_ filter. Not all GPUs support resetting, so adding a sleep helps.*/
+#  if WIN32
+    Sleep(1000);
+#  else
     sleep(1);
+#  endif
   }
 
   std::string gpuYvvLabelNoSync = "gpu_Yvv_NoSyn";
@@ -287,7 +291,11 @@ testImage(std::string inputFilename, float sigma, itk::TimeProbesCollectorBase *
   {
     testGpuFilter<GPUrecursiveYVVFilterType>(
       gpuYvvLabelNoSync, inputFilename, size, sigma, parameterStream.str(), timeCollector, false);
+#  if WIN32
+    Sleep(1000); // helps for stress tests
+#  else
     sleep(1); // helps for stress tests
+#  endif
   }
 
 #endif
@@ -341,7 +349,11 @@ testWhite(typename ImageType::SizeType   size,
       gpuYvvLabelSync, emptyFilename, size, sigma, parameterStream.str(), timeCollector, true);
     /* Stress tests (e.g. high ntests) may cause CL_MEM_OBJECT_ALLOCATION_FAILURE,
      * even when re-instantiating input _and_ filter. Not all GPUs support resetting, so adding a sleep helps.*/
+#  if WIN32
+    Sleep(1000);
+#  else
     sleep(1);
+#  endif
   }
 
   std::string gpuYvvLabelNoSync = "gpu_Yvv_NoSyn";
@@ -349,7 +361,11 @@ testWhite(typename ImageType::SizeType   size,
   {
     testGpuFilter<GPUrecursiveYVVFilterType>(
       gpuYvvLabelNoSync, emptyFilename, size, sigma, parameterStream.str(), timeCollector, false);
+#  if WIN32
+    Sleep(1000); // helps for stress tests
+#  else
     sleep(1); // helps for stress tests
+#  endif
   }
 #endif
   return EXIT_SUCCESS;


### PR DESCRIPTION
Make the `SmoothingRecursiveYvvGaussianFilter` module (in-tree, `EXCLUDE_FROM_DEFAULT`, header-only) build under `ITK_USE_GPU=ON`. Enabling it currently fails first at configure, then at link. Two fixes in its `test/CMakeLists.txt`.

> ⚠️ Test execution requires an OpenCL GPU device and was **not** exercised locally (no device on the dev machine). Relying on GPU-enabled CI for first test run. Configure/build/link were validated locally.

<details>
<summary>Defect 1 — configure error (empty include directory)</summary>

`include_directories("${${itk-module}KernelDir}")` referenced `${itk-module}KernelDir`, a variable that is **never set anywhere in ITK** (it is the only reference in the tree — legacy from before the module was ingested from its upstream remote). It expands to an empty string, so CMake aborts configure with *"include_directories given empty-string as include directory."* No other GPU module needs a kernel include path (the generated `<Filter>Kernel.cxx` compiles into the module library). Removed.
</details>

<details>
<summary>Defect 2 — link error (kernel symbol undefined)</summary>

Once configure passed, the test driver failed to link with `undefined reference to itk::GPUSmoothingRecursiveYvvGaussianImageFilterKernel::GetOpenCLSource()`. That symbol lives in the generated kernel object compiled into `libitkSmoothingRecursiveYvvGaussianFilter`, which is built **only** under `ITK_USE_GPU`. Because the module is declared header-only, this GPU-only library is not part of its `Test_LIBRARIES`, so the test driver never linked it. Added `target_link_libraries(${itk-module}TestDriver PRIVATE ${itk-module})` under `ITK_USE_GPU`.
</details>

<details>
<summary>Local validation</summary>

With `ITK_USE_GPU=ON` + `Module_SmoothingRecursiveYvvGaussianFilter=ON`:
- `cmake` configure: **done** (previously errored).
- `ninja SmoothingRecursiveYvvGaussianFilterTestDriver`: **builds and links**.
- Test run: **not possible locally** — the module compiles all its tests with `-DGPU`, and every test aborts with *"OpenCL-enabled GPU is not present"* on a machine without an OpenCL device. Needs GPU CI.
</details>

<!--
provenance: claude-code session 2026-07-23
branch: itk-yvv-gpu-cmake-fix (hjmjohnson fork), 1 commit on upstream/main
file: Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/CMakeLists.txt
surfaced_by: enabling ITK_USE_GPU on build_forest-itkv6_main during a test-warning sweep (companion PR #6690)
validated: configure + build + link with GPU on; test execution needs OpenCL device (not available locally)
note: module has NO GoogleTests; 5 legacy data-driven CTests, all require an OpenCL GPU at runtime
-->
