### PR TITLE
COMP: Silence CMP0219 warning in vendored JPEG configure check

### DIFF
--- a/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/CMakeLists.txt
+++ b/Modules/ThirdParty/JPEG/src/itkjpeg-turbo/CMakeLists.txt
@@ -65,8 +65,9 @@ if(UNIX)
         res |= 0xFFFFFFFFL << (32-4);
         if (res == -0x7F7E80CL)
           return 0; /* right shift is unsigned */
-        printf(\"Right shift isn't acting as I expect it to.\\\\n\");
-        printf(\"I fear the JPEG software will not work at all.\\\\n\\\\n\");
+        puts(\"Right shift isn't acting as I expect it to.\");
+        puts(\"I fear the JPEG software will not work at all.\");
+        puts(\"\");
         return 0; /* try it with unsigned anyway */
       }
       int main (void) {


### PR DESCRIPTION
Silences a CMake 4.4 `CMP0219` policy warning emitted during configure from the vendored JPEG `RIGHT_SHIFT_IS_UNSIGNED` check. Reported upstream as [libjpeg-turbo/libjpeg-turbo#905](https://github.com/libjpeg-turbo/libjpeg-turbo/issues/905).

Emits the check's two diagnostic messages with `puts()` instead of `printf("...\n")`, removing the only backslashes from the `check_c_source_runs()` argument. Behavior and output are unchanged.

<details>
<summary>Root cause</summary>

CMake 4.4 adds policy [CMP0219](https://cmake.org/cmake/help/latest/policy/CMP0219.html): backslashes in the arguments of a **macro** invocation are reinterpreted as escape sequences. `CHECK_C_SOURCE_RUNS` is a `macro()`, and the only backslashes in its argument are the `\n` newline escapes in the two diagnostic `printf()` calls, so every configure on CMake 4.4+ prints:

```
CMake Warning (policy) at Modules/ThirdParty/JPEG/src/itkjpeg-turbo/CMakeLists.txt:56 (check_c_source_runs):
  Policy CMP0219 is not set: Macro invocations preserve backslashes in arguments. ...
  Command "CHECK_C_SOURCE_RUNS" called with arguments containing backslashes.
```

`puts()` appends the newline itself, so the C source carries no backslashes and the warning cannot fire — on any CMake version or policy setting. This is preferred over `cmake_policy(SET CMP0219 OLD)`, which a future CMake will eventually drop.
</details>

<details>
<summary>Verification (CMake 4.4.0)</summary>

- Old `printf` form: 2 CMP0219 warnings. New `puts` form: **0**.
- `RIGHT_SHIFT_IS_UNSIGNED` detection result unchanged (standalone `check_c_source_runs` reproduction).
- Output byte-identical: `puts("…to.")` → `…to.\n`; `puts("…all.")` + `puts("")` → `…all.\n\n`; concatenating to `…to.\n…all.\n\n` as before.
- `pre-commit run --all-files` clean. Diff is one ThirdParty JPEG file (+3/−2).
</details>

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)

<!--
provenance: claude-code session 2026-07-23
upstream_report: libjpeg-turbo/libjpeg-turbo#905 (+ ready branch hjmjohnson/libjpeg-turbo@fix-cmp0219-backslash-configure-check)
note: itkjpeg-turbo/CMakeLists.txt is ITK-authored (not imported by UpdateFromUpstream.sh), so this fix does not round-trip from upstream; independent of #905.
verified_cmake: 4.4.0 -> old=2 CMP0219 warnings, new=0
-->
