### PR TITLE
COMP: Use itk::Math::Absolute in transform inverse test

### DIFF
--- a/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
+++ b/Modules/Core/Transform/test/itkTestTransformGetInverse.cxx
@@ -154,7 +154,7 @@ InverseRoundTripTest(const TTransform * forward)
     const auto roundTrip = inverse->TransformPoint(forward->TransformPoint(p));
     for (unsigned int d = 0; d < 3; ++d)
     {
-      if (itk::Math::abs(roundTrip[d] - p[d]) > 1e-6)
+      if (itk::Math::Absolute(roundTrip[d] - p[d]) > 1e-6)
       {
         std::cerr << "ERROR: " << name << " inverse round-trip failed: got " << roundTrip << " expected " << p
                   << std::endl;


### PR DESCRIPTION
Replace the legacy `itk::Math::abs` alias with the non-deprecated `itk::Math::Absolute` in the transform inverse round-trip test, fixing the `ITK_FUTURE_LEGACY_REMOVE` nightly build.

<details>
<summary>Root cause</summary>

`itk::Math::abs` (itkMath.h) is a backward-compat alias for `itk::Math::Absolute`, wrapped in `#if !defined(ITK_FUTURE_LEGACY_REMOVE)`. The test added in `b0252917ba4` used the alias, so it compiles in ordinary builds — but the alias is compiled out under `ITK_FUTURE_LEGACY_REMOVE`, breaking the `Mac14.x-AppleClang-dbg-Universal` nightly ([CDash build 11438342](https://open.cdash.org/builds/11438342/build)):

```
Modules/Core/Transform/test/itkTestTransformGetInverse.cxx:157:11:
error: no member named 'abs' in namespace 'itk::Math'; did you mean simply 'abs'?
```

Ordinary PR CI does not enable `ITK_FUTURE_LEGACY_REMOVE`, so the legacy-removal nightly is the first build to exercise it.

</details>

<details>
<summary>Test plan</summary>

- Builds clean in a local `ITK_FUTURE_LEGACY_REMOVE=ON` tree (reproduces the failing config).
- `ctest -R itkTestTransformGetInverse` passes in a normal build.
- `pre-commit run --all-files` clean.

</details>

<!--
provenance: claude-code session 2026-07-24
cdash_build: 11438342 Mac14.x-AppleClang-dbg-Universal (Nightly 20260724-0100)
introduced_by: b0252917ba4 ENH: GetInverseTransform() preserves concrete type for 3D transforms
fix_file: Modules/Core/Transform/test/itkTestTransformGetInverse.cxx:157
-->