### PR TITLE
COMP: Skip dot-directories when scanning for ITK modules

### DIFF
--- a/CMake/ITKModuleEnablement.cmake
+++ b/CMake/ITKModuleEnablement.cmake
@@ -8,6 +8,8 @@ macro(itk_module_load_dag)
     RELATIVE "${ITK_SOURCE_DIR}"
     "${ITK_SOURCE_DIR}/*/*/*/itk-module.cmake" # grouped modules
   )
+  # Dot-directories hold tool state (worktrees, environments, caches), not ITK source.
+  list(FILTER meta EXCLUDE REGEX "(^|/)\\.")
   foreach(f ${meta})
     include(${ITK_SOURCE_DIR}/${f})
     list(APPEND ITK_MODULES_ALL ${itk-module})


### PR DESCRIPTION
`itk_module_load_dag()` uses `GLOB_RECURSE`, which matches `itk-module.cmake` at **any** depth. Any nested source tree under the ITK checkout is therefore absorbed as a set of duplicate modules and built as if it were part of the project.

Nesting a second tree inside a project is a widespread convention, and it almost always lives under a dot-directory. On one affected workstation this produced **984 discovered modules where 204 exist**, and the duplicates broke the build outright.

<details>
<summary>Why dot-directories, specifically</summary>

Dot-directories are the near-universal convention for content that is *not* project source: version-control internals, tool and editor state, language environments, and caches. A checkout of ITK — or of anything containing `*/*/*/itk-module.cmake` — commonly ends up inside one:

| Paradigm | Typical location |
|---|---|
| Secondary `git worktree` trees | `.worktrees/<branch>/`, or a tool-managed directory |
| Editor / IDE / agent state | `.vscode/`, `.idea/`, `.vs/`, and similar |
| Language & package environments | `.pixi/`, `.venv/`, `.tox/`, `.conda/` |
| Build and download caches | `.cache/`, `.ExternalData/` |

This is not hypothetical for ITK. **ITK's own documented build tool creates `.pixi/` inside the source tree** — 3.3 GB on the machine where this was found — and `.gitignore` already declares `.pixi` and `.idea` as non-source. The module scan simply does not honor the same convention that the rest of the project already assumes.

The failure is also easy to misread, because the duplicates are built against the *outer* tree's configuration. A nested checkout on an older branch fails in ways that look like a defect in the tree you are actually working on:

```
FAILED: .<dot-dir>/<nested-tree>/Modules/Numerics/FEM/src/CMakeFiles/ITKFEM.dir/....o
vnl/algo/vnl_svd.h:13:6: error: #error "vnl/algo/vnl_svd.h is deprecated; migrate to itk::Math::SVD"
```

The path is the giveaway, but it is easy to miss in a full log, and `ninja` stops there — a plain `ninja` in that tree could not complete.

</details>

<details>
<summary>Fix</summary>

```cmake
list(FILTER meta EXCLUDE REGEX "(^|/)\\.")
```

Scoped deliberately narrowly:

- Matches a dot only at the start of a **path component**, so directory names that merely contain a dot (`ITK.Something`) are unaffected.
- The glob is `RELATIVE "${ITK_SOURCE_DIR}"`, so an ITK checkout that itself lives under a dot-path (`/home/user/.cache/src/ITK`) is unaffected — the absolute prefix is stripped before matching.
- ITK ships no `itk-module.cmake` under any dot-directory, so nothing in-project is excluded.

</details>

<details>
<summary>Validation</summary>

Verified on a tree containing four nested checkouts:

| Check | Result |
|---|---|
| Modules discovered before | 984 |
| Excluded by the filter | 780 |
| Excluded that were **not** a nested checkout | **0** (no false positives) |
| Modules discovered after | 204 |
| `Modules/Remote/*` retained | 10 of 10 |

Behavioral check with `ITK_FUTURE_LEGACY_REMOVE=ON`, `ITK_LEGACY_REMOVE=ON`, `Module_ITKReview=ON`, 10 remote modules enabled:

- before: 314 nested targets, `ninja -k 0` failed
- after: 0 nested targets, `ninja -k 0` exits **0 with zero failures**

Had the filter dropped a real module, that build would have failed to link.

</details>

<details>
<summary>Remote modules are unaffected</summary>

**In-tree:** remotes are always fetched to `${ITK_SOURCE_DIR}/Modules/Remote/${_name}` (`CMake/ITKModuleRemote.cmake`), a path the regex cannot match. All 10 enabled remotes are retained above.

**Standalone:** a remote module built on its own against an installed ITK never reaches this code. `ITKModuleEnablement` is included only from ITK's top-level `CMakeLists.txt` and is not installed for downstream consumers, so a module using `find_package(ITK REQUIRED)` + `itk_module_impl()` never calls `itk_module_load_dag()`.

</details>

<!--
provenance: claude-code session 2026-07-26
file: CMake/ITKModuleEnablement.cmake, itk_module_load_dag()
validation_trees: build (RelWithDebInfo), build-future-legacy-remove (FUTURE_LEGACY_REMOVE=ON)
false_positive_check: of 780 excluded paths, 0 were outside nested checkouts
dot_dirs_observed_in_source_tree: .cache .claude .devlocal .ExternalData .git .github .idea .pixi .serena .vs
  (.github is excluded by the filter but ships no itk-module.cmake, so nothing is lost)
remote_module_safety:
  - in-tree: CMake/ITKModuleRemote.cmake pins dest to Modules/Remote/${_name}
  - standalone: ITKModuleEnablement included only at CMakeLists.txt:787, not installed;
    standalone modules use find_package(ITK) + itk_module_impl(), never itk_module_load_dag()
note: a target-count delta seen during validation was traced to commit caf908a1a5a
      retiring FEM to a remote module, not to this change.
-->
