### PR TITLE
BUG: Make the SyN registration tests actually run a registration

### DIFF
--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -119,11 +119,7 @@ PerformBSplineSyNImageRegistration(int argc, char * argv[])
   using GradientDescentOptimizerv4Type = itk::GradientDescentOptimizerv4;
   auto * optimizer = dynamic_cast<GradientDescentOptimizerv4Type *>(affineSimple->GetModifiableOptimizer());
   ITK_TEST_EXPECT_TRUE(optimizer != nullptr);
-#ifdef NDEBUG
   optimizer->SetNumberOfIterations(100);
-#else
-  optimizer->SetNumberOfIterations(1);
-#endif
 
   using AffineCommandType = CommandIterationUpdate<AffineRegistrationType>;
   auto affineObserver = AffineCommandType::New();
@@ -215,15 +211,9 @@ PerformBSplineSyNImageRegistration(int argc, char * argv[])
 
   typename DisplacementFieldRegistrationType::NumberOfIterationsArrayType numberOfIterationsPerLevel;
   numberOfIterationsPerLevel.SetSize(3);
-#ifdef NDEBUG
   numberOfIterationsPerLevel[0] = std::stoi(argv[5]);
   numberOfIterationsPerLevel[1] = 2;
   numberOfIterationsPerLevel[2] = 1;
-#else
-  numberOfIterationsPerLevel[0] = 1;
-  numberOfIterationsPerLevel[1] = 1;
-  numberOfIterationsPerLevel[2] = 1;
-#endif
   typename DisplacementFieldRegistrationType::ShrinkFactorsArrayType shrinkFactorsPerLevel;
   shrinkFactorsPerLevel.SetSize(3);
   shrinkFactorsPerLevel[0] = 3;

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineSyNImageRegistrationTest.cxx
@@ -77,7 +77,7 @@ template <unsigned int TDimension>
 int
 PerformBSplineSyNImageRegistration(int argc, char * argv[])
 {
-  ITK_TEST_EXPECT_TRUE(argc == 4);
+  ITK_TEST_EXPECT_TRUE(argc == 7);
   const unsigned int ImageDimension = TDimension;
 
   using PixelType = double;
@@ -361,26 +361,29 @@ PerformBSplineSyNImageRegistration(int argc, char * argv[])
 int
 itkBSplineSyNImageRegistrationTest(int argc, char * argv[])
 {
-  if (argc < 5)
+  if (argc != 7)
   {
-    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Incorrect number of parameters." << std::endl;
     std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate"
               << std::endl;
     return EXIT_FAILURE;
   }
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformBSplineSyNImageRegistration<2>(argc, argv);
+      testStatus = PerformBSplineSyNImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformBSplineSyNImageRegistration<3>(argc, argv);
+      testStatus = PerformBSplineSyNImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+
+  std::cout << "Test finished." << std::endl;
+  return testStatus;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -111,11 +111,7 @@ template <unsigned int TDimension>
 int
 PerformDisplacementFieldImageRegistration(int argc, char * argv[])
 {
-  if (argc != 5)
-  {
-    std::cout << "ERROR: incorrect number of arguments" << std::endl;
-    return EXIT_FAILURE;
-  }
+  ITK_TEST_EXPECT_TRUE(argc == 7);
   const unsigned int ImageDimension = TDimension;
 
   using PixelType = double;
@@ -464,7 +460,7 @@ PerformDisplacementFieldImageRegistration(int argc, char * argv[])
 int
 itkSyNImageRegistrationTest(int argc, char * argv[])
 {
-  if (argc < 5)
+  if (argc != 7)
   {
     std::cout << itkNameOfTestExecutableMacro(argv)
               << " imageDimension fixedImage movingImage outputPrefix numberOfDeformableIterations learningRate"
@@ -488,13 +484,14 @@ itkSyNImageRegistrationTest(int argc, char * argv[])
     displacementFieldRegistration, SyNImageRegistrationMethod, ImageRegistrationMethodv4);
 
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformDisplacementFieldImageRegistration<2>(argc, argv);
+      testStatus = PerformDisplacementFieldImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformDisplacementFieldImageRegistration<3>(argc, argv);
+      testStatus = PerformDisplacementFieldImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
@@ -503,5 +500,5 @@ itkSyNImageRegistrationTest(int argc, char * argv[])
 
 
   std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSyNImageRegistrationTest.cxx
@@ -153,11 +153,7 @@ PerformDisplacementFieldImageRegistration(int argc, char * argv[])
   using GradientDescentOptimizerv4Type = itk::GradientDescentOptimizerv4;
   auto * optimizer = dynamic_cast<GradientDescentOptimizerv4Type *>(affineSimple->GetModifiableOptimizer());
   ITK_TEST_EXPECT_TRUE(optimizer != nullptr);
-#ifdef NDEBUG
   optimizer->SetNumberOfIterations(100);
-#else
-  optimizer->SetNumberOfIterations(1);
-#endif
 
   std::cout << "Affine transform" << std::endl;
 
@@ -261,15 +257,9 @@ PerformDisplacementFieldImageRegistration(int argc, char * argv[])
 
   typename DisplacementFieldRegistrationType::NumberOfIterationsArrayType numberOfIterationsPerLevel;
   numberOfIterationsPerLevel.SetSize(3);
-#ifdef NDEBUG
   numberOfIterationsPerLevel[0] = std::stoi(argv[5]);
   numberOfIterationsPerLevel[1] = 2;
   numberOfIterationsPerLevel[2] = 1;
-#else
-  numberOfIterationsPerLevel[0] = 1;
-  numberOfIterationsPerLevel[1] = 1;
-  numberOfIterationsPerLevel[2] = 1;
-#endif
   constexpr RealType varianceForUpdateField{ 1.75 };
   constexpr RealType varianceForTotalField{ 0.5 };
 


### PR DESCRIPTION
`itkSyNImageRegistrationTest` and `itkBSplineSyNImageRegistrationTest` passed in ~0.06 s without ever constructing a registration: an argument-count guard rejected the CMake-supplied argv, and the helper's return value was discarded so the failure was swallowed.

Fixes #6701

<details>
<summary>The defect</summary>

Both tests dispatch on image dimension into a templated helper. The helper guarded on an argument count that no longer matched the CMake invocation, which supplies seven arguments:

```cpp
// itkSyNImageRegistrationTest.cxx
if (argc != 5) { std::cout << "ERROR: incorrect number of arguments"; return EXIT_FAILURE; }
// itkBSplineSyNImageRegistrationTest.cxx
ITK_TEST_EXPECT_TRUE(argc == 4);
```

The caller then dropped that status:

```cpp
case 2:
  PerformDisplacementFieldImageRegistration<2>(argc, argv);   // return value ignored
  break;
```

So the observed output was a failure message followed by a pass:

```
Name of Class = SyNImageRegistrationMethod
ERROR: incorrect number of arguments
Test finished.
1/1 Test #3193: itkSyNImageRegistrationTest ......   Passed    0.07 sec
```

Only `ITK_EXERCISE_BASIC_OBJECT_METHODS` ran. True in Release and Debug alike.

</details>

<details>
<summary>Commit 2: removing the Debug iteration reduction</summary>

With the registrations running again, the `#ifdef NDEBUG` reduction in these two tests (affine 100 → 1 iteration, deformable levels → 1/1/1) becomes the next thing that hollows them out. Neither test compares against a baseline, so Debug and Release can share iteration counts and nothing can go stale the way `Baseline/itkSimpleImageRegistrationTest.3.nii` did (see #6702).

Measured on gcc 13.3 x86_64: the pair takes 4.3 s in Debug with full iterations against 1.9 s reduced.

</details>

<details>
<summary>Test plan</summary>

Release, Ninja, gcc 13.3, Ubuntu 24.04, `BUILD_TESTING=ON`, `ITK_USE_KWSTYLE=ON`:

- Full build 5609/5609, zero compiler warnings.
- `ctest -j6`: **100% tests passed, 0 failed out of 4695** (198.9 s), including all 112 KWStyle tests. One skip, `NumericLocale.WorksWithDifferentInitialLocale`, unrelated.
- `pre-commit run --all-files` exits 0.

Behavioral verification of the SyN pair, TBB threader:

| | before | after |
|---|---|---|
| Release | 0.13 s, no registration | 1.92 s |
| Debug | 0.13 s, no registration | 4.31 s |

The SyN log now shows the real level sweep — 10 iterations at level 0, 2 at level 1, 1 at level 2 — with the internal-transform consistency check firing at each. Invoking either test with 5 arguments now exits 1; previously it exited 0.

</details>

<!--
provenance: claude-code session 2026-07-24/25, cortex.ecn.uiowa.edu
base: upstream/main @ 07382b56fa5
commits: b40e0f52dca (argc + status), 4e80479461e (NDEBUG removal)
sweep_script: scratchpad/sweep.py - parses itk_add_test COMMAND lists, compares argc against
  entry-point guards; flags statement-level calls to int-returning helpers taking (argc, argv)
kwstyle: not available via conda-forge and the main checkout's .pixi/envs/cxx/bin/KWStyle was a
  broken symlink to a deleted tree; built from source at ~/src/KWStyle-build/bin/KWStyle (v1.1.0)
  and passed via -DKWSTYLE_EXECUTABLE
related: #6702 (itkSimpleImageRegistrationTest Debug failure, same module, separate defect)
-->

