### PR TITLE
ENH: Run itkSimpleImageRegistrationTest fully in Debug builds

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -225,11 +225,7 @@ PerformSimpleImageRegistration(int argc, char * argv[])
   {
     itkGenericExceptionMacro("Error dynamic_cast failed");
   }
-#ifdef NDEBUG
   affineOptimizer->SetNumberOfIterations(std::stoi(argv[6]));
-#else
-  affineOptimizer->SetNumberOfIterations(1);
-#endif
   affineOptimizer->SetDoEstimateLearningRateOnce(false); // true by default
   affineOptimizer->SetDoEstimateLearningRateAtEachIteration(true);
   affineOptimizer->SetScalesEstimator(scalesEstimator1);
@@ -293,11 +289,7 @@ PerformSimpleImageRegistration(int argc, char * argv[])
 
   auto optimizer = GradientDescentOptimizerv4Type::New();
   optimizer->SetLearningRate(1.0);
-#ifdef NDEBUG
   optimizer->SetNumberOfIterations(std::stoi(argv[7]));
-#else
-  optimizer->SetNumberOfIterations(1);
-#endif
   optimizer->SetScalesEstimator(scalesEstimator);
   optimizer->SetDoEstimateLearningRateOnce(false); // true by default
   optimizer->SetDoEstimateLearningRateAtEachIteration(true);


### PR DESCRIPTION
`itkSimpleImageRegistrationTest{Float,Double}` have failed in every Debug build since PR #6569 (2026-07-09). Removing the `#ifdef NDEBUG` one-iteration reduction makes the Debug result bit-identical to Release, so the existing baselines cover both.

Currently failing on `corista.kitware/Ubuntu-22.04-gcc11.4-TBB-Debug`, `ryzenator.kitware/Windows11-VS2022-Static-DebugTBB`, `RogueResearch19/Mac27.x-AppleClang-dbg-arm64`, and the SimpleITK `itk-coverage` nightly.

<details>
<summary>Root cause</summary>

Two facts combine; neither alone is a bug.

**1.** Since `e3cf08697f9` (2013, "ENH: Reduce test times for Debug builds") the test collapses both optimizers to a single iteration when `NDEBUG` is undefined:

```cpp
#ifdef NDEBUG
  affineOptimizer->SetNumberOfIterations(std::stoi(argv[6]));  // 100
#else
  affineOptimizer->SetNumberOfIterations(1);
#endif
```

A one-iteration registration stops at near-identity (translation ≈2.8 px where the converged answer is ≈43.6 px). That is by design, and it explains why the `ImageError` values are bit-identical across distributions and compilers rather than drifting — this is behavioral divergence, not accumulated floating-point rounding.

**2.** That Debug output had its own baseline. `47b61d2b2d7` (2018, "BUG: Add additional baseline for debug") added `Baseline/itkSimpleImageRegistrationTest.3.nii`, picked up automatically by the `DATA{...nii,:}` series glob. `3297d567f09` in PR #6569 regenerated the baselines for the JointHistogramMutualInformation fix and dropped `.3` as stale; nothing replaced it.

ITK's own CI never caught this: `AzurePipelinesLinux.yml` job `LinuxLegacyRemovedDebugCxx20` is the only official Debug build and sets `CTEST_TEST_ARGS EXCLUDE_LABEL "BigIO|RUNS_LONG"`. Both tests carry `RUNS_LONG`.

</details>

<details>
<summary>Why remove the reduction rather than regenerate a Debug baseline</summary>

Measured on gcc 13.3 / Ubuntu 24.04 / x86_64 / system TBB:

| Build | Iterations | Result | ImageError vs `.nii` / `.1` / `.2` |
|---|---|---|---|
| Debug, as on main | 1 / 1 | FAIL | 23496 / 23491 / 23484 |
| Release | 100 / 10 | PASS | **0** / 98 / 1738 |
| Debug, this PR | 100 / 10 | PASS | **0** / 98 / 1738 |

Debug with full iterations is bit-identical to Release, so no Debug-only baseline is needed and none can go stale again. Restoring the deleted `.3` object would not have worked either — today's one-iteration output differs from it by 9430 pixels against a tolerance of 8, because the JHMI fix changed that result too.

A one-iteration registration also tests very little; the alternative of skipping the test in Debug would drop Debug coverage of the registration path entirely, which is where assertions actually fire.

</details>

<details>
<summary>Test plan</summary>

Debug + TBB build, gcc 13.3, `ITK_GLOBAL_DEFAULT_THREADER=TBB`:

- `itkSimpleImageRegistrationTestDouble` and `...Float` both pass: 42.19 s + 44.47 s serial, **44.54 s under `ctest -j2`**.
- Full `ITKRegistrationMethodsv4` label under `-j2`: 175.87 s, 23/24 pass. The exception is `ITKRegistrationMethodsv4KWStyleTest` ("Not Run" — KWStyle absent on the test machine, unchanged by this PR).
- `pre-commit run --all-files` exits 0.

</details>

Note: with the `RUNS_LONG` exclusion still in place, ITK's Azure Debug job will not run these tests even after this PR, so a future recurrence would again surface only on external Debug dashboards. Lifting that exclusion is a separate discussion.

<!--
provenance: claude-code session 2026-07-24, cortex.ecn.uiowa.edu
base: upstream/main @ 07382b56fa5 ; commit 3bac4ac0cf (8 lines deleted)
regression_introduced_by: 3297d567f09 in PR #6569 (dropped Baseline/itkSimpleImageRegistrationTest.3.nii)
debug_reduction_introduced_by: e3cf08697f9 (2013)
old_debug_baseline_cid: bafkreic3fpf34kla3gduhp3cvam5jdhjjk4uyr3gyap6jekuoi5qxurhim (ImageError 9430 vs today's debug output)
validated_in: ~/src/ITK-regv4-debug-iters-src/build-debug-tbb (Debug, Module_ITKTBB=ON, gcc 13.3)
related_issue: 6701 (SyN tests vacuous - separate defect found during this investigation)
-->
