### PR TITLE
BUG: Propagate test helper status and mark the helpers [[nodiscard]]

### DIFF
--- a/Modules/Core/Common/test/SparseLUSolverTraitsGTest.cxx
+++ b/Modules/Core/Common/test/SparseLUSolverTraitsGTest.cxx
@@ -47,7 +47,7 @@ VectorsEquals(const TVector & v1, const TVector & v2, const typename TVector::Sc
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSparseLUSolverTraitsTest(int, char *[])
 {
   using CoordinateType = double;

--- a/Modules/Core/Common/test/VNLSparseLUSolverTraitsGTest.cxx
+++ b/Modules/Core/Common/test/VNLSparseLUSolverTraitsGTest.cxx
@@ -51,7 +51,7 @@ VectorsEquals(const TVector & v1, const TVector & v2, const typename TVector::el
 
 namespace
 {
-int
+[[nodiscard]] int
 DoVNLSparseLUSolverTraitsTest(int, char *[])
 {
   /**

--- a/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkBSplineInterpolationWeightFunctionGTest.cxx
@@ -43,7 +43,7 @@ static_assert((itk::BSplineInterpolationWeightFunction<float, 2, 1>::NumberOfWei
  */
 namespace
 {
-int
+[[nodiscard]] int
 DoBSplineInterpolationWeightFunctionTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkColorTableTest.cxx
+++ b/Modules/Core/Common/test/itkColorTableTest.cxx
@@ -23,7 +23,7 @@
 
 
 template <typename TComponent>
-int
+[[nodiscard]] int
 ColorTableTestExpectedConditionChecker(typename itk::ColorTable<TComponent>::Pointer colors,
                                        unsigned int                                  colorId,
                                        itk::RGBPixel<TComponent>                     rgbPixel,
@@ -62,7 +62,7 @@ ColorTableTestExpectedConditionChecker(typename itk::ColorTable<TComponent>::Poi
 }
 
 template <typename TComponent>
-int
+[[nodiscard]] int
 ColorTableTestSpecialConditionChecker(typename itk::ColorTable<TComponent>::Pointer colors, unsigned int numberOfColors)
 {
   using RGBPixelType = itk::RGBPixel<TComponent>;
@@ -132,7 +132,7 @@ ColorTableTestSpecialConditionChecker(typename itk::ColorTable<TComponent>::Poin
 }
 
 template <typename TComponent>
-int
+[[nodiscard]] int
 ColorTableTestHelper(const char * name, unsigned int numberOfColors)
 {
   int testStatus = EXIT_SUCCESS;

--- a/Modules/Core/Common/test/itkConicShellInteriorExteriorSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkConicShellInteriorExteriorSpatialFunctionGTest.cxx
@@ -24,7 +24,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoConicShellInteriorExteriorSpatialFunctionTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
+++ b/Modules/Core/Common/test/itkConstNeighborhoodIteratorWithOnlyIndexTest.cxx
@@ -38,7 +38,7 @@ itkConstNeighborhoodIteratorWithOnlyIndexTestGetTestImage(int d1, int d2, int d3
 }
 
 template <typename TImage>
-int
+[[nodiscard]] int
 itkConstNeighborhoodIteratorWithOnlyIndexTestRun()
 {
   const typename TImage::Pointer img = itkConstNeighborhoodIteratorWithOnlyIndexTestGetTestImage<TImage>(10, 10, 5, 3);

--- a/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkEllipsoidInteriorExteriorSpatialFunctionGTest.cxx
@@ -21,7 +21,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
 {
   std::cout << "itkEllipsoidInteriorExteriorSpatialFunction test start" << std::endl;

--- a/Modules/Core/Common/test/itkFileOutputWindowGTest.cxx
+++ b/Modules/Core/Common/test/itkFileOutputWindowGTest.cxx
@@ -24,7 +24,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoFileOutputWindowTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkFiniteCylinderSpatialFunctionGTest.cxx
@@ -22,7 +22,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoFiniteCylinderSpatialFunctionTest(int, char *[])
 {
   std::cout << "itkFiniteCylinderSpatialFunction test start" << std::endl;

--- a/Modules/Core/Common/test/itkFrustumSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkFrustumSpatialFunctionGTest.cxx
@@ -24,7 +24,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoFrustumSpatialFunctionTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkMetaDataObjectTest.cxx
+++ b/Modules/Core/Common/test/itkMetaDataObjectTest.cxx
@@ -22,7 +22,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TMetaData>
-int
+[[nodiscard]] int
 testMetaData(const TMetaData & value)
 {
   using MetaDataType = TMetaData;

--- a/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
+++ b/Modules/Core/Common/test/itkObjectFactoryTest3.cxx
@@ -84,7 +84,7 @@ private:
 
 using DescriptionListType = std::vector<std::string>;
 
-int
+[[nodiscard]] int
 ListRegisteredFactories(const std::string & TestName, const DescriptionListType & expectedList)
 {
   using FactoryListType = std::list<itk::ObjectFactoryBase *>;

--- a/Modules/Core/Common/test/itkRealTimeClockGTest.cxx
+++ b/Modules/Core/Common/test/itkRealTimeClockGTest.cxx
@@ -26,7 +26,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoRealTimeClockTest(int, char *[])
 {
   // Save the format stream variables for std::cout

--- a/Modules/Core/Common/test/itkSTLContainerAdaptorGTest.cxx
+++ b/Modules/Core/Common/test/itkSTLContainerAdaptorGTest.cxx
@@ -26,7 +26,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSTLContainerAdaptorTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkSimpleFilterWatcherGTest.cxx
+++ b/Modules/Core/Common/test/itkSimpleFilterWatcherGTest.cxx
@@ -83,7 +83,7 @@ protected:
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSimpleFilterWatcherTest(int, char *[])
 {
   // Test out the code

--- a/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
+++ b/Modules/Core/Common/test/itkSobelOperatorImageConvolutionTest.cxx
@@ -76,7 +76,7 @@ DoConvolution(typename ImageType::Pointer inputImage, unsigned long int directio
 }
 
 template <typename PixelType, unsigned long Dimension>
-int
+[[nodiscard]] int
 DoSimpleConvolutionTest(unsigned long direction, const std::string & pixelType)
 {
   using ImageType = typename itk::Image<PixelType, Dimension>;

--- a/Modules/Core/Common/test/itkSparseFieldLayerGTest.cxx
+++ b/Modules/Core/Common/test/itkSparseFieldLayerGTest.cxx
@@ -31,7 +31,7 @@ struct node_type
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSparseFieldLayerTest(int, char *[])
 {
   auto * store = new node_type[4000];

--- a/Modules/Core/Common/test/itkSparseImageGTest.cxx
+++ b/Modules/Core/Common/test/itkSparseImageGTest.cxx
@@ -41,7 +41,7 @@ public:
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSparseImageTest(int, char *[])
 {
   using DummyImageType = itk::Image<int, 2>;

--- a/Modules/Core/Common/test/itkSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialFunctionGTest.cxx
@@ -24,7 +24,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSpatialFunctionTest(int, char *[])
 {
   // Change this parameter (and the positions, below) to work in higher or lower dimensions

--- a/Modules/Core/Common/test/itkSpatialOrientationGTest.cxx
+++ b/Modules/Core/Common/test/itkSpatialOrientationGTest.cxx
@@ -24,7 +24,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSpatialOrientationTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkSymmetricEllipsoidInteriorExteriorSpatialFunctionGTest.cxx
@@ -21,7 +21,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoSymmetricEllipsoidInteriorExteriorSpatialFunctionTest(int, char *[])
 {
   std::cout << "itkSymmetricEllipsoidInteriorExteriorSpatialFunction test start" << std::endl;

--- a/Modules/Core/Common/test/itkTorusInteriorExteriorSpatialFunctionGTest.cxx
+++ b/Modules/Core/Common/test/itkTorusInteriorExteriorSpatialFunctionGTest.cxx
@@ -23,7 +23,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoTorusInteriorExteriorSpatialFunctionTest(int, char *[])
 {
 

--- a/Modules/Core/Common/test/itkVariableSizeMatrixGTest.cxx
+++ b/Modules/Core/Common/test/itkVariableSizeMatrixGTest.cxx
@@ -22,7 +22,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 DoVariableSizeMatrixTest(int, char *[])
 {
   using FloatVariableSizeMatrixType = itk::VariableSizeMatrix<float>;

--- a/Modules/Core/Common/test/itkZeroFluxBoundaryConditionGTest.cxx
+++ b/Modules/Core/Common/test/itkZeroFluxBoundaryConditionGTest.cxx
@@ -121,7 +121,7 @@ CheckInputRequestedRegion(const RegionType & imageRegion,
 
 namespace
 {
-int
+[[nodiscard]] int
 DoZeroFluxBoundaryConditionTest(int, char *[])
 {
   // Test an image to cover one operator() method.

--- a/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkBSplineInterpolateImageFunctionTest.cxx
@@ -611,7 +611,7 @@ testInteger3DSpline()
 
 // Test to verify that EvaluateDerivativeAtContinuousIndex and EvaluateValueAndDerivativeAtContinuousIndex
 // produce identical results.
-int
+[[nodiscard]] int
 testEvaluateValueAndDerivative()
 {
   constexpr unsigned int ImageDimension{ 2 };

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx
@@ -21,7 +21,7 @@
 #include "itkTestingMacros.h"
 
 template <unsigned int vecLength>
-int
+[[nodiscard]] int
 itkCentralDifferenceImageFunctionOnVectorSpeedTestRun(char * argv[])
 {
   const int  imageSize = std::stoi(argv[1]);
@@ -130,41 +130,42 @@ itkCentralDifferenceImageFunctionOnVectorSpeedTest(int argc, char * argv[])
   }
   const int vecLength = std::stoi(argv[6]);
 
+  int testStatus = EXIT_SUCCESS;
   switch (vecLength)
   {
     case 1:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<1>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<1>(argv);
       break;
     case 2:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<2>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<2>(argv);
       break;
     case 3:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<3>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<3>(argv);
       break;
     case 4:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<4>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<4>(argv);
       break;
     case 5:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<5>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<5>(argv);
       break;
     case 6:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<6>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<6>(argv);
       break;
     case 7:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<7>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<7>(argv);
       break;
     case 8:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<8>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<8>(argv);
       break;
     case 9:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<9>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<9>(argv);
       break;
     case 10:
-      itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<10>(argv);
+      testStatus = itkCentralDifferenceImageFunctionOnVectorSpeedTestRun<10>(argv);
       break;
     default:
       std::cout << "Invalid vecLength" << std::endl;
       break;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkCentralDifferenceImageFunctionOnVectorTest.cxx
@@ -39,7 +39,7 @@ IsEqual(T & m1, T & m2)
 }
 
 template <unsigned int VectorLength>
-int
+[[nodiscard]] int
 itkCentralDifferenceImageFunctionOnVectorTestRun()
 {
   std::cout << "\n**************************" << std::endl

--- a/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkGaussianDerivativeImageFunctionTest.cxx
@@ -21,7 +21,7 @@
 #include <type_traits> // For std::is_same.
 
 template <typename TPixel>
-int
+[[nodiscard]] int
 TestGaussianDerivativeImageFunction()
 {
   constexpr unsigned int Dimension{ 2 };

--- a/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkLinearInterpolateImageFunctionTest.cxx
@@ -25,7 +25,7 @@
 
 /* Allows testing up to TDimension=4 */
 template <unsigned int TDimension>
-int
+[[nodiscard]] int
 RunLinearInterpolateTest()
 {
   using PixelType = float;

--- a/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
+++ b/Modules/Core/ImageFunction/test/itkSumOfSquaresImageFunctionGTest.cxx
@@ -93,7 +93,7 @@ Expect_EvaluateAtIndex_returns_number_of_neigbors_when_all_pixels_are_one(const 
 }
 
 template <typename TImage>
-int
+[[nodiscard]] int
 TestBasicObjectProperties()
 {
   const auto imageFunction = itk::SumOfSquaresImageFunction<TImage>::New();

--- a/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
+++ b/Modules/Core/Mesh/test/itkCellInterfaceTest.cxx
@@ -46,7 +46,7 @@ using CellAutoPointer = CellType::CellAutoPointer;
 // Test the cell interface
 
 template <typename TCell>
-int
+[[nodiscard]] int
 TestCellInterface(const std::string_view name, TCell * aCell)
 {
   const CellAutoPointer cell(aCell, true);

--- a/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
+++ b/Modules/Core/Mesh/test/itkParametricSpaceToImageSpaceMeshFilterTest.cxx
@@ -60,7 +60,7 @@ struct helper<itk::Point<TCoord, VDimension>>
 
 
 template <class TPosition>
-int
+[[nodiscard]] int
 InternalTest(int argc, char * argv[])
 {
   if (argc != 2)

--- a/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
+++ b/Modules/Core/QuadEdgeMesh/test/itkQuadEdgeMeshCellInterfaceTest.cxx
@@ -68,7 +68,7 @@ public:
 
 // Test the cell interface
 template <typename TCell>
-int
+[[nodiscard]] int
 TestCellInterface(const std::string_view name, TCell * aCell)
 {
 
@@ -177,7 +177,7 @@ TestCellInterface(const std::string_view name, TCell * aCell)
 // Test the QEcell interface
 
 template <typename TCell>
-int
+[[nodiscard]] int
 TestQECellInterface(const std::string_view name, TCell * aCell)
 {
   std::cout << "-------- " << name << '(' << aCell->GetNameOfClass() << ')' << std::endl;

--- a/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
+++ b/Modules/Core/SpatialObjects/test/itkImageMaskSpatialObjectTest4.cxx
@@ -35,7 +35,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 Test3dImageMask()
 {
   using BoxType = itk::BoxSpatialObject<3>;
@@ -166,7 +166,7 @@ Test3dImageMask()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Test2dImageMask()
 {
   using BoxType = itk::BoxSpatialObject<2>;

--- a/Modules/Core/TestKernel/test/itkRandomImageSourceAttributesTest.cxx
+++ b/Modules/Core/TestKernel/test/itkRandomImageSourceAttributesTest.cxx
@@ -21,7 +21,7 @@
 
 
 template <typename TImage>
-int
+[[nodiscard]] int
 itkRandomImageSourceAttributesTestHelper(const typename TImage::SizeType      size,
                                          const typename TImage::SpacingType   spacing,
                                          const typename TImage::PointType     origin,

--- a/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineDeformableTransformTest.cxx
@@ -37,7 +37,7 @@
  * This module test the functionality of the BSplineDeformableTransform class.
  *
  */
-int
+[[nodiscard]] int
 itkBSplineDeformableTransformTest1()
 {
 
@@ -428,7 +428,7 @@ itkBSplineDeformableTransformTest1()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 itkBSplineDeformableTransformTest2()
 {
   /**
@@ -557,7 +557,7 @@ itkBSplineDeformableTransformTest2()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 itkBSplineDeformableTransformTest3()
 {
 

--- a/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkBSplineTransformTest.cxx
@@ -35,7 +35,7 @@
  * This module test the functionality of the BSplineTransform class.
  *
  */
-int
+[[nodiscard]] int
 itkBSplineTransformTest1()
 {
 
@@ -458,7 +458,7 @@ itkBSplineTransformTest1()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 itkBSplineTransformTest2()
 {
   /**
@@ -574,7 +574,7 @@ itkBSplineTransformTest2()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 itkBSplineTransformTest3()
 {
 

--- a/Modules/Core/Transform/test/itkThinPlateSplineKernelTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkThinPlateSplineKernelTransformTest.cxx
@@ -38,7 +38,7 @@ namespace
 // - the inverse transform correctly maps every target back to its source,
 // - unsupported operations correctly throw exceptions.
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 TestThinPlateSplineKernelTransform()
 {
   constexpr double epsilon{ 1e-12 };

--- a/Modules/Filtering/AnisotropicDiffusionLBR/test/CoherenceEnhancingDiffusionTest.cxx
+++ b/Modules/Filtering/AnisotropicDiffusionLBR/test/CoherenceEnhancingDiffusionTest.cxx
@@ -28,19 +28,19 @@ namespace
 
 using namespace itk;
 
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[]);
 
 template <int VDimension>
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[], itk::ImageIOBase::IOComponentEnum, int nComponents);
 
 template <int VDimension, typename ScalarType, typename ComponentType>
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[], int nComponents);
 
 template <int VDimension, typename ScalarType, typename PixelType, typename ExportPixelType>
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[]);
 
 
@@ -94,7 +94,7 @@ Execute(int argc, char * argv[])
 }
 
 template <int Dimension>
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[], itk::IOComponentEnum componentType, int nComponents)
 {
   switch (componentType)
@@ -111,7 +111,7 @@ Execute(int argc, char * argv[], itk::IOComponentEnum componentType, int nCompon
 }
 
 template <int Dimension, typename ScalarType, typename ComponentType>
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[], int nComponents)
 {
   switch (nComponents)
@@ -128,7 +128,7 @@ Execute(int argc, char * argv[], int nComponents)
 }
 
 template <int Dimension, typename ScalarType, typename PixelType, typename ExportPixelType>
-int
+[[nodiscard]] int
 Execute(int argc, char * argv[])
 {
   using ImageType = Image<PixelType, Dimension>;
@@ -228,7 +228,9 @@ Execute(int argc, char * argv[])
 int
 CoherenceEnhancingDiffusionTest(int argc, char * argv[])
 {
-  ITK_TRY_EXPECT_NO_EXCEPTION(Execute(argc, argv));
+  int testStatus = EXIT_SUCCESS;
 
-  return EXIT_SUCCESS;
+  ITK_TRY_EXPECT_NO_EXCEPTION(testStatus = Execute(argc, argv));
+
+  return testStatus;
 }

--- a/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/AnisotropicSmoothing/test/itkMinMaxCurvatureFlowImageFilterTest.cxx
@@ -41,7 +41,7 @@ public:
 constexpr unsigned int MAXRUNS{ 5 }; // maximum number of runs
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 testMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,
                         double                       radius,
                         int                          numberOfRuns,
@@ -115,7 +115,7 @@ itkMinMaxCurvatureFlowImageFilterTest(int, char *[])
 
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 testMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,         // ND image size
                         double                       radius,       // ND-sphere radius
                         int                          numberOfRuns, // number of times to run the filter

--- a/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
+++ b/Modules/Filtering/BiasCorrection/test/itkN4BiasFieldCorrectionImageFilterTest.cxx
@@ -112,7 +112,7 @@ ConvertVector(const std::string & optionString)
 }
 
 template <unsigned int ImageDimension>
-int
+[[nodiscard]] int
 N4(int argc, char * argv[])
 {
   using RealType = float;

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterStreamingTest.cxx
@@ -45,7 +45,7 @@ GenerateKernelForStreamingTest()
 }
 
 template <typename ConvolutionFilterType>
-int
+[[nodiscard]] int
 doConvolutionImageFilterStreamingTest(int argc, char * argv[])
 {
   constexpr int ImageDimension{ 2 };

--- a/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
+++ b/Modules/Filtering/Convolution/test/itkConvolutionImageFilterSubregionTest.cxx
@@ -44,7 +44,7 @@ GenerateGaussianKernelForSubregionTest()
 }
 
 template <typename ConvolutionFilterType>
-int
+[[nodiscard]] int
 doConvolutionImageFilterSubregionTest(int argc, char * argv[])
 {
   constexpr int ImageDimension{ 2 };

--- a/Modules/Filtering/Cuberille/test/CuberilleTest01.cxx
+++ b/Modules/Filtering/Cuberille/test/CuberilleTest01.cxx
@@ -37,7 +37,7 @@
 #include "itkTestingMacros.h"
 
 template <typename ImageType, typename MeshType>
-int
+[[nodiscard]] int
 CuberilleTest01Helper(int argc, char * argv[])
 {
 

--- a/Modules/Filtering/Cuberille/test/CuberilleTest03.cxx
+++ b/Modules/Filtering/Cuberille/test/CuberilleTest03.cxx
@@ -119,7 +119,7 @@ CuberilleTest03Helper(TImage::Pointer image)
   }
 }
 
-int
+[[nodiscard]] int
 CuberilleTest03Parameters(const bool triangles, const bool project)
 {
 

--- a/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
+++ b/Modules/Filtering/CurvatureFlow/test/itkBinaryMinMaxCurvatureFlowImageFilterTest.cxx
@@ -42,7 +42,7 @@ public:
 constexpr unsigned int MAXRUNS{ 5 }; // maximum number of runs
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 testBinaryMinMaxCurvatureFlow(itk::Size<VImageDimension> & size,
                               double                       threshold,
                               double                       radius,
@@ -83,7 +83,7 @@ itkBinaryMinMaxCurvatureFlowImageFilterTest(int, char *[])
 
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 testBinaryMinMaxCurvatureFlow(itk::Size<VImageDimension> & size, // ND image size
                               double                       threshold,
                               double                       radius,       // ND-sphere radius

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterDefaultTest.cxx
@@ -25,7 +25,7 @@
 
 
 template <typename ImageT>
-int
+[[nodiscard]] int
 doDenoising(const std::string & inputFileName, const std::string & outputFileName)
 {
   using ReaderType = itk::ImageFileReader<ImageT>;

--- a/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
+++ b/Modules/Filtering/Denoising/test/itkPatchBasedDenoisingImageFilterTest.cxx
@@ -66,7 +66,7 @@ ParseKernelBandwidthSigma(char * kernelBandwidthSigmaIn, unsigned int numIndepen
 }
 
 template <typename ImageT>
-int
+[[nodiscard]] int
 doDenoising(const std::string & inputFileName,
             const std::string & outputFileName,
             const unsigned int  numIterations,

--- a/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplex1DFFTImageFilterTest.cxx
@@ -33,7 +33,7 @@
 #include "itkTestingMacros.h"
 
 template <typename FFTType>
-int
+[[nodiscard]] int
 doTest(const char * inputRealFullImage, const char * inputImaginaryFullImage, const char * outputImage)
 {
   using ComplexImageType = typename FFTType::InputImageType;

--- a/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkComplexToComplexFFTImageFilterTest.cxx
@@ -40,7 +40,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TPixel, unsigned int VDimension>
-int
+[[nodiscard]] int
 transformImage(const char * inputImageFileName, const char * outputImageFileName)
 {
   using RealPixelType = TPixel;

--- a/Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFT1DImageFilterTest.cxx
@@ -34,7 +34,7 @@
 #include "itkTestingMacros.h"
 
 template <typename FFTForwardType, typename FFTInverseType>
-int
+[[nodiscard]] int
 doTest(const char * inputImage, const char * outputImage)
 {
   constexpr unsigned int direction{ 1 };

--- a/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkFFTWComplexToComplexFFTImageFilterTest.cxx
@@ -44,7 +44,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TPixel, unsigned int VDimension>
-int
+[[nodiscard]] int
 transformImage(const char * inputImageFileName, const char * outputImageFileName)
 {
   using RealPixelType = TPixel;

--- a/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkForward1DFFTImageFilterTest.cxx
@@ -32,7 +32,7 @@
 #include "itkTestingMacros.h"
 
 template <typename FFTType>
-int
+[[nodiscard]] int
 doTest(const char * inputImage, const char * outputImagePrefix)
 {
   using ImageType = typename FFTType::InputImageType;

--- a/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkInverse1DFFTImageFilterTest.cxx
@@ -31,7 +31,7 @@
 #include "itkTestingMacros.h"
 
 template <typename FFTType>
-int
+[[nodiscard]] int
 doTest(const char * inputRealFullImage, const char * inputImaginaryFullImage, const char * outputImage)
 {
   using ImageType = typename FFTType::OutputImageType;

--- a/Modules/Filtering/FFT/test/itkPocketFFTComplexToComplexFFTImageFilterTest.cxx
+++ b/Modules/Filtering/FFT/test/itkPocketFFTComplexToComplexFFTImageFilterTest.cxx
@@ -28,7 +28,7 @@
 #include "itkPocketFFTInverseFFTImageFilter.h"
 
 template <typename TPixel, unsigned int VDimension>
-int
+[[nodiscard]] int
 transformImage(const char * inputImageFileName, const char * outputImageFileName)
 {
   using RealPixelType = TPixel;

--- a/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
+++ b/Modules/Filtering/FastMarching/test/itkFastMarchingImageTopologicalTest.cxx
@@ -27,7 +27,7 @@
 
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 FastMarchingImageFilter(unsigned int argc, char * argv[])
 {
   using InternalPixelType = float;

--- a/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
+++ b/Modules/Filtering/GPUAnisotropicSmoothing/test/itkGPUGradientAnisotropicDiffusionImageFilterTest.cxx
@@ -34,7 +34,7 @@
 #include "itkGPUGradientAnisotropicDiffusionImageFilter.h"
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 runGPUGradientAnisotropicDiffusionImageFilterTest(const std::string & inFile, const std::string & outFile)
 {
   using InputPixelType = float;

--- a/Modules/Filtering/GPUImageFilterBase/test/itkGPUNeighborhoodOperatorImageFilterTest.cxx
+++ b/Modules/Filtering/GPUImageFilterBase/test/itkGPUNeighborhoodOperatorImageFilterTest.cxx
@@ -33,7 +33,7 @@
  */
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 runGPUNeighborhoodOperatorImageFilterTest(const std::string & inFile, const std::string & outFile)
 {
 

--- a/Modules/Filtering/GPUSmoothing/test/itkGPUDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/GPUSmoothing/test/itkGPUDiscreteGaussianImageFilterTest.cxx
@@ -36,7 +36,7 @@
  */
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 runGPUDiscreteGaussianImageFilterTest(const std::string & inFile, const std::string & outFile)
 {
 

--- a/Modules/Filtering/GPUSmoothing/test/itkGPUMeanImageFilterTest.cxx
+++ b/Modules/Filtering/GPUSmoothing/test/itkGPUMeanImageFilterTest.cxx
@@ -38,7 +38,7 @@
  * Testing GPU Mean Image Filter
  */
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 runGPUMeanImageFilterTest(const std::string & inFile, const std::string & outFile)
 {
   using InputPixelType = unsigned char;

--- a/Modules/Filtering/GPUThresholding/test/itkGPUBinaryThresholdImageFilterTest.cxx
+++ b/Modules/Filtering/GPUThresholding/test/itkGPUBinaryThresholdImageFilterTest.cxx
@@ -34,7 +34,7 @@
 #include "itkGPUBinaryThresholdImageFilter.h"
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 runGPUBinaryThresholdImageFilterTest(const std::string & inFile, const std::string & outFile)
 {
   using InputPixelType = unsigned char;

--- a/Modules/Filtering/GPUThresholding/test/itkGPUImageFilterTest.cxx
+++ b/Modules/Filtering/GPUThresholding/test/itkGPUImageFilterTest.cxx
@@ -38,7 +38,7 @@
 #include <string>
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 runGPUImageFilterTest(const std::string & inFile, const std::string & outFile)
 {
   using InputPixelType = unsigned char;

--- a/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
+++ b/Modules/Filtering/ImageFeature/test/itkUnsharpMaskImageFilterTest.cxx
@@ -25,7 +25,7 @@
 namespace
 {
 template <typename OutPixelType>
-int
+[[nodiscard]] int
 RunTest(int argc, char * argv[])
 {
   constexpr unsigned int Dimension{ 2 };

--- a/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientImageFilterTest2.cxx
@@ -27,7 +27,7 @@ namespace
 {
 
 template <typename TInputImage>
-int
+[[nodiscard]] int
 DoIt(const std::string & infname, const std::string & outfname)
 {
   using InputImageType = TInputImage;

--- a/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
+++ b/Modules/Filtering/ImageGradient/test/itkGradientRecursiveGaussianFilterTest3.cxx
@@ -33,7 +33,7 @@
  */
 
 template <typename TImageType, typename TGradImageType, unsigned int TComponents>
-int
+[[nodiscard]] int
 itkGradientRecursiveGaussianFilterTest3Run(typename TImageType::PixelType &   myPixelBorder,
                                            typename TImageType::PixelType &   myPixelFill,
                                            typename TGradImageType::Pointer & outputImage,
@@ -137,7 +137,7 @@ itkGradientRecursiveGaussianFilterTest3Run(typename TImageType::PixelType &   my
 }
 
 template <typename TGradImage1DType, typename TGradImageVectorType>
-int
+[[nodiscard]] int
 itkGradientRecursiveGaussianFilterTest3Compare(typename TGradImage1DType::Pointer     scalarPixelGradImage,
                                                typename TGradImageVectorType::Pointer vectorPixelGradImage,
                                                unsigned int                           numDimensions)

--- a/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkBSplineControlPointImageFilterTest.cxx
@@ -24,7 +24,7 @@
 
 
 template <unsigned int ImageDimension>
-int
+[[nodiscard]] int
 BSpline(int argc, char * argv[])
 {
   using RealType = float;

--- a/Modules/Filtering/ImageGrid/test/itkInterpolateImagePointsFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkInterpolateImagePointsFilterTest.cxx
@@ -82,7 +82,7 @@ set3DData();
 /** test2DInterpolateImagePointsFilter() Tests InterpolateImagePointsFilter for
  * expected results at a handful of index locations.
  */
-int
+[[nodiscard]] int
 test2DInterpolateImagePointsFilter()
 {
   int testStatus = EXIT_SUCCESS;
@@ -188,7 +188,7 @@ test2DInterpolateImagePointsFilter()
   return testStatus;
 }
 
-int
+[[nodiscard]] int
 test3DInterpolateImagePointsFilter()
 {
   int testStatus = EXIT_SUCCESS;

--- a/Modules/Filtering/ImageGrid/test/itkMirrorPadImageFilterTest.cxx
+++ b/Modules/Filtering/ImageGrid/test/itkMirrorPadImageFilterTest.cxx
@@ -25,7 +25,7 @@
 namespace
 {
 template <typename OutPixelType>
-int
+[[nodiscard]] int
 RunTest(int argc, char * argv[])
 {
   constexpr unsigned int Dimension{ 2 };

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteGaussianDerivativeImageFunctionTest.cxx
@@ -24,7 +24,7 @@
 
 
 template <int VDimension>
-int
+[[nodiscard]] int
 itkDiscreteGaussianDerivativeImageFunctionTestND(int argc, char * argv[])
 {
   using PixelType = float;

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteGradientMagnitudeGaussianImageFunctionTest.cxx
@@ -24,7 +24,7 @@
 
 
 template <int VDimension>
-int
+[[nodiscard]] int
 itkDiscreteGradientMagnitudeGaussianImageFunctionTestND(int argc, char * argv[])
 {
   using PixelType = float;

--- a/Modules/Filtering/ImageIntensity/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
+++ b/Modules/Filtering/ImageIntensity/test/itkDiscreteHessianGaussianImageFunctionTest.cxx
@@ -25,7 +25,7 @@
 
 
 template <int VDimension>
-int
+[[nodiscard]] int
 itkDiscreteHessianGaussianImageFunctionTestND(int argc, char * argv[])
 {
   using PixelType = float;

--- a/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
+++ b/Modules/Filtering/ImageSources/test/itkGaborImageSourceTest.cxx
@@ -22,7 +22,7 @@
 
 
 template <int ImageDimension>
-int
+[[nodiscard]] int
 itkGaborImageSourceTestHelper(char * outputFilename, bool calculcateImaginaryPart)
 {
   using PixelType = float;

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
@@ -23,7 +23,7 @@
 #include <iomanip>
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 LabelOverlapMeasures(int, char * argv[])
 {
   using PixelType = unsigned int;
@@ -38,7 +38,7 @@ LabelOverlapMeasures(int, char * argv[])
   using FilterType = itk::LabelOverlapMeasuresImageFilter<ImageType>;
   auto filter = FilterType::New();
 
-  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, LabelOverlapMeasuresImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, LabelOverlapMeasuresImageFilter, ImageSink);
 
 
   filter->SetSourceImage(reader1->GetOutput());

--- a/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
+++ b/Modules/Filtering/ImageStatistics/test/itkLabelOverlapMeasuresImageFilterTest.cxx
@@ -178,17 +178,18 @@ itkLabelOverlapMeasuresImageFilterTest(int argc, char * argv[])
   ITK_EXERCISE_BASIC_OBJECT_METHODS(labelOverlapMeasuresImageFilter, LabelOverlapMeasuresImageFilter, ImageSink);
 
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      LabelOverlapMeasures<2>(argc, argv);
+      testStatus = LabelOverlapMeasures<2>(argc, argv);
       break;
     case 3:
-      LabelOverlapMeasures<3>(argc, argv);
+      testStatus = LabelOverlapMeasures<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Filtering/IsotropicWavelets/test/itkExpandWithZerosImageFilterTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkExpandWithZerosImageFilterTest.cxx
@@ -30,7 +30,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runExpandWithZerosImageFilterTest(unsigned int expandFactor)
 {
   using PixelType = float;

--- a/Modules/Filtering/IsotropicWavelets/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -48,7 +48,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::string & outputImage)
 {
   bool               testPassed = true;

--- a/Modules/Filtering/IsotropicWavelets/test/itkFrequencyExpandTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkFrequencyExpandTest.cxx
@@ -41,7 +41,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runFrequencyExpandTest(const std::string & inputImage, const std::string & outputImage)
 {
   bool               testPassed = true;

--- a/Modules/Filtering/IsotropicWavelets/test/itkFrequencyShrinkTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkFrequencyShrinkTest.cxx
@@ -47,7 +47,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runFrequencyShrinkTest(const std::string & inputImage, const std::string & outputImage)
 {
   bool               testPassed = true;

--- a/Modules/Filtering/IsotropicWavelets/test/itkIsotropicWaveletFrequencyFunctionTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkIsotropicWaveletFrequencyFunctionTest.cxx
@@ -55,7 +55,7 @@ linSpaceForIWFF(double init = 0.0, double end = 1.0, size_t points = 1000)
 } // namespace itk
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runIsotropicWaveletFrequencyFunctionTest(const std::string & profileDataRootPath,
                                          const std::string &, // outputImage,
                                          const unsigned int & inputBands,

--- a/Modules/Filtering/IsotropicWavelets/test/itkRieszFrequencyFunctionTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkRieszFrequencyFunctionTest.cxx
@@ -34,7 +34,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runRieszFrequencyFunctionTest(unsigned int inputOrder)
 {
   bool               testPassed = true;

--- a/Modules/Filtering/IsotropicWavelets/test/itkRieszRotationMatrixTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkRieszRotationMatrixTest.cxx
@@ -25,7 +25,7 @@
 #include "itkTestingComparisonImageFilter.h"
 
 template <typename TImage>
-int
+[[nodiscard]] int
 compareRealImagesAndReport(typename TImage::Pointer validImage, typename TImage::Pointer testImage)
 {
   using ImageType = TImage;
@@ -63,7 +63,7 @@ compareRealImagesAndReport(typename TImage::Pointer validImage, typename TImage:
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 runRieszRotationMatrixInterfaceWithRieszFrequencyFilterBankGeneratorTest()
 {
   constexpr unsigned int Dimension = 2;
@@ -220,7 +220,7 @@ runRieszRotationMatrixInterfaceWithRieszFrequencyFilterBankGeneratorTest()
 }
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runRieszRotationMatrixTest()
 {
   bool               testPassed = true;

--- a/Modules/Filtering/IsotropicWavelets/test/itkRieszWaveletPhaseAnalysisTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkRieszWaveletPhaseAnalysisTest.cxx
@@ -63,7 +63,7 @@ AppendToFilenameRiesz(const std::string & filename, const std::string & appendix
 // 5. The result of the reconstruction will be an image that uses phase information at each level/band for improving
 // local structure information, and can also work as an equalization of brightness.
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runRieszWaveletPhaseAnalysisTest(const std::string &  inputImage,
                                  const std::string &  outputImage,
                                  const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkShrinkDecimateImageFilterTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkShrinkDecimateImageFilterTest.cxx
@@ -29,7 +29,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runShrinkDecimateImageFilterTest()
 {
   using PixelType = float;

--- a/Modules/Filtering/IsotropicWavelets/test/itkStructureTensorImageFilterTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkStructureTensorImageFilterTest.cxx
@@ -34,7 +34,7 @@
 #endif
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runStructureTensorImageFilterTest()
 {
   const unsigned int Dimension = VDimension;

--- a/Modules/Filtering/IsotropicWavelets/test/itkStructureTensorWithGeneralizedRieszTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkStructureTensorWithGeneralizedRieszTest.cxx
@@ -48,7 +48,7 @@
 #endif
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runStructureTensorWithGeneralizedRieszTest(const std::string & inputImage,
                                            const std::string &, // outputImage
                                            const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletCoeffsPhaseAnalyzisImageFilterTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletCoeffsPhaseAnalyzisImageFilterTest.cxx
@@ -33,7 +33,7 @@ AppendToOutputFilename(const std::string & filename, const std::string & appendi
 }
 
 template <unsigned int VDimension, typename TWavelet>
-int
+[[nodiscard]] int
 runWaveletCoeffsPhaseAnalyzisImageFilterTest(const std::string &  inputImage,
                                              const std::string &  outputImage,
                                              const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletCoeffsSpatialDomainImageFilterTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletCoeffsSpatialDomainImageFilterTest.cxx
@@ -33,7 +33,7 @@ AppendToDifferentOutputFilename(const std::string & filename, const std::string 
 }
 
 template <unsigned int VDimension, typename TWavelet>
-int
+[[nodiscard]] int
 runWaveletCoeffsSpatialDomainImageFilterTest(const std::string &  inputImage,
                                              const std::string &  outputImage,
                                              const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
@@ -43,7 +43,7 @@
 #endif
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runWaveletFrequencyFilterBankGeneratorDownsampleTest(const std::string & inputImage,
                                                      const std::string &,
                                                      const unsigned int & inputBands)

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
@@ -41,7 +41,7 @@
 #endif
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runWaveletFrequencyFilterBankGeneratorTest(const std::string &  inputImage,
                                            const std::string &  outputImage,
                                            const unsigned int & inputBands)

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyForwardTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyForwardTest.cxx
@@ -48,7 +48,7 @@ AppendToFilename(const std::string & filename, const std::string & appendix)
 }
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runWaveletFrequencyForwardTest(const std::string &  inputImage,
                                const std::string &  outputImage,
                                const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
@@ -48,7 +48,7 @@ AppendToFilenameUndecimated(const std::string & filename, const std::string & ap
 }
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runWaveletFrequencyForwardUndecimatedTest(const std::string &  inputImage,
                                           const std::string &  outputImage,
                                           const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyInverseTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyInverseTest.cxx
@@ -42,7 +42,7 @@
 #endif
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runWaveletFrequencyInverseTest(const std::string &  inputImage,
                                const std::string &  outputImage,
                                const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
@@ -41,7 +41,7 @@
 #endif
 
 template <unsigned int VDimension, typename TWaveletFunction>
-int
+[[nodiscard]] int
 runWaveletFrequencyInverseUndecimatedTest(const std::string &  inputImage,
                                           const std::string &  outputImage,
                                           const unsigned int & inputLevels,

--- a/Modules/Filtering/IsotropicWavelets/test/itkZeroDCImageFilterTest.cxx
+++ b/Modules/Filtering/IsotropicWavelets/test/itkZeroDCImageFilterTest.cxx
@@ -27,7 +27,7 @@
 #include <string>
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 runZeroDCImageFilterTest(const std::string & inputImage)
 {
   const unsigned int Dimension = VDimension;

--- a/Modules/Filtering/LabelErodeDilate/test/itkLabelSetDilateTest.cxx
+++ b/Modules/Filtering/LabelErodeDilate/test/itkLabelSetDilateTest.cxx
@@ -24,7 +24,7 @@
 #include "read_info.cxx"
 
 template <class MaskPixType, int Dim>
-int
+[[nodiscard]] int
 doDilate(char * In, char * Out, int radius)
 {
   using MaskImType = typename itk::Image<MaskPixType, Dim>;

--- a/Modules/Filtering/LabelErodeDilate/test/itkLabelSetErodeTest.cxx
+++ b/Modules/Filtering/LabelErodeDilate/test/itkLabelSetErodeTest.cxx
@@ -25,7 +25,7 @@
 #include "read_info.cxx"
 
 template <class MaskPixType, int Dim>
-int
+[[nodiscard]] int
 doErode(char * In, char * Out, int radius)
 {
   using MaskImType = typename itk::Image<MaskPixType, Dim>;

--- a/Modules/Filtering/LabelMap/test/itkBinaryFillholeImageFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkBinaryFillholeImageFilterTest1.cxx
@@ -25,7 +25,7 @@
 namespace // Anonymous namespace avoids name collisions
 {
 template <unsigned Dimension>
-int
+[[nodiscard]] int
 DoIt(char * argv[])
 {
   using PixelType = unsigned char;

--- a/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
+++ b/Modules/Filtering/LabelMap/test/itkStatisticsUniqueLabelMapFilterTest1.cxx
@@ -30,7 +30,7 @@
 #include "itkObjectByObjectLabelMapFilter.h"
 
 template <typename TLabelMap>
-int
+[[nodiscard]] int
 CheckLabelMapOverlap(TLabelMap * labelMap)
 {
   int exitCode = EXIT_SUCCESS;

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMaximaImageFilterTest.cxx
@@ -26,7 +26,7 @@
 
 
 template <typename TInputImage, typename TOutputImage>
-int
+[[nodiscard]] int
 RegionalMaximaImageFilterTestHelper(std::string inputImageFile,
                                     std::string outputImageFile,
                                     std::string outputImageFile2,

--- a/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkRegionalMinimaImageFilterTest.cxx
@@ -26,7 +26,7 @@
 
 
 template <typename TInputImage, typename TOutputImage>
-int
+[[nodiscard]] int
 RegionalMinimaImageFilterTestHelper(std::string inputImageFile,
                                     std::string outputImageFile,
                                     std::string outputImageFile2,

--- a/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
+++ b/Modules/Filtering/MathematicalMorphology/test/itkTopHatImageFilterTest.cxx
@@ -27,7 +27,7 @@
 
 
 template <typename TKernelImageFilter>
-int
+[[nodiscard]] int
 itkTopHatImageFilterTestHelper(TKernelImageFilter *                              filter,
                                typename TKernelImageFilter::KernelType           ball,
                                const bool                                        safeBorder,

--- a/Modules/Filtering/Path/test/itkHilbertPathTest.cxx
+++ b/Modules/Filtering/Path/test/itkHilbertPathTest.cxx
@@ -22,7 +22,7 @@
 
 
 template <typename PathType>
-int
+[[nodiscard]] int
 HilbertPathTestHelper(unsigned int maxHilbertPathOder)
 {
   int testStatus = EXIT_SUCCESS;

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkDelaunayConformingQuadEdgeMeshFilterTest.cxx
@@ -24,7 +24,7 @@
 // NEW
 #include "itkDelaunayConformingQuadEdgeMeshFilter.h"
 
-int
+[[nodiscard]] int
 itkDelaunayConformingQuadEdgeMeshFilterTestHelper(const std::string & input,
                                                   const std::string & output,
                                                   const bool          cell_data)

--- a/Modules/Filtering/QuadEdgeMeshFiltering/test/itkParameterizationQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/test/itkParameterizationQuadEdgeMeshFilterTest.cxx
@@ -25,7 +25,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TSolver>
-int
+[[nodiscard]] int
 ParameterizationQuadEdgeMeshFilterTest(const char * inputFilename,
                                        unsigned int borderType,
                                        unsigned int coefficientType,

--- a/Modules/Filtering/RLEImage/test/itkRLEImageTest.cxx
+++ b/Modules/Filtering/RLEImage/test/itkRLEImageTest.cxx
@@ -123,7 +123,7 @@ roiTest(itk::SmartPointer<itk::RLEImage<typename ImageType::PixelType, ImageType
 }
 
 template <typename ImageType>
-int
+[[nodiscard]] int
 doTest(std::string inFilename, std::string outFilename)
 {
   using ReaderType = itk::ImageFileReader<ImageType>;

--- a/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest2.cxx
+++ b/Modules/Filtering/Smoothing/test/itkDiscreteGaussianImageFilterTest2.cxx
@@ -25,7 +25,7 @@
 /** Execute the filter on user-provided input */
 
 template <typename TIMAGE>
-int
+[[nodiscard]] int
 itkDiscreteGaussianImageFilterTestA(const char *       inputFilename,
                                     const char *       outputFilename,
                                     const float        sigma,
@@ -94,26 +94,27 @@ itkDiscreteGaussianImageFilterTest2(int argc, char * argv[])
   using ScalarPixelType = float;
   using VectorPixelType = itk::Vector<ScalarPixelType, 3>;
 
+  int testStatus = EXIT_SUCCESS;
   if (img_dim == 2 && vec_dim == 1)
   {
-    itkDiscreteGaussianImageFilterTestA<itk::Image<ScalarPixelType, 2>>(
+    testStatus = itkDiscreteGaussianImageFilterTestA<itk::Image<ScalarPixelType, 2>>(
       argv[3], argv[4], sigma, kernelError, kernelWidth, filterDimensionality);
   }
   else if (img_dim == 2 && vec_dim == 3)
   {
-    itkDiscreteGaussianImageFilterTestA<itk::Image<VectorPixelType, 2>>(
+    testStatus = itkDiscreteGaussianImageFilterTestA<itk::Image<VectorPixelType, 2>>(
       argv[3], argv[4], sigma, kernelError, kernelWidth, filterDimensionality);
   }
   else if (img_dim == 3 && vec_dim == 1)
   {
-    itkDiscreteGaussianImageFilterTestA<itk::Image<ScalarPixelType, 3>>(
+    testStatus = itkDiscreteGaussianImageFilterTestA<itk::Image<ScalarPixelType, 3>>(
       argv[3], argv[4], sigma, kernelError, kernelWidth, filterDimensionality);
   }
   else if (img_dim == 3 && vec_dim == 3)
   {
-    itkDiscreteGaussianImageFilterTestA<itk::Image<VectorPixelType, 3>>(
+    testStatus = itkDiscreteGaussianImageFilterTestA<itk::Image<VectorPixelType, 3>>(
       argv[3], argv[4], sigma, kernelError, kernelWidth, filterDimensionality);
   }
 
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkFFTDiscreteGaussianImageFilterTest.cxx
@@ -25,7 +25,7 @@
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 
 template <typename ImageType>
-int
+[[nodiscard]] int
 itkFFTDiscreteGaussianImageFilterTestProcedure(int argc, char ** argv)
 {
   const float        sigma = (argc > 4) ? std::stof(argv[4]) : 0.0;
@@ -121,18 +121,19 @@ itkFFTDiscreteGaussianImageFilterTest(int argc, char * argv[])
 
   const unsigned int ImageDimension = static_cast<unsigned int>(std::stoi(argv[1]));
 
+  int testStatus = EXIT_SUCCESS;
   if (ImageDimension == 2)
   {
-    itkFFTDiscreteGaussianImageFilterTestProcedure<itk::Image<float, 2>>(argc, &argv[0]);
+    testStatus = itkFFTDiscreteGaussianImageFilterTestProcedure<itk::Image<float, 2>>(argc, &argv[0]);
   }
   else if (ImageDimension == 3)
   {
-    itkFFTDiscreteGaussianImageFilterTestProcedure<itk::Image<float, 3>>(argc, &argv[0]);
+    testStatus = itkFFTDiscreteGaussianImageFilterTestProcedure<itk::Image<float, 3>>(argc, &argv[0]);
   }
   else
   {
     std::cout << "Did not recognize image dimension argument!" << std::endl;
     return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
+++ b/Modules/Filtering/Smoothing/test/itkSmoothingRecursiveGaussianImageFilterTest.cxx
@@ -27,7 +27,7 @@ namespace
 {
 
 template <typename TFilter>
-int
+[[nodiscard]] int
 InPlaceTest(char * inputFilename, bool normalizeAcrossScale, typename TFilter::SigmaArrayType::ValueType sigmaValue)
 {
   // Read the input image

--- a/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/itkYvvGpuCpuSimilarityTest.cxx
+++ b/Modules/Filtering/SmoothingRecursiveYvvGaussianFilter/test/itkYvvGpuCpuSimilarityTest.cxx
@@ -48,7 +48,7 @@ using PixelType = float;
 #endif
 
 template <typename ImageType>
-int
+[[nodiscard]] int
 runYvvGpuCpuSimilarityTest(const std::string & inFile, float mySigma)
 {
   using InputPixelType = PixelType;

--- a/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkCriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -29,7 +29,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TTriangleCellSubdivisionFilter>
-int
+[[nodiscard]] int
 CriterionTriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
 

--- a/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkCriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -28,7 +28,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TTriangleEdgeCellSubdivisionFilter>
-int
+[[nodiscard]] int
 CriterionTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
 

--- a/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkTriangleCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -29,7 +29,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TTriangleCellSubdivisionFilter>
-int
+[[nodiscard]] int
 TriangleCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
   using TriangleCellSubdivisionFilterType = TTriangleCellSubdivisionFilter;

--- a/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
+++ b/Modules/Filtering/SubdivisionQuadEdgeMeshFilter/test/itkTriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest.cxx
@@ -27,7 +27,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TTriangleEdgeCellSubdivisionFilter>
-int
+[[nodiscard]] int
 TriangleEdgeCellSubdivisionQuadEdgeMeshFilterTest(int argc, char * argv[])
 {
 

--- a/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
+++ b/Modules/Filtering/Thresholding/test/itkThresholdLabelerImageFilterTest.cxx
@@ -22,7 +22,7 @@
 #include "itkUnaryFunctorImageFilter.h"
 #include "itkTestingMacros.h"
 
-int
+[[nodiscard]] int
 ThresholdLabelerImageFilterTestHelper(bool useRealTypeThresholds)
 {
   //

--- a/Modules/IO/CSV/test/itkCSVArray2DFileReaderWriterTest.cxx
+++ b/Modules/IO/CSV/test/itkCSVArray2DFileReaderWriterTest.cxx
@@ -63,7 +63,7 @@ testArray(const itk::Array2D<T> & m1, const itk::Array2D<T> & m2)
   return pass;
 }
 
-int
+[[nodiscard]] int
 itkCSVFileReaderWriterTest_Func(int argc, char * argv[], bool headers)
 {
   constexpr double nan{ std::numeric_limits<double>::quiet_NaN() };

--- a/Modules/IO/GDCM/test/itkGDCMImageReadWriteTest.cxx
+++ b/Modules/IO/GDCM/test/itkGDCMImageReadWriteTest.cxx
@@ -28,7 +28,7 @@ namespace
 {
 
 template <typename TImageType>
-int
+[[nodiscard]] int
 ReadWrite(const std::string & inputImage, const std::string & outputImage)
 {
   using ImageType = TImageType;
@@ -54,7 +54,7 @@ ReadWrite(const std::string & inputImage, const std::string & outputImage)
 }
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 internalMain(const std::string &       inputImage,
              const std::string &       outputImage,
              const std::string &       expectedPixelType,

--- a/Modules/IO/GE/test/itkGEImageIOTest.cxx
+++ b/Modules/IO/GE/test/itkGEImageIOTest.cxx
@@ -35,7 +35,7 @@ using ImagePointer = ImageType::Pointer;
 using ImageReaderType = itk::ImageFileReader<ImageType>;
 using ImageWriterType = itk::ImageFileWriter<ImageType>;
 
-int
+[[nodiscard]] int
 itkGEImageIOFactoryTest(int argc, char * argv[])
 {
   static bool firstTime = true;

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOStreamingReadWriteTest.cxx
@@ -88,7 +88,7 @@ private:
 } // namespace itk
 
 template <typename TPixel>
-int
+[[nodiscard]] int
 HDF5ReadWriteTest2(const char * fileName)
 {
   { // START an isolation block for the streaming readers and writers.

--- a/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
+++ b/Modules/IO/HDF5/test/itkHDF5ImageIOTest.cxx
@@ -26,7 +26,7 @@
 
 
 template <typename TPixel>
-int
+[[nodiscard]] int
 HDF5ReadWriteTest(const char * fileName)
 {
   std::cout << fileName << std::endl;
@@ -247,7 +247,7 @@ HDF5ReadWriteTest(const char * fileName)
   return success;
 }
 
-int
+[[nodiscard]] int
 HDF5ReuseReadWriteTest(const char * fileName)
 {
   constexpr int success{ EXIT_SUCCESS };

--- a/Modules/IO/ImageBase/test/itk64bitTest.cxx
+++ b/Modules/IO/ImageBase/test/itk64bitTest.cxx
@@ -25,7 +25,7 @@
 using PixelType = unsigned long long;
 using ImageType = itk::Image<PixelType, 3>;
 
-int
+[[nodiscard]] int
 verifyContent(ImageType::Pointer image)
 {
   itk::ImageRegionConstIterator<ImageType> it(image, image->GetBufferedRegion());

--- a/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
+++ b/Modules/IO/ImageBase/test/itkLargeImageWriteReadTest.cxx
@@ -26,7 +26,7 @@ namespace
 {
 
 template <typename TImageType>
-int
+[[nodiscard]] int
 ActualTest(std::string filename, typename TImageType::SizeType size)
 {
   using ImageType = TImageType;

--- a/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest.cxx
@@ -190,7 +190,7 @@ eql_vector_diff(const itk::Point<TPixel, 3> & v1, const itk::Point<TPixel, 3> & 
 
 // TODO: properly implement storage type in MINC2 IO
 template <typename TPixel, int VDimension>
-int
+[[nodiscard]] int
 MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double tolerance = 0.0)
 {
   int success(EXIT_SUCCESS);
@@ -449,7 +449,7 @@ MINCReadWriteTest(const char * fileName, const char * minc_storage_type, double 
 }
 
 template <typename TPixel, int VDimension>
-int
+[[nodiscard]] int
 MINCReadWriteTestVector(const char * fileName,
                         size_t       vector_length,
                         const char * minc_storage_type,

--- a/Modules/IO/MINC/test/itkMINCImageIOTest_2D.cxx
+++ b/Modules/IO/MINC/test/itkMINCImageIOTest_2D.cxx
@@ -30,7 +30,7 @@
 
 
 template <typename ImageType>
-int
+[[nodiscard]] int
 test_image_moments(const char * input_image,
                    const char * output_image,
                    double       total,

--- a/Modules/IO/MeshFreeSurfer/test/itkFreeSurferMeshIOTest.cxx
+++ b/Modules/IO/MeshFreeSurfer/test/itkFreeSurferMeshIOTest.cxx
@@ -23,7 +23,7 @@
 
 
 template <typename TMeshIO>
-int
+[[nodiscard]] int
 itkFreeSurferMeshIOTestHelper(typename TMeshIO::Pointer       fsMeshIO,
                               typename TMeshIO::Pointer       readWritefsMeshIO,
                               char *                          inputFileName,

--- a/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
+++ b/Modules/IO/Meta/test/itkLargeMetaImageWriteReadTest.cxx
@@ -29,7 +29,7 @@ namespace
 {
 
 template <typename TImageType>
-int
+[[nodiscard]] int
 ActualTest(std::string filename, typename TImageType::SizeType size)
 {
   using ImageType = TImageType;

--- a/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
+++ b/Modules/IO/Meta/test/itkMetaImageIOTest2.cxx
@@ -29,7 +29,7 @@
 namespace
 {
 
-int
+[[nodiscard]] int
 TestUnknowMetaDataBug(const std::string & fname)
 {
   std::cout << "Testing for unknown meta data entry bug." << std::endl;

--- a/Modules/IO/Meta/test/testMetaImage.cxx
+++ b/Modules/IO/Meta/test/testMetaImage.cxx
@@ -28,7 +28,7 @@
 #include "itkMetaImageIO.h"
 
 template <typename PixelType, unsigned int Dimension>
-int
+[[nodiscard]] int
 ReadWriteCompare(PixelType value, const std::string & type)
 {
   std::cout << "Testing: " << type << std::endl;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest3.cxx
@@ -42,7 +42,7 @@ Decrement(ScalarType & value, std::enable_if_t<std::numeric_limits<ScalarType>::
 }
 
 template <typename ScalarType, unsigned int TVecLength, unsigned int TDimension>
-int
+[[nodiscard]] int
 TestImageOfVectors(const std::string & fname, const std::string & intentCode = "")
 {
   constexpr int dimsize{ 2 };
@@ -296,7 +296,7 @@ TestImageOfVectors(const std::string & fname, const std::string & intentCode = "
  *
  *  This test FAILS without the ConvertNumberToString fix in itkNiftiImageIO.cxx.
  */
-int
+[[nodiscard]] int
 TestNiftiFloatMetadataPrecision(const std::string & fname)
 {
   using ImageType = itk::Image<float, 3>;

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTest5.cxx
@@ -21,7 +21,7 @@
 
 
 template <typename PixelType, unsigned int TType>
-int
+[[nodiscard]] int
 SlopeInterceptTest()
 {
   //
@@ -134,7 +134,7 @@ SlopeInterceptTest()
 }
 
 template <typename PixelType>
-int
+[[nodiscard]] int
 SlopeInterceptWriteTest()
 {
   //

--- a/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOTestHelper.cxx
@@ -22,7 +22,7 @@
 // The WriteNiftiTestFiles function writes binary data to disk to ensure that both big and little endian files are
 // available. This allows all the data necessary to create the images to be stored in source files rather than have
 // separate reference images.
-int
+[[nodiscard]] int
 WriteNiftiTestFiles(const std::string & prefix)
 {
 #include "LittleEndian_hdr.h"
@@ -73,7 +73,7 @@ WriteNiftiTestFiles(const std::string & prefix)
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 TestNiftiByteSwap(const std::string & prefix)
 {
   using ImageType = itk::Image<double, 3>;

--- a/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiReadAnalyzeTest.cxx
@@ -123,7 +123,7 @@ const unsigned char LittleEndian_img[] = {
 /** WriteFile
  * Write out a char array as binary
  */
-int
+[[nodiscard]] int
 WriteFile(const std::string & name, const unsigned char * buf, size_t buflen)
 {
   std::ofstream f(name.c_str(), std::ios::binary | std::ios::out);
@@ -175,7 +175,7 @@ ReadImage(const std::string &                     fileName,
 } // namespace
 
 
-int
+[[nodiscard]] int
 itkNiftiAnalyzeContentsAndCoordinatesTest(char *                                  argv[],
                                           unsigned char                           hist_orient_code,
                                           itk::AnatomicalOrientation              expected_code,

--- a/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
+++ b/Modules/IO/PNG/test/itkPNGImageIOTest2.cxx
@@ -28,7 +28,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 CompareExtensions(itk::ImageIOBase::ArrayOfExtensionsType & a1, itk::ImageIOBase::ArrayOfExtensionsType & a2)
 {
   std::sort(a1.begin(), a1.end());

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupSpatialObjectXMLFileTest.cxx
@@ -28,7 +28,7 @@ using Polygon3DType = itk::PolygonSpatialObject<3>;
 using PolygonGroup3DType = itk::GroupSpatialObject<3>;
 using PolygonGroup3DPointer = PolygonGroup3DType::Pointer;
 
-int
+[[nodiscard]] int
 buildPolygonGroup(PolygonGroup3DPointer & PolygonGroup)
 {
   try
@@ -64,7 +64,7 @@ buildPolygonGroup(PolygonGroup3DPointer & PolygonGroup)
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 testPolygonGroupEquivalence(PolygonGroup3DPointer & p1, PolygonGroup3DPointer & p2)
 {
   //

--- a/Modules/IO/SpatialObjects/test/itkPolygonGroupXMLMalformedTest.cxx
+++ b/Modules/IO/SpatialObjects/test/itkPolygonGroupXMLMalformedTest.cxx
@@ -31,7 +31,7 @@
 
 namespace
 {
-int
+[[nodiscard]] int
 runOne(const std::string & xmlPath, const std::string & xmlBody)
 {
   {

--- a/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
+++ b/Modules/IO/TIFF/test/itkLargeTIFFImageWriteReadTest.cxx
@@ -28,7 +28,7 @@ namespace
 {
 
 template <typename TImage>
-int
+[[nodiscard]] int
 itkLargeTIFFImageWriteReadTestHelper(std::string filename, typename TImage::SizeType size)
 {
   using ImageType = TImage;

--- a/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOCompressionTest.cxx
@@ -30,7 +30,7 @@ namespace
 {
 
 template <typename TImage>
-int
+[[nodiscard]] int
 itkTIFFImageIOCompressionTestHelper(int, char * argv[], int JPEGQuality)
 {
   using ImageType = TImage;

--- a/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
+++ b/Modules/IO/TIFF/test/itkTIFFImageIOTest.cxx
@@ -59,7 +59,7 @@ TestMultipleReads(const std::string & fname, TImage *)
 // Specific ImageIO test
 
 template <typename TImage>
-int
+[[nodiscard]] int
 itkTIFFImageIOTestHelper(int, char * argv[])
 {
   using ImageType = TImage;

--- a/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
+++ b/Modules/IO/TransformInsightLegacy/test/itkIOTransformTxtTest.cxx
@@ -197,7 +197,7 @@ oneTest(const std::string & outputDirectory, const char * goodname, const char *
 // This test will exercise this reported bug:
 // https://public.kitware.com/Bug/view.php?id=7028
 template <typename ScalarType>
-int
+[[nodiscard]] int
 secondTest(const std::string & outputDirectory)
 {
   std::filebuf fb;
@@ -240,7 +240,7 @@ secondTest(const std::string & outputDirectory)
 }
 
 
-int
+[[nodiscard]] int
 templatelessTest(const std::string & outputDirectory)
 {
   const std::string outputFile = outputDirectory + "itkIOTransformTxtTestRigid2DTransform.tfm";

--- a/Modules/IO/VTK/test/itkVTIImageIOReadWriteTest.cxx
+++ b/Modules/IO/VTK/test/itkVTIImageIOReadWriteTest.cxx
@@ -26,7 +26,7 @@
 namespace
 {
 template <typename TImageType>
-int
+[[nodiscard]] int
 ReadWrite(const std::string & inputImage, const std::string & outputImage, bool compress)
 {
   auto image = itk::ReadImage<TImageType>(inputImage);
@@ -35,7 +35,7 @@ ReadWrite(const std::string & inputImage, const std::string & outputImage, bool 
 }
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 internalMain(const std::string &       inputImage,
              const std::string &       outputImage,
              itk::ImageIOBase::Pointer imageIO,

--- a/Modules/IO/VTK/test/itkVTIImageIOTest.cxx
+++ b/Modules/IO/VTK/test/itkVTIImageIOTest.cxx
@@ -107,7 +107,7 @@ ImagesEqual(const TImage * a, const TImage * b)
 }
 
 template <typename TImage>
-int
+[[nodiscard]] int
 RoundTripCompressed(const std::string & filename, const typename TImage::SizeType & size)
 {
   using ReaderType = itk::ImageFileReader<TImage>;
@@ -140,7 +140,7 @@ RoundTripCompressed(const std::string & filename, const typename TImage::SizeTyp
 }
 
 template <typename TImage>
-int
+[[nodiscard]] int
 RoundTrip(const std::string & filename, const typename TImage::SizeType & size, itk::IOFileEnum fileType)
 {
   using ReaderType = itk::ImageFileReader<TImage>;

--- a/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIO2Test.cxx
@@ -301,7 +301,7 @@ public:
 };
 
 template <typename TScalar>
-int
+[[nodiscard]] int
 Test1AsciiBinary(std::string         filePrefix,
                  std::string         outputPath,
                  const std::string & typeName,

--- a/Modules/IO/VTK/test/itkVTKImageIOFileReadTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOFileReadTest.cxx
@@ -22,7 +22,7 @@
 #include "itkTestingMacros.h"
 
 template <class TImage>
-int
+[[nodiscard]] int
 ReadImage(const std::string & fileName, typename TImage::Pointer image)
 {
 

--- a/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOStreamTest.cxx
@@ -123,7 +123,7 @@ ImagesEqual(const TImage * img1, const TImage * img2)
  * compares the original image with the read image.
  */
 template <class TScalar, unsigned int TDimension>
-int
+[[nodiscard]] int
 TestStreamWrite(char * file1, unsigned int numberOfStreams = 0)
 {
   using ImageType = itk::Image<TScalar, TDimension>;
@@ -193,7 +193,7 @@ TestStreamWrite(char * file1, unsigned int numberOfStreams = 0)
  * compares the original image with the read image.
  */
 template <class TScalar, unsigned int TDimension>
-int
+[[nodiscard]] int
 TestStreamRead(char * file1, unsigned int numberOfStreams = 0)
 {
   using ImageType = itk::Image<TScalar, TDimension>;

--- a/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
+++ b/Modules/IO/VTK/test/itkVTKImageIOTest.cxx
@@ -28,7 +28,7 @@
 // Specific ImageIO test
 
 template <typename TScalar, unsigned int TDimension>
-int
+[[nodiscard]] int
 ReadWrite(TScalar low, TScalar hi, char * file1, char * file2, bool ascii)
 {
   using ImageType = itk::Image<TScalar, TDimension>;

--- a/Modules/IO/XML/test/itkFancyStringTest.cxx
+++ b/Modules/IO/XML/test/itkFancyStringTest.cxx
@@ -39,16 +39,18 @@ testFancyStringWithItkArray();
 void
 testFancyStringForStringOperations();
 
-int
+[[nodiscard]] int
 testFancyStringUnequalOperator();
 
-int
+[[nodiscard]] int
 testFancyStringEqualOperator();
 
 
 int
 itkFancyStringTest(int, char *[])
 {
+  int testStatus = EXIT_SUCCESS;
+
   ITK_TRY_EXPECT_NO_EXCEPTION(testFancyStringWithBasicType());
 
   ITK_TRY_EXPECT_NO_EXCEPTION(testFancyStringWithStdVector());
@@ -57,13 +59,13 @@ itkFancyStringTest(int, char *[])
 
   ITK_TRY_EXPECT_NO_EXCEPTION(testFancyStringForStringOperations());
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(testFancyStringUnequalOperator());
+  ITK_TRY_EXPECT_NO_EXCEPTION(testStatus |= testFancyStringUnequalOperator());
 
-  ITK_TRY_EXPECT_NO_EXCEPTION(testFancyStringEqualOperator());
+  ITK_TRY_EXPECT_NO_EXCEPTION(testStatus |= testFancyStringEqualOperator());
 
 
   std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
+  return testStatus;
 }
 
 // test for basic data type
@@ -435,7 +437,7 @@ testFancyStringForStringOperations()
   // all testings were successful if reached here
 }
 
-int
+[[nodiscard]] int
 testFancyStringUnequalOperator()
 {
   {
@@ -474,7 +476,7 @@ testFancyStringUnequalOperator()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 testFancyStringEqualOperator()
 {
   {

--- a/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
+++ b/Modules/Nonunit/IntegratedTest/test/itkImageToHistogramFilterTest4.cxx
@@ -32,7 +32,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TVectorImage>
-int
+[[nodiscard]] int
 itkImageToHistogramFilterTest4Templated(int argc, char * argv[])
 {
 

--- a/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
+++ b/Modules/Nonunit/Review/test/itkLabelGeometryImageFilterTest.cxx
@@ -29,7 +29,7 @@
 
 // Helper function declaration.
 template <const unsigned int VDimension>
-int
+[[nodiscard]] int
 LabelGeometryImageFilterTest(std::string labelImageName,
                              std::string intensityImageName,
                              std::string outputImageName,
@@ -86,7 +86,7 @@ itkLabelGeometryImageFilterTest(int argc, char * argv[])
 }
 
 template <const unsigned int VDimension>
-int
+[[nodiscard]] int
 LabelGeometryImageFilterTest(std::string labelImageName,
                              std::string intensityImageName,
                              std::string outputImageName,

--- a/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkAmoebaOptimizerTest.cxx
@@ -231,13 +231,13 @@ private:
 /**
  * Test Amoeba with a 2D quadratic function - happy day scenario.
  */
-int
+[[nodiscard]] int
 AmoebaTest1();
 
 /**
  * Test Amoeba and Amoeba with restarts on a function with two minima.
  */
-int
+[[nodiscard]] int
 AmoebaTest2();
 
 int
@@ -257,7 +257,7 @@ itkAmoebaOptimizerTest(int, char *[])
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 AmoebaTest1()
 {
 
@@ -462,7 +462,7 @@ AmoebaTest1()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 AmoebaTest2()
 {
   std::cout << "Amoeba Optimizer Test 2\n \n";

--- a/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkInitializationBiasedParticleSwarmOptimizerTest.cxx
@@ -31,29 +31,29 @@ static OptimizerType::RandomVariateGeneratorType::IntegerType seedOffset = 0;
  * domain of either parabolas (runs the optimizer once with initial guess in
  * each of the domains).
  */
-int IBPSOTest1(OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType);
+[[nodiscard]] int IBPSOTest1(OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType);
 
 
 /**
  * Test using a 2D quadratic function (single minimum), check that converges
  * correctly.
  */
-int IBPSOTest2(OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType);
+[[nodiscard]] int IBPSOTest2(OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType);
 
 
 /**
  * Test using the 2D Rosenbrock function.
  */
-int IBPSOTest3(OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType,
-               OptimizerType::CoefficientType);
+[[nodiscard]] int IBPSOTest3(OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType,
+                             OptimizerType::CoefficientType);
 
 bool initalizationBasedTestVerboseFlag = false;
 
@@ -126,7 +126,7 @@ itkInitializationBiasedParticleSwarmOptimizerTest(int argc, char * argv[])
 }
 
 
-int
+[[nodiscard]] int
 IBPSOTest1(OptimizerType::CoefficientType inertiaCoefficient,
            OptimizerType::CoefficientType personalCoefficient,
            OptimizerType::CoefficientType globalCoefficient,
@@ -250,7 +250,7 @@ IBPSOTest1(OptimizerType::CoefficientType inertiaCoefficient,
 }
 
 
-int
+[[nodiscard]] int
 IBPSOTest2(OptimizerType::CoefficientType inertiaCoefficient,
            OptimizerType::CoefficientType personalCoefficient,
            OptimizerType::CoefficientType globalCoefficient,
@@ -349,7 +349,7 @@ IBPSOTest2(OptimizerType::CoefficientType inertiaCoefficient,
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 IBPSOTest3(OptimizerType::CoefficientType inertiaCoefficient,
            OptimizerType::CoefficientType personalCoefficient,
            OptimizerType::CoefficientType globalCoefficient,

--- a/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkLevenbergMarquardtOptimizerTest.cxx
@@ -221,7 +221,7 @@ private:
   itk::GradientEvaluationIterationEvent m_GradientEvent;
 };
 
-int
+[[nodiscard]] int
 itkRunLevenbergMarquardOptimization(bool   useGradient,
                                     double fTolerance,
                                     double gTolerance,

--- a/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
+++ b/Modules/Numerics/Optimizers/test/itkParticleSwarmOptimizerTest.cxx
@@ -30,7 +30,7 @@ static OptimizerType::RandomVariateGeneratorType::IntegerType seedOffset = 0;
  * domain of either parabolas (runs the optimizer once with initial guess in
  * each of the domains).
  */
-int
+[[nodiscard]] int
 PSOTest1();
 
 
@@ -38,14 +38,14 @@ PSOTest1();
  * Test using a 2D quadratic function (single minimum), check that converges
  * correctly.
  */
-int
+[[nodiscard]] int
 PSOTest2();
 
 
 /**
  * Test using the 2D Rosenbrock function.
  */
-int
+[[nodiscard]] int
 PSOTest3();
 
 namespace
@@ -104,7 +104,7 @@ itkParticleSwarmOptimizerTest(int argc, char * argv[])
 }
 
 
-int
+[[nodiscard]] int
 PSOTest1()
 {
   std::cout << "Particle Swarm Optimizer Test 1 [f(x) = if(x<0) x^2+4x; else 2x^2-8x]\n";
@@ -201,7 +201,7 @@ PSOTest1()
 }
 
 
-int
+[[nodiscard]] int
 PSOTest2()
 {
   std::cout << "Particle Swarm Optimizer Test 2 [f(x) = 1/2 x^T A x - b^T x]\n";
@@ -277,7 +277,7 @@ PSOTest2()
 }
 
 
-int
+[[nodiscard]] int
 PSOTest3()
 {
   std::cout << "Particle Swarm Optimizer Test 3 [f(x,y) = (1-x)^2 + 100(y-x^2)^2]\n";

--- a/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAmoebaOptimizerv4Test.cxx
@@ -296,13 +296,13 @@ private:
 /**
  * Test Amoeba with a 2D quadratic function - happy day scenario.
  */
-int
+[[nodiscard]] int
 AmoebaTest1();
 
 /**
  * Test Amoeba and Amoeba with restarts on a function with two minima.
  */
-int
+[[nodiscard]] int
 AmoebaTest2();
 
 int
@@ -322,7 +322,7 @@ itkAmoebaOptimizerv4Test(int, char *[])
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 AmoebaTest1()
 {
 
@@ -461,7 +461,7 @@ AmoebaTest1()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 AmoebaTest2()
 {
   std::cout << "Amoeba Optimizer Test 2\n \n";

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationOnVectorTest.cxx
@@ -34,7 +34,7 @@
  */
 
 template <typename TMovingTransform>
-int
+[[nodiscard]] int
 itkAutoScaledGradientDescentRegistrationOnVectorTestTemplated(int                 numberOfIterations,
                                                               double              shiftOfStep,
                                                               const std::string & scalesOption)

--- a/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkAutoScaledGradientDescentRegistrationTest.cxx
@@ -34,7 +34,7 @@
  */
 
 template <typename TMovingTransform>
-int
+[[nodiscard]] int
 itkAutoScaledGradientDescentRegistrationTestTemplated(int                 numberOfIterations,
                                                       double              shiftOfStep,
                                                       const std::string & scalesOption,

--- a/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkConjugateGradientLineSearchOptimizerv4Test.cxx
@@ -157,7 +157,7 @@ private:
 };
 
 ///////////////////////////////////////////////////////////
-int
+[[nodiscard]] int
 ConjugateGradientLineSearchOptimizerv4RunTest(itk::ConjugateGradientLineSearchOptimizerv4::Pointer & itkOptimizer)
 {
   try

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentLineSearchOptimizerv4Test.cxx
@@ -159,7 +159,7 @@ private:
 };
 
 ///////////////////////////////////////////////////////////
-int
+[[nodiscard]] int
 GradientDescentLineSearchOptimizerv4RunTest(itk::GradientDescentLineSearchOptimizerv4::Pointer & itkOptimizer)
 {
   try

--- a/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkGradientDescentOptimizerv4Test.cxx
@@ -152,7 +152,7 @@ private:
 };
 
 ///////////////////////////////////////////////////////////
-int
+[[nodiscard]] int
 GradientDescentOptimizerv4RunTest(itk::GradientDescentOptimizerv4::Pointer &             itkOptimizer,
                                   GradientDescentOptimizerv4TestMetric::ParametersType & trueParameters)
 {

--- a/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiGradientOptimizerv4Test.cxx
@@ -277,7 +277,7 @@ private:
  *  we expect an average result with solution @ (1.5,-1.5)
  */
 ///////////////////////////////////////////////////////////
-int
+[[nodiscard]] int
 MultiGradientOptimizerv4RunTest(itk::MultiGradientOptimizerv4::Pointer & itkOptimizer)
 {
   try

--- a/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkMultiStartOptimizerv4Test.cxx
@@ -153,7 +153,7 @@ private:
 };
 
 ///////////////////////////////////////////////////////////
-int
+[[nodiscard]] int
 MultiStartOptimizerv4RunTest(itk::MultiStartOptimizerv4::Pointer & itkOptimizer)
 {
   try

--- a/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkQuasiNewtonOptimizerv4Test.cxx
@@ -36,7 +36,7 @@
  */
 
 template <typename TMovingTransform>
-int
+[[nodiscard]] int
 itkQuasiNewtonOptimizerv4TestTemplated(int                 numberOfIterations,
                                        double              shiftOfStep,
                                        const std::string & scalesOption,

--- a/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
+++ b/Modules/Numerics/Optimizersv4/test/itkRegularStepGradientDescentOptimizerv4Test.cxx
@@ -154,7 +154,7 @@ private:
 };
 
 template <typename OptimizerType>
-int
+[[nodiscard]] int
 RegularStepGradientDescentOptimizerv4TestHelper(
   itk::SizeValueType                                   numberOfIterations,
   bool                                                 doEstimateLearningRateAtEachIteration,

--- a/Modules/Numerics/PrincipalComponentsAnalysis/test/itkVectorKernelPCATest.cxx
+++ b/Modules/Numerics/PrincipalComponentsAnalysis/test/itkVectorKernelPCATest.cxx
@@ -24,7 +24,7 @@
 
 
 template <typename TPixel, typename TMesh, typename TVectorContainer>
-int
+[[nodiscard]] int
 ParseVectorFields(std::vector<std::string> vectorFieldFilenames, typename TVectorContainer::Pointer vectorFieldSet)
 {
   int testStatus = EXIT_SUCCESS;

--- a/Modules/Numerics/Statistics/test/itkDecisionRuleBackwardCompatibility.cxx
+++ b/Modules/Numerics/Statistics/test/itkDecisionRuleBackwardCompatibility.cxx
@@ -23,7 +23,7 @@
 #include "itkMinimumDecisionRule2.h"      // 2007 refactored statistics library
 #include "itkMaximumRatioDecisionRule2.h" // 2007 refactored statistics library
 
-int
+[[nodiscard]] int
 itkDecisionRuleBackwardCompatibilityTest(int, char *[])
 {
   // Define a type from the old statistics library

--- a/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest.cxx
+++ b/Modules/Numerics/Statistics/test/itkImageToListSampleAdaptorTest.cxx
@@ -22,7 +22,7 @@
 #include "itkMath.h"
 
 template <typename TImage>
-int
+[[nodiscard]] int
 itkImageToListSampleAdaptorTestTemplate()
 {
   using ImageType = TImage;

--- a/Modules/Registration/Common/test/itkImageRegistrationMethodTest_5.cxx
+++ b/Modules/Registration/Common/test/itkImageRegistrationMethodTest_5.cxx
@@ -29,7 +29,7 @@
  *
  */
 
-int
+[[nodiscard]] int
 itkImageRegistrationMethodTest_5_Func(int argc, char * argv[], bool subtractMean)
 {
 

--- a/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
+++ b/Modules/Registration/Common/test/itkMattesMutualInformationImageToImageMetricTest.cxx
@@ -40,7 +40,7 @@
  *
  */
 template <typename TImage, typename TInterpolator>
-int
+[[nodiscard]] int
 TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
                                     bool            useSampling,
                                     bool            useExplicitJointPDFDerivatives,
@@ -429,7 +429,7 @@ TestMattesMetricWithAffineTransform(TInterpolator * interpolator,
  *
  */
 template <typename TImage, typename TInterpolator>
-int
+[[nodiscard]] int
 TestMattesMetricWithBSplineTransform(TInterpolator * interpolator,
                                      bool            useSampling,
                                      bool            useExplicitJointPDFDerivatives,

--- a/Modules/Registration/Common/test/itkPointsLocatorTest.cxx
+++ b/Modules/Registration/Common/test/itkPointsLocatorTest.cxx
@@ -21,7 +21,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TPointsContainer>
-int
+[[nodiscard]] int
 testPointsLocatorTest()
 {
   /**

--- a/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
+++ b/Modules/Registration/GPUPDEDeformable/test/itkGPUDemonsRegistrationFilterTest.cxx
@@ -81,7 +81,7 @@ itk::TimeProbe m_GPUTime;
 itk::TimeProbe m_CPUTime;
 
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 GPUDemonsRegistrationFilterTestTemplate(int argc, char * argv[]);
 
 template <unsigned int VDimension, typename TDisplacementFieldPointer>
@@ -139,7 +139,7 @@ itkGPUDemonsRegistrationFilterTest(int argc, char * argv[])
 namespace
 {
 template <unsigned int VDimension>
-int
+[[nodiscard]] int
 GPUDemonsRegistrationFilterTestTemplate(int argc, char * argv[])
 {
   bool         passed;

--- a/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkCorrelationImageToImageMetricv4Test.cxx
@@ -46,7 +46,7 @@ itkCorrelationImageToImageMetricv4Test_GetToyImagePixelValue(TIndexType         
 }
 
 template <typename TMetricPointer, typename TValue, typename TDerivativeType>
-int
+[[nodiscard]] int
 itkCorrelationImageToImageMetricv4Test_WithSpecifiedThreads(TMetricPointer &  metric,
                                                             TValue &          value,
                                                             TDerivativeType & derivative)

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricRegistrationTest.cxx
@@ -66,7 +66,7 @@ using itkEuclideanDistancePointSetMetricRegistrationTestTransformType = itk::Tra
 
 /////////////////////////////////////////////////////////
 template <typename TTransform, typename TMetric, typename TPointSet>
-int
+[[nodiscard]] int
 itkEuclideanDistancePointSetMetricRegistrationTestRun(unsigned int                   numberOfIterations,
                                                       double                         maximumPhysicalStepSize,
                                                       double                         pointMax,

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest.cxx
@@ -23,7 +23,7 @@
 #include "itkMath.h"
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkEuclideanDistancePointSetMetricTestRun()
 {
   using PointSetType = itk::PointSet<unsigned char, Dimension>;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest2.cxx
@@ -29,7 +29,7 @@
  */
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkEuclideanDistancePointSetMetricTest2Run()
 {
   using PointSetType = itk::PointSet<unsigned char, Dimension>;

--- a/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
+++ b/Modules/Registration/Metricsv4/test/itkEuclideanDistancePointSetMetricTest3.cxx
@@ -28,7 +28,7 @@
  */
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkEuclideanDistancePointSetMetricTest3Run(double distanceThreshold)
 {
   using PointSetType = itk::PointSet<float, Dimension>;

--- a/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkExpectationBasedPointSetMetricTest.cxx
@@ -24,7 +24,7 @@
 #include "itkTestingMacros.h"
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkExpectationBasedPointSetMetricTestRun()
 {
   using PointSetType = itk::PointSet<unsigned char, Dimension>;

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4RegistrationTest.cxx
@@ -39,7 +39,7 @@
  */
 
 template <unsigned int Dimension, typename TImage, typename TMetric>
-int
+[[nodiscard]] int
 ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
                                         int                        numberOfIterations,
                                         typename TImage::PixelType maximumStepSize,
@@ -207,7 +207,7 @@ ImageToImageMetricv4RegistrationTestRun(typename TMetric::Pointer  metric,
 
 //////////////////////////////////////////////////////////////
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkImageToImageMetricv4RegistrationTestRunAll(int argc, char * argv[])
 {
   using ImageType = itk::Image<double, Dimension>;

--- a/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkImageToImageMetricv4Test.cxx
@@ -306,7 +306,7 @@ ImageToImageMetricv4TestComputeIdentityTruthValues(const ImageToImageMetricv4Tes
 // Useful for establishing a relative truth for multiple runs.
 // Otherwise, this will compare the results of calling the metric
 // with truthValue and truthDerivative.
-int
+[[nodiscard]] int
 ImageToImageMetricv4TestRunSingleTest(const ImageToImageMetricv4TestMetricPointer &        metric,
                                       ImageToImageMetricv4TestMetricType::MeasureType &    truthValue,
                                       ImageToImageMetricv4TestMetricType::DerivativeType & truthDerivative,

--- a/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkJensenHavrdaCharvatTsallisPointSetMetricTest.cxx
@@ -23,7 +23,7 @@
 #include <fstream>
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkJensenHavrdaCharvatTsallisPointSetMetricTestRun()
 {
   using PointSetType = itk::PointSet<unsigned char, Dimension>;

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricRegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricRegistrationTest.cxx
@@ -63,7 +63,7 @@ public:
 };
 
 template <class PointSetMetricType>
-int
+[[nodiscard]] int
 itkLabeledPointSetMetricRegistrationTestPerMetric(unsigned int numberOfIterations, PointSetMetricType * pointSetMetric)
 {
   using PointSetType = typename PointSetMetricType::FixedPointSetType;

--- a/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkLabeledPointSetMetricTest.cxx
@@ -25,7 +25,7 @@
 #include "itkMath.h"
 
 template <unsigned int Dimension>
-int
+[[nodiscard]] int
 itkLabeledPointSetMetricTestRun()
 {
   using LabelType = unsigned int;

--- a/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMattesMutualInformationImageToImageMetricv4Test.cxx
@@ -48,7 +48,7 @@
  *
  */
 template <typename TImage, typename TInterpolator>
-int
+[[nodiscard]] int
 TestMattesMetricWithAffineTransform(TInterpolator * const interpolator, const bool useSampling, const size_t imageSize)
 {
 

--- a/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
+++ b/Modules/Registration/Metricsv4/test/itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx
@@ -25,7 +25,7 @@
  */
 
 template <typename TMetric>
-int
+[[nodiscard]] int
 itkMeanSquaresImageToImageMetricv4OnVectorTest2Run(typename TMetric::MeasureType &    measureReturn,
                                                    typename TMetric::DerivativeType & derivativeReturn)
 {
@@ -138,10 +138,12 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2(int, char ** const)
   using VectorMetricType =
     itk::MeanSquaresImageToImageMetricv4<VectorImageType, VectorImageType, VectorImageType, double, MetricTraitsType>;
 
+  int testStatus = EXIT_SUCCESS;
+
   VectorMetricType::MeasureType    vectorMeasure = 0.0;
   VectorMetricType::DerivativeType vectorDerivative{};
 
-  itkMeanSquaresImageToImageMetricv4OnVectorTest2Run<VectorMetricType>(vectorMeasure, vectorDerivative);
+  testStatus |= itkMeanSquaresImageToImageMetricv4OnVectorTest2Run<VectorMetricType>(vectorMeasure, vectorDerivative);
   std::cout << "vectorMeasure: " << vectorMeasure << " vectorDerivative: " << vectorDerivative << std::endl;
 
   /* The scalar metric */
@@ -151,7 +153,7 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2(int, char ** const)
   ScalarMetricType::MeasureType    scalarMeasure = 0.0;
   ScalarMetricType::DerivativeType scalarDerivative{};
 
-  itkMeanSquaresImageToImageMetricv4OnVectorTest2Run<ScalarMetricType>(scalarMeasure, scalarDerivative);
+  testStatus |= itkMeanSquaresImageToImageMetricv4OnVectorTest2Run<ScalarMetricType>(scalarMeasure, scalarDerivative);
   std::cout << "scalarMeasure: " << scalarMeasure << " scalarDerivative: " << scalarDerivative << std::endl;
 
   /* Compare */
@@ -177,5 +179,5 @@ itkMeanSquaresImageToImageMetricv4OnVectorTest2(int, char ** const)
   std::cout << "Derivative values match." << std::endl;
 
   std::cout << "Test passed." << std::endl;
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4RegistrationTest.cxx
@@ -135,7 +135,7 @@ ObjectToObjectMultiMetricv4RegistrationTestCreateImages(typename TImage::Pointer
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <typename TMetric>
-int
+[[nodiscard]] int
 ObjectToObjectMultiMetricv4RegistrationTestRun(typename TMetric::Pointer &                    metric,
                                                int                                            numberOfIterations,
                                                typename TMetric::MeasureType &                valueResult,
@@ -224,10 +224,12 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
 
   translationTransform->SetIdentity();
 
+  int testStatus = EXIT_SUCCESS;
+
   std::cout << std::endl << "*** Single image metric: " << std::endl;
   CorrelationMetricType::MeasureType    singleValueResult = 0.0;
   CorrelationMetricType::DerivativeType singleDerivativeResult{};
-  ObjectToObjectMultiMetricv4RegistrationTestRun<CorrelationMetricType>(
+  testStatus |= ObjectToObjectMultiMetricv4RegistrationTestRun<CorrelationMetricType>(
     correlationMetric, numberOfIterations, singleValueResult, singleDerivativeResult, 1.0, true);
 
   std::cout << "*** multi-variate metric: " << std::endl;
@@ -247,7 +249,7 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
 
   CorrelationMetricType::MeasureType    multiValueResult = 0.0;
   CorrelationMetricType::DerivativeType multiDerivativeResult{};
-  ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
+  testStatus |= ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
     multiMetric, numberOfIterations, multiValueResult, multiDerivativeResult, 1.0, true);
 
   // Comparison between single-metric and multi-variate metric registrations
@@ -283,12 +285,12 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
   //
   std::cout << std::endl << "*** Single image metric 2: " << std::endl;
   translationTransform->SetIdentity();
-  ObjectToObjectMultiMetricv4RegistrationTestRun<CorrelationMetricType>(
+  testStatus |= ObjectToObjectMultiMetricv4RegistrationTestRun<CorrelationMetricType>(
     correlationMetric, numberOfIterations, singleValueResult, singleDerivativeResult, 0.25, false);
 
   std::cout << std::endl << "*** Multi-variate image metric 2: " << std::endl;
   translationTransform->SetIdentity();
-  ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
+  testStatus |= ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
     multiMetric, numberOfIterations, multiValueResult, multiDerivativeResult, 0.25, false);
 
   if (itk::Math::Absolute(multiDerivativeResult[0] - singleDerivativeResult[0]) > tolerance ||
@@ -331,7 +333,7 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
 
   translationTransform->SetIdentity();
   std::cout << "*** Multi-metric with different metric types: " << std::endl;
-  ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
+  testStatus |= ObjectToObjectMultiMetricv4RegistrationTestRun<MultiMetricType>(
     multiMetric2, numberOfIterations, multiValueResult, multiDerivativeResult, 1.0, true);
 
   // compare results with truth
@@ -344,5 +346,5 @@ itkObjectToObjectMultiMetricv4RegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
+++ b/Modules/Registration/Metricsv4/test/itkObjectToObjectMultiMetricv4Test.cxx
@@ -43,7 +43,7 @@ using ObjectToObjectMultiMetricv4TestMultiMetricType =
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-int
+[[nodiscard]] int
 itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiMetricType::Pointer & multiVariateMetric,
                                            bool useDisplacementTransform)
 {
@@ -198,7 +198,7 @@ itkObjectToObjectMultiMetricv4TestEvaluate(ObjectToObjectMultiMetricv4TestMultiM
 
 ////////////////////////////////////////////////////////////
 
-int
+[[nodiscard]] int
 itkObjectToObjectMultiMetricv4TestRun(bool useDisplacementTransform)
 {
   // Create two simple images

--- a/Modules/Registration/Montage/test/itkMontagePCMTestFiles.cxx
+++ b/Modules/Registration/Montage/test/itkMontagePCMTestFiles.cxx
@@ -29,7 +29,7 @@ namespace itk
 {
 
 template <unsigned int VDimension, typename TFixedImagePixel, typename TMovingImagePixel>
-int
+[[nodiscard]] int
 PhaseCorrelationRegistrationFiles(int argc, char * argv[])
 {
   int testStatus = EXIT_SUCCESS;

--- a/Modules/Registration/Montage/test/itkMontagePCMTestSynthetic.cxx
+++ b/Modules/Registration/Montage/test/itkMontagePCMTestSynthetic.cxx
@@ -118,7 +118,7 @@ public:
 
 
 template <unsigned int VDimension, typename TFixedImagePixel, typename TMovingImagePixel>
-int
+[[nodiscard]] int
 PhaseCorrelationRegistration(int argc, char * argv[])
 {
   if (argc < 6)

--- a/Modules/Registration/Montage/test/itkMontageTest.cxx
+++ b/Modules/Registration/Montage/test/itkMontageTest.cxx
@@ -23,7 +23,7 @@
 #include "itkNumericTraits.h"
 
 template <typename PixelType, typename AccumulatePixelType, unsigned Dimension>
-int
+[[nodiscard]] int
 itkMontageTestHelper2(int                               argc,
                       char *                            argv[],
                       const std::string &               inputPath,

--- a/Modules/Registration/Montage/test/itkMontageTruthCreator.cxx
+++ b/Modules/Registration/Montage/test/itkMontageTruthCreator.cxx
@@ -26,7 +26,7 @@
 
 
 template <typename PixelType, unsigned Dimension>
-int
+[[nodiscard]] int
 CreateGroundTruth(char *                        inFilename,
                   const std::vector<unsigned> & montageSize,
                   const std::vector<double> &   overlap,
@@ -129,7 +129,7 @@ CreateGroundTruth(char *                        inFilename,
 }
 
 template <typename PixelType>
-int
+[[nodiscard]] int
 CreateGroundTruth(int argc, char * argv[], unsigned dimension)
 {
   std::string outputPath = argv[2];
@@ -172,7 +172,7 @@ CreateGroundTruth(int argc, char * argv[], unsigned dimension)
 }
 
 template <typename ComponentType>
-int
+[[nodiscard]] int
 CreateGroundTruth(int argc, char * argv[], unsigned dimension, itk::IOPixelEnum pixelType)
 {
   if (pixelType == itk::IOPixelEnum::RGB) // possibly add RGBA

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -108,7 +108,7 @@ public:
 };
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 PerformBSplineExpImageRegistration(int argc, char * argv[])
 {
   if (argc < 6)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineExponentialImageRegistrationTest.cxx
@@ -406,17 +406,18 @@ itkBSplineExponentialImageRegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformBSplineExpImageRegistration<2>(argc, argv);
+      testStatus = PerformBSplineExpImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformBSplineExpImageRegistration<3>(argc, argv);
+      testStatus = PerformBSplineExpImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -355,13 +355,14 @@ itkBSplineImageRegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformBSplineImageRegistration<2>(argc, argv);
+      testStatus = PerformBSplineImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformBSplineImageRegistration<3>(argc, argv);
+      testStatus = PerformBSplineImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
@@ -379,5 +380,5 @@ itkBSplineImageRegistrationTest(int argc, char * argv[])
     std::cout << "STREAMED ENUM VALUE ImageRegistrationMethodv4Enums::MetricSamplingStrategy: " << ee << std::endl;
   }
 
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkBSplineImageRegistrationTest.cxx
@@ -97,7 +97,7 @@ public:
 };
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 PerformBSplineImageRegistration(int argc, char * argv[])
 {
   if (argc < 6)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -111,7 +111,7 @@ public:
 };
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 PerformExpImageRegistration(int argc, char * argv[])
 {
   if (argc < 10)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkExponentialImageRegistrationTest.cxx
@@ -461,17 +461,18 @@ itkExponentialImageRegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformExpImageRegistration<2>(argc, argv);
+      testStatus = PerformExpImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformExpImageRegistration<3>(argc, argv);
+      testStatus = PerformExpImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkQuasiNewtonOptimizerv4RegistrationTest.cxx
@@ -50,7 +50,7 @@
 #include "itkTestingMacros.h"
 
 template <unsigned int Dimension, typename TAffineTransform>
-int
+[[nodiscard]] int
 itkQuasiNewtonOptimizerv4RegistrationTestMain(int argc, char * argv[])
 {
   const std::string metricString = argv[2];

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest.cxx
@@ -113,7 +113,7 @@ public:
 };
 
 template <unsigned int VImageDimension, typename TPixel>
-int
+[[nodiscard]] int
 PerformSimpleImageRegistration(int argc, char * argv[])
 {
   if (argc < 7)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest2.cxx
@@ -130,7 +130,7 @@ public:
 };
 
 template <unsigned int VImageDimension>
-int
+[[nodiscard]] int
 PerformSimpleImageRegistration2(int argc, char * argv[])
 {
   if (argc < 6)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest3.cxx
@@ -117,7 +117,7 @@ public:
 };
 
 template <unsigned int TDimension>
-int
+[[nodiscard]] int
 PerformCompositeImageRegistration(int argc, char * argv[])
 {
   if (argc != 5)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTest4.cxx
@@ -76,7 +76,7 @@ public:
 };
 
 template <unsigned int TDimension>
-int
+[[nodiscard]] int
 ImageRegistration(int argc, char * argv[])
 {
   ITK_TEST_EXPECT_TRUE(argc == 4);

--- a/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkSimpleImageRegistrationTestWithMaskAndSampling.cxx
@@ -113,7 +113,7 @@ public:
 };
 
 template <unsigned int VImageDimension, typename TPixel>
-int
+[[nodiscard]] int
 PerformSimpleImageRegistrationWithMaskAndSampling(int argc, char * argv[])
 {
   if (argc < 7)

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -73,7 +73,7 @@ public:
 };
 
 template <unsigned int TDimension>
-int
+[[nodiscard]] int
 PerformTimeVaryingBSplineVelocityFieldImageRegistration(int argc, char * argv[])
 {
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx
@@ -488,17 +488,18 @@ itkTimeVaryingBSplineVelocityFieldImageRegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformTimeVaryingBSplineVelocityFieldImageRegistration<2>(argc, argv);
+      testStatus = PerformTimeVaryingBSplineVelocityFieldImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformTimeVaryingBSplineVelocityFieldImageRegistration<3>(argc, argv);
+      testStatus = PerformTimeVaryingBSplineVelocityFieldImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -73,7 +73,7 @@ public:
 };
 
 template <unsigned int TDimension>
-int
+[[nodiscard]] int
 PerformTimeVaryingVelocityFieldImageRegistration(int argc, char * argv[])
 {
 

--- a/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
+++ b/Modules/Registration/RegistrationMethodsv4/test/itkTimeVaryingVelocityFieldImageRegistrationTest.cxx
@@ -423,17 +423,18 @@ itkTimeVaryingVelocityFieldImageRegistrationTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
+  int testStatus = EXIT_SUCCESS;
   switch (std::stoi(argv[1]))
   {
     case 2:
-      PerformTimeVaryingVelocityFieldImageRegistration<2>(argc, argv);
+      testStatus = PerformTimeVaryingVelocityFieldImageRegistration<2>(argc, argv);
       break;
     case 3:
-      PerformTimeVaryingVelocityFieldImageRegistration<3>(argc, argv);
+      testStatus = PerformTimeVaryingVelocityFieldImageRegistration<3>(argc, argv);
       break;
     default:
       std::cerr << "Unsupported dimension" << std::endl;
       return EXIT_FAILURE;
   }
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
+++ b/Modules/Segmentation/Classifiers/test/itkBayesianClassifierImageFilterTest.cxx
@@ -30,7 +30,7 @@
 
 
 template <typename TInputImage, typename TBayesianClassifierInitializer, typename TBayesianClassifierFilter>
-int
+[[nodiscard]] int
 TestBayesianClassifierImageFilterWithNoPriors(typename TInputImage::Pointer image,
                                               unsigned int                  numberOfClasses,
                                               unsigned int                  numberOfSmoothingIterations,
@@ -97,7 +97,7 @@ TestBayesianClassifierImageFilterWithNoPriors(typename TInputImage::Pointer imag
 
 
 template <typename TInputImage, typename TBayesianClassifierInitializer, typename TBayesianClassifierFilter>
-int
+[[nodiscard]] int
 TestBayesianClassifierImageFilterWithPriors(typename TInputImage::Pointer                                image,
                                             typename TBayesianClassifierFilter::PriorsImageType::Pointer priorsImage,
                                             unsigned int numberOfClasses,

--- a/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
+++ b/Modules/Segmentation/ConnectedComponents/test/itkHardConnectedComponentImageFilterTest.cxx
@@ -22,7 +22,7 @@
 #include "itkTestingMacros.h"
 
 template <typename TPixel>
-int
+[[nodiscard]] int
 DoIt(int argc, char * argv[], const std::string & pixelType)
 {
   if (argc < 2)

--- a/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
+++ b/Modules/Segmentation/LabelVoting/test/itkVotingBinaryImageFilterTest.cxx
@@ -26,7 +26,7 @@ namespace
 {
 
 template <typename TInputImageType>
-int
+[[nodiscard]] int
 itkVotingBinaryImageFilterTestImp(const std::string & infname,
                                   const std::string & outfname,
                                   itk::SizeValueType  radius,

--- a/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
+++ b/Modules/Segmentation/SuperPixel/test/itkSLICImageFilterTest.cxx
@@ -44,7 +44,7 @@ iterationEventCallback(itk::Object * object, const itk::EventObject & event, voi
 
 
 template <typename TInputImageType>
-int
+[[nodiscard]] int
 itkSLICImageFilterTestHelper(const std::string & inFileName,
                              const std::string & outFileName,
                              const unsigned int  gridSize,
@@ -117,28 +117,31 @@ itkSLICImageFilterTest(int argc, char * argv[])
 
   const unsigned int Dimension = reader->GetImageIO()->GetNumberOfDimensions();
   const unsigned int numberOfComponents = reader->GetImageIO()->GetNumberOfComponents();
+  int                testStatus = EXIT_SUCCESS;
   switch (Dimension)
   {
     case 1:
     case 2:
       if (numberOfComponents == 1)
       {
-        itkSLICImageFilterTestHelper<itk::Image<float, 2>>(inFileName, outFileName, gridSize, enforceConnectivity);
+        testStatus =
+          itkSLICImageFilterTestHelper<itk::Image<float, 2>>(inFileName, outFileName, gridSize, enforceConnectivity);
       }
       else
       {
-        itkSLICImageFilterTestHelper<itk::VectorImage<float, 2>>(
+        testStatus = itkSLICImageFilterTestHelper<itk::VectorImage<float, 2>>(
           inFileName, outFileName, gridSize, enforceConnectivity);
       }
       break;
     case 3:
       if (numberOfComponents == 1)
       {
-        itkSLICImageFilterTestHelper<itk::Image<float, 3>>(inFileName, outFileName, gridSize, enforceConnectivity);
+        testStatus =
+          itkSLICImageFilterTestHelper<itk::Image<float, 3>>(inFileName, outFileName, gridSize, enforceConnectivity);
       }
       else
       {
-        itkSLICImageFilterTestHelper<itk::VectorImage<float, 3>>(
+        testStatus = itkSLICImageFilterTestHelper<itk::VectorImage<float, 3>>(
           inFileName, outFileName, gridSize, enforceConnectivity);
       }
       break;
@@ -149,5 +152,5 @@ itkSLICImageFilterTest(int argc, char * argv[])
 
 
   std::cout << "Test finished." << std::endl;
-  return EXIT_SUCCESS;
+  return testStatus;
 }

--- a/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
+++ b/Modules/Segmentation/Voronoi/test/itkVoronoiSegmentationRGBImageFilterTest.cxx
@@ -199,7 +199,7 @@ CheckResults(SegmentationType::Pointer outputImage)
 //
 // Test with no prior
 //
-int
+[[nodiscard]] int
 TestNoPrior(ImageType::Pointer inputImage)
 {
 
@@ -261,7 +261,7 @@ TestNoPrior(ImageType::Pointer inputImage)
 //
 // Test with a prior
 //
-int
+[[nodiscard]] int
 TestWithPrior(ImageType::Pointer inputImage)
 {
   // set up the filter

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVBasicTypeBridgeTest.cxx
@@ -19,7 +19,7 @@
 
 namespace FromOpenCV
 {
-int
+[[nodiscard]] int
 Point2ConversionTest()
 {
   using ITKPoint2iType = itk::Point<int, 2>;
@@ -53,7 +53,7 @@ Point2ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Point3ConversionTest()
 {
   using ITKPoint3iType = itk::Point<int, 3>;
@@ -87,7 +87,7 @@ Point3ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 PointToVectorConversionTest()
 {
   using ITKPoint3dType = itk::Point<double, 3>;
@@ -111,7 +111,7 @@ PointToVectorConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Index2ConversionTest()
 {
   using ITKIndexType = itk::Index<2>;
@@ -129,7 +129,7 @@ Index2ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Index3ConversionTest()
 {
   using ITKIndexType = itk::Index<3>;
@@ -147,7 +147,7 @@ Index3ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Size2ConversionTest()
 {
   using ITKSizeType = itk::Size<2>;
@@ -166,7 +166,7 @@ Size2ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 MatrixConversionTest()
 {
   constexpr unsigned int NumberOfRows{ 2 };
@@ -208,7 +208,7 @@ MatrixConversionTest()
   return oResult;
 }
 
-int
+[[nodiscard]] int
 VectorConversionTest()
 {
   constexpr unsigned int Dimension{ 10 };
@@ -242,7 +242,7 @@ VectorConversionTest()
   return oResult;
 }
 
-int
+[[nodiscard]] int
 ToITK()
 {
   if (Point2ConversionTest() != EXIT_SUCCESS)
@@ -292,7 +292,7 @@ ToITK()
 
 namespace FromITK
 {
-int
+[[nodiscard]] int
 Point2ConversionTest()
 {
   using ITKPoint2iType = itk::Point<int, 2>;
@@ -333,7 +333,7 @@ Point2ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Point3ConversionTest()
 {
   using ITKPoint3iType = itk::Point<int, 3>;
@@ -378,7 +378,7 @@ Point3ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Index2ConversionTest()
 {
   using ITKIndexType = itk::Index<2>;
@@ -398,7 +398,7 @@ Index2ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Index3ConversionTest()
 {
   using ITKIndexType = itk::Index<3>;
@@ -419,7 +419,7 @@ Index3ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 Size2ConversionTest()
 {
   using ITKSizeType = itk::Size<2>;
@@ -439,7 +439,7 @@ Size2ConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 MatrixConversionTest()
 {
   constexpr unsigned int NumberOfRows{ 2 };
@@ -481,7 +481,7 @@ MatrixConversionTest()
   return oResult;
 }
 
-int
+[[nodiscard]] int
 VectorConversionTest()
 {
   constexpr unsigned int Dimension{ 10 };
@@ -515,7 +515,7 @@ VectorConversionTest()
   return oResult;
 }
 
-int
+[[nodiscard]] int
 PointToVectorConversionTest()
 {
   using ITKPoint3dType = itk::Point<double, 3>;
@@ -539,7 +539,7 @@ PointToVectorConversionTest()
   return EXIT_SUCCESS;
 }
 
-int
+[[nodiscard]] int
 ToOpenCV()
 {
   if (Point2ConversionTest() != EXIT_SUCCESS)

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeGrayScaleTest.cxx
@@ -82,7 +82,7 @@ ConvertIplImageDataType(IplImage * in)
 
 // Templated test function to do the heavy lifting for scalar case
 template <typename TPixelType, unsigned int VDimension>
-int
+[[nodiscard]] int
 itkOpenCVImageBridgeTestTemplatedScalar(char * argv)
 {
   // type alias
@@ -207,7 +207,7 @@ itkOpenCVImageBridgeTestTemplatedScalar(char * argv)
 }
 
 template <typename TPixel>
-int
+[[nodiscard]] int
 itkRunScalarTest(char * argv)
 {
   if (itkOpenCVImageBridgeTestTemplatedScalar<TPixel, 2>(argv) == EXIT_FAILURE)

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVImageBridgeRGBTest.cxx
@@ -138,7 +138,7 @@ ConvertIplImageDataType(IplImage * in)
 
 // Templated test function to do the heavy lifting for RGB case
 template <typename TValue, unsigned int VDimension>
-int
+[[nodiscard]] int
 itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
 {
   // type alias
@@ -234,7 +234,7 @@ itkOpenCVImageBridgeTestTemplatedRGB(char * argv0, char * argv1)
 }
 
 template <typename TValue>
-int
+[[nodiscard]] int
 itkRunRGBTest(char * argv0, char * argv1)
 {
   if (itkOpenCVImageBridgeTestTemplatedRGB<TValue, 2>(argv0, argv1) == EXIT_FAILURE)

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOFactoryTest.cxx
@@ -31,7 +31,7 @@ using SizeValueType = itk::SizeValueType;
 // Usage: [Video Input] [Non-Video Input] [Video Output] [Width] [Height]
 //            [Num Frames] [FpS]
 
-int
+[[nodiscard]] int
 test_OpenCVVideoIOFactory(char * input, char * output, SizeValueType cameraNumber)
 {
 

--- a/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
+++ b/Modules/Video/BridgeOpenCV/test/itkOpenCVVideoIOTest.cxx
@@ -193,7 +193,7 @@ videosMatch(char * file1, char * file2)
 // Usage: [Video Input] [Non-Video Input] [Video Output] [Width] [Height]
 //            [Num Frames] [FpS]
 
-int
+[[nodiscard]] int
 test_OpenCVVideoIO(char *          input,
                    char *          nonVideoInput,
                    char *          output,

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOFactoryTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOFactoryTest.cxx
@@ -27,7 +27,7 @@
 // Usage: [Video Input] [Non-Video Input] [Video Output] [Width] [Height]
 //            [Num Frames] [FpS]
 
-int
+[[nodiscard]] int
 test_VXLVideoIOFactory(char * input, char * output, itk::SizeValueType itkNotUsed(cameraNumber))
 {
 

--- a/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
+++ b/Modules/Video/BridgeVXL/test/itkVXLVideoIOTest.cxx
@@ -189,7 +189,7 @@ bool videosMatch(char* file1, char* file2)
 // Usage: [Video Input] [Non-Video Input] [Video Output] [Width] [Height]
 //            [Num Frames] [FpS]
 
-int
+[[nodiscard]] int
 test_VXLVideoIO(char *        input,
                 char *        nonVideoInput,
                 char *        output,

--- a/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
+++ b/Modules/Video/BridgeVXL/test/vidl_itk_istreamTest.cxx
@@ -49,7 +49,7 @@ TestFormat(vidl_pixel_format expectedFormat)
 
 
 template <typename TPixelType>
-int
+[[nodiscard]] int
 vidl_itk_istreamTestWithPixelType(char * argv[], vidl_pixel_format expectedFormat)
 {
   // type alias

--- a/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOFactoryTest.cxx
@@ -28,7 +28,7 @@
 // Usage: [Video Input] [Non-Video Input] [Video Output] [Width] [Height]
 //            [Num Frames] [FpS]
 
-int
+[[nodiscard]] int
 test_FileListVideoIOFactory(const char * input, char * output, itk::SizeValueType itkNotUsed(cameraNumber))
 {
 

--- a/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
+++ b/Modules/Video/IO/test/itkFileListVideoIOTest.cxx
@@ -29,7 +29,7 @@
 using SizeValueType = itk::SizeValueType;
 
 
-int
+[[nodiscard]] int
 test_FileListVideoIO(const char *  input,
                      char *        nonVideoInput,
                      char *        output,


### PR DESCRIPTION
Test helpers that return `EXIT_SUCCESS`/`EXIT_FAILURE` are now `[[nodiscard]]`, so a caller that drops the status no longer compiles. That plus the six original call-site fixes turns 13 explicit failure returns and 31 `ITK_TEST_*` assertions back into real assertions, and exposed a wrong superclass assertion that only MSVC evaluates.

<details>
<summary>The defect</summary>

```cpp
switch (std::stoi(argv[1]))
{
  case 2:
    PerformBSplineExpImageRegistration<2>(argc, argv);   // return value ignored
    break;
  ...
}
return EXIT_SUCCESS;
```

The helpers do run — each one's argument-count guard matches its registered CMake invocation — so the defect is latent: the assertions execute but their verdict is discarded.

| File | Swallowed inside the helper |
|---|---|
| `itkLabelOverlapMeasuresImageFilterTest.cxx` | 6 `return EXIT_FAILURE` |
| `itkBSplineExponentialImageRegistrationTest.cxx` | 2 + 2 `ITK_TEST_*` |
| `itkBSplineImageRegistrationTest.cxx` | 2 + 2 |
| `itkExponentialImageRegistrationTest.cxx` | 3 + 7 |
| `itkTimeVaryingBSplineVelocityFieldImageRegistrationTest.cxx` | 13 `ITK_TEST_*` |
| `itkTimeVaryingVelocityFieldImageRegistrationTest.cxx` | 7 `ITK_TEST_*` |

</details>

<details>
<summary>Commit 2: the Windows failure this unmasked</summary>

`itkLabelOverlapMeasuresImageFilterTest`'s helper asserts

```cpp
ITK_EXERCISE_BASIC_OBJECT_METHODS(filter, LabelOverlapMeasuresImageFilter, ImageToImageFilter);
```

but the filter derives from `ImageSink` (`itkLabelOverlapMeasuresImageFilter.h:43`), and the enclosing test asserts `ImageSink` correctly 140 lines later.

The assertion is compiler-dependent. `itkTestingMacros.h:54-83` defines two variants: under `__GNUC__` the macro only prints the class name, while everywhere else it also compares `Superclass::GetNameOfClass()` and returns `EXIT_FAILURE` on mismatch. GCC and Clang both define `__GNUC__`, so only MSVC evaluates the check — and only once commit 1 stopped discarding the helper's status did that reach the test result. `Pixi-Cxx (windows-2022)` was the sole red check before this fix.

</details>

<details>
<summary>Commit 3: [[nodiscard]] across the test tree</summary>

290 declarations in 211 files. Selection is mechanical: a file-scope, non-entry-point function returning `int` whose body contains `EXIT_SUCCESS` or `EXIT_FAILURE`.

The attribute goes on **every** declaration, not only the definition. `[[nodiscard]]` governs calls that follow the declaration carrying it, so a bare forward declaration leaves earlier call sites unchecked — annotating the 14 forward declarations is what exposed the `CoherenceEnhancingDiffusionTest` site below.

Deliberately not annotated:

- 38 `int`-returning helpers whose return is a value, not a status (`lookup` in `itkExceptionObjectTest`, the `dynamic_castDownCast*` family, the `test*Spline` helpers). Annotating these would only force `(void)` casts at legitimate discard sites.
- `TestKernelTransform`, which uses a bare `0`/`1` convention and needs a semantics change first — handled separately.
- `itkSyNImageRegistrationTest` and `itkBSplineSyNImageRegistrationTest`, whose discarded call sites are fixed by #6703. Annotating them without that PR's argc fix makes `itkBSplineSyNImageRegistrationTest` fail. They can be annotated once #6703 lands.

The attribute exposed 30 discarded call sites in 8 tests, all fixed here:

| File | Sites |
|---|---|
| `itkCentralDifferenceImageFunctionOnVectorSpeedTest.cxx` | 10 |
| `itkObjectToObjectMultiMetricv4RegistrationTest.cxx` | 5 |
| `itkDiscreteGaussianImageFilterTest2.cxx` | 4 |
| `itkSLICImageFilterTest.cxx` | 4 |
| `itkFFTDiscreteGaussianImageFilterTest.cxx` | 2 |
| `itkFancyStringTest.cxx` | 2 |
| `itkMeanSquaresImageToImageMetricv4OnVectorTest2.cxx` | 2 |
| `CoherenceEnhancingDiffusionTest.cxx` | 1 |

Where a helper is called several times in one scope the status accumulates with `testStatus |=` (the existing idiom in `itkColorTableTest.cxx`); plain `=` is used only where the branches are mutually exclusive.

Three of these were invisible to a source-level audit: in `itkFancyStringTest` and `CoherenceEnhancingDiffusionTest` the discard happens inside `ITK_TRY_EXPECT_NO_EXCEPTION(...)`, where the call is not lexically a statement. The compiler sees it after expansion; a grep does not.

</details>

<details>
<summary>Test plan</summary>

Release, Ninja, AppleClang, macOS arm64, in a build tree configured against this branch alone (`Module_ITKReview=ON` added so no annotated file goes uncompiled).

- Full build of 8452 targets plus incremental passes: zero `-Wunused-result` diagnostics, zero errors, no new warnings.
- `ctest -j8`: 100% passed, 0 failed out of 6207.
- `pre-commit run --all-files` exits 0.

Not exercised locally: the annotated files under `Video/BridgeOpenCV`, `Video/BridgeVXL` and the GPU modules, which need OpenCV / VXL / OpenCL. Every helper and call site in those 20 files was inspected by hand and all consume their return value. CI covers the compile.

</details>

<!--
provenance: claude-code session 2026-07-25
base: upstream/main @ 3ae346c2409 (rebased from 07382b56fa5)
commits: dfb57953468 (propagate), 72c18a43de0 (ImageSink superclass), 021999f0c7a (nodiscard sweep)
split out of PR #6703 (unrelated to the SyN argc defect)
sibling: fix-kerneltransform-status — TestKernelTransform bare-0/1 conversion, separate PR
followup: annotate the two SyN test files once #6703 merges
audit_idea: every ITK_EXERCISE_BASIC_OBJECT_METHODS third argument is unverified on
  GCC/Clang (itkTestingMacros.h:54 branch); a sweep comparing each against the class's
  real Superclass would find more of these without needing a Windows machine
-->
