### PR TITLE
BUG: Backport release 5.4 Disown Python objects adopted by unique_ptr members 

### DIFF
--- a/Modules/Core/Common/wrapping/itkOptimizerParameters.wrap
+++ b/Modules/Core/Common/wrapping/itkOptimizerParameters.wrap
@@ -7,6 +7,10 @@ itk_end_wrap_class()
 
 itk_wrap_class("itk::OptimizerParameters")
 foreach(t ${types})
+  # SetHelper stores the argument in a unique_ptr member.
+  string(APPEND ITK_WRAP_PYTHON_SWIG_EXT
+         "%apply SWIGTYPE *DISOWN { itkOptimizerParametersHelper${ITKM_${t}} * helper };\n")
+
   itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")
 endforeach()
 itk_end_wrap_class()

--- a/Modules/Core/Common/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/Common/wrapping/test/CMakeLists.txt
@@ -62,4 +62,9 @@ if(ITK_WRAP_PYTHON)
     itkImageLifetimePythonTest
     COMMAND
     ${CMAKE_CURRENT_SOURCE_DIR}/itkImageLifetimeTest.py)
+  itk_python_add_test(
+    NAME
+    itkOptimizerParametersOwnershipPythonTest
+    COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/itkOptimizerParametersOwnershipTest.py)
 endif()

--- a/Modules/Core/Common/wrapping/test/itkOptimizerParametersOwnershipTest.py
+++ b/Modules/Core/Common/wrapping/test/itkOptimizerParametersOwnershipTest.py
@@ -1,0 +1,36 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+"""OptimizerParameters.SetHelper takes ownership of its argument.
+
+Without a DISOWN typemap, Python and the m_Helper unique_ptr both free the helper,
+and the interpreter aborts at shutdown.  A non-zero exit code from this script is
+itself part of the regression check.
+"""
+
+import itk
+
+parameters = itk.OptimizerParameters[itk.D](3)
+helper = itk.OptimizerParametersHelper[itk.D]()
+
+assert helper.thisown, "Python should own a freshly constructed helper"
+
+parameters.SetHelper(helper)
+
+assert not helper.thisown, "SetHelper must transfer ownership away from Python"
+
+print("Test finished.")

--- a/Modules/Filtering/ImageGradient/wrapping/itkGradientImageFilter.wrap
+++ b/Modules/Filtering/ImageGradient/wrapping/itkGradientImageFilter.wrap
@@ -4,6 +4,10 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
   set(vector_dim ${d}) # Wrap only vector dimensions which are the same as image dimensions
   foreach(t ${WRAP_ITK_SCALAR})
 
+    # OverrideBoundaryCondition stores the argument in a unique_ptr member.
+    string(APPEND ITK_WRAP_PYTHON_SWIG_EXT
+           "%apply SWIGTYPE *DISOWN { itkImageBoundaryCondition${ITKM_I${t}${vector_dim}} * boundaryCondition };\n")
+
     if(ITK_WRAP_covariant_vector_float)
       itk_wrap_template("${ITKM_I${t}${vector_dim}}${ITKM_F}${ITKM_F}" "${ITKT_I${t}${vector_dim}},${ITKT_F},${ITKT_F}")
     endif()

--- a/Modules/Filtering/ImageGradient/wrapping/test/CMakeLists.txt
+++ b/Modules/Filtering/ImageGradient/wrapping/test/CMakeLists.txt
@@ -20,4 +20,10 @@ if(ITK_WRAP_PYTHON
     DATA{${test_input_dir}/BrainProtonDensitySlice.png}
     ${ITK_TEST_OUTPUT_DIR}/GradientMagnitudeRecursiveGaussianImageFilterTest.png
     5)
+
+  itk_python_add_test(
+    NAME
+    itkGradientImageFilterOwnershipPythonTest
+    COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/itkGradientImageFilterOwnershipTest.py)
 endif()

--- a/Modules/Filtering/ImageGradient/wrapping/test/itkGradientImageFilterOwnershipTest.py
+++ b/Modules/Filtering/ImageGradient/wrapping/test/itkGradientImageFilterOwnershipTest.py
@@ -1,0 +1,57 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+"""GradientImageFilter.OverrideBoundaryCondition takes ownership of its argument.
+
+Without a DISOWN typemap, Python and the filter's unique_ptr member both free the
+boundary condition, and the interpreter aborts at shutdown.  A non-zero exit code
+from this script is itself part of the regression check.
+"""
+
+import itk
+
+itk.auto_progress(2)
+
+ImageType = itk.Image[itk.F, 2]
+
+filt = itk.GradientImageFilter[ImageType, itk.F, itk.F].New()
+boundaryCondition = itk.PeriodicBoundaryCondition[ImageType]()
+
+assert (
+    boundaryCondition.thisown
+), "Python should own a freshly constructed boundary condition"
+
+filt.OverrideBoundaryCondition(boundaryCondition)
+
+assert (
+    not boundaryCondition.thisown
+), "OverrideBoundaryCondition must transfer ownership away from Python"
+
+# The filter must remain usable with the adopted boundary condition.
+image = ImageType.New()
+region = itk.ImageRegion[2]()
+region.SetSize([8, 8])
+image.SetRegions(region)
+image.Allocate()
+image.FillBuffer(1.0)
+
+filt.SetInput(image)
+filt.Update()
+
+assert filt.GetOutput().GetLargestPossibleRegion().GetSize()[0] == 8
+
+print("Test finished.")


### PR DESCRIPTION
Backport of #6707 to `release-5.4`. Two wrapped ITK methods adopt their raw-pointer argument into a `std::unique_ptr` member, but the Python wrapping left ownership with the proxy object. Both sides free it, and the interpreter aborts at shutdown. Fixed by applying `SWIGTYPE *DISOWN` to both parameters; no C++ change.

Affects `itk.GradientImageFilter.OverrideBoundaryCondition` and `itk.OptimizerParameters.SetHelper`.

<details>
<summary>Reproducer (release-5.4, before this change)</summary>

```python
import itk
ImageType = itk.Image[itk.F, 2]
filt = itk.GradientImageFilter[ImageType, itk.F, itk.F].New()
bc = itk.PeriodicBoundaryCondition[ImageType]()
filt.OverrideBoundaryCondition(bc)
print(bc.thisown)   # True  <-- Python still owns it
# interpreter dumps core at shutdown
```

```python
import itk
p = itk.OptimizerParameters[itk.D](3)
h = itk.OptimizerParametersHelper[itk.D]()
p.SetHelper(h)
print(h.thisown)    # True  <-- Python still owns it
# interpreter dumps core at shutdown
```

After this change, `thisown` is `False` in both cases and the interpreter exits cleanly.

</details>

<details>
<summary>Root cause</summary>

Both methods take a raw pointer and immediately adopt it:

| Method | Body | Location in release-5.4 |
|---|---|---|
| `GradientImageFilter::OverrideBoundaryCondition` | `m_BoundaryCondition.reset(boundaryCondition)` | `itkGradientImageFilter.hxx:45` |
| `OptimizerParameters::SetHelper` | `m_Helper.reset(helper)` | `itkOptimizerParameters.h:142` |

`OptimizerParameters::SetHelper` documents the intent explicitly: *"OptimizerParameters manages the helper once its been assigned."*

SWIG's default typemap for a raw pointer parameter is non-owning, so the Python proxy keeps `thisown == True`. The C++ `unique_ptr` and the Python proxy then both destroy the object.

</details>

<details>
<summary>Test plan — built and run against release-5.4</summary>

This was not assumed to apply from `main`; it was built and tested on a `release-5.4` worktree.

| Stage | Result |
|---|---|
| Full `ITK_WRAP_PYTHON=ON` build of release-5.4 | 8818/8818 targets, 0 failures |
| Rebuild after pinning the interpreter | 3355/3355 targets, 0 failures |
| `itkGradientImageFilterOwnershipPythonTest` | Passed |
| `itkOptimizerParametersOwnershipPythonTest` | Passed |
| Full `release-5.4` Python suite (`ctest -R Python`) | **168/168 passed** |

Because the double-free manifests at interpreter shutdown, a non-zero exit code is itself part of the regression check — these tests fail on unpatched `release-5.4` even with the assertions removed.

</details>

<details>
<summary>Differences from the main-branch change</summary>

The `.wrap` and `.py` content is identical to #6707. Only the two `wrapping/test/CMakeLists.txt` hunks differ, because `release-5.4` predates the gersemi restyle — the new `itk_python_add_test` calls follow 5.4's local formatting (`NAME` on its own line, closing paren attached to the last argument).

`release-5.4` has no `.pre-commit-config.yaml`, so the pre-commit hooks were not run against this branch.

</details>

<!--
provenance: claude-code session 2026-07-26
backport_of: PR #6707 (main), commit d7608fdbf93
cherry_pick: conflicts in BOTH wrapping/test/CMakeLists.txt files (gersemi restyle);
             resolved to 5.4 local style. git reported one CONFLICT but both were UU.
validation_tree: /home/johnsonhj/src/ITK-backport-54-src/build-python-54
  Release, BUILD_TESTING=ON, ITK_WRAP_PYTHON=ON, Python3_EXECUTABLE pinned to pixi env python3.12
  (default CMake search picked a user python3.11 without numpy -> all ITK python tests fail;
   itk/__init__.py -> itk.support.extras -> import numpy)
  SSL_CERT_FILE must be exported for ExternalData/SWIG fetches in the pixi cxx/python envs.
sites_fixed:
  - Modules/Filtering/ImageGradient/wrapping/itkGradientImageFilter.wrap (DISOWN on boundaryCondition)
  - Modules/Core/Common/wrapping/itkOptimizerParameters.wrap (DISOWN on helper)
protected_adopters_not_in_scope (same as main): SetCostFunctionAdaptor on
  SingleValuedNonLinearVnlOptimizer / MultipleValuedNonLinearVnlOptimizer /
  SingleValuedNonLinearVnlOptimizerv4 -- protected, not wrapped, unreachable from Python.
-->
