### PR TITLE
COMP: Avoid semicolon in IOScanco module DESCRIPTION

### DIFF
--- a/Modules/IO/IOScanco/itk-module.cmake
+++ b/Modules/IO/IOScanco/itk-module.cmake
@@ -16,7 +16,7 @@ itk_module(
   FACTORY_NAMES
     ImageIO::Scanco
   DESCRIPTION
-    "ITK Image IO for Scanco microCT files: reads ISQ, RSQ, RAD and AIM; writes ISQ and AIM."
+    "ITK Image IO for Scanco microCT files: reads ISQ, RSQ, RAD and AIM, writes ISQ and AIM."
   EXCLUDE_FROM_DEFAULT
   ENABLE_SHARED
 )


### PR DESCRIPTION
Removes the semicolon from the `IOScanco` module `DESCRIPTION` added in #6700, which caused an `AUTHOR_WARNING` on every configure and silently truncated the stored description.

<details>
<summary>Root cause</summary>

`itk_module()` is a **macro**, not a function, so `ARGN` is textually substituted and argument boundaries are lost. `foreach(arg ${ARGN})` then re-splits on any embedded `;`, so the single `DESCRIPTION` argument arrived as two tokens:

```
[ITK Image IO for Scanco microCT files: reads ISQ, RSQ, RAD and AIM]
[ writes ISQ and AIM.]
```

The first became the description; the second fell through to the `else()` branch at `CMake/ITKModuleMacros.cmake:112`:

```
CMake Warning (dev) at CMake/ITKModuleMacros.cmake:112 (message):
  Unknown argument [ writes ISQ and AIM.]
Call Stack (most recent call first):
  Modules/IO/IOScanco/itk-module.cmake:9 (itk_module)
  CMake/ITKModuleEnablement.cmake:12 (include)
  CMake/ITKModuleEnablement.cmake:105 (itk_module_load_dag)
  CMakeLists.txt:787 (include)
```

`foreach(arg IN LISTS ARGN)` does **not** fix this inside a macro — `ARGN` is not a real variable there and the loop yields nothing. A general fix would require converting `itk_module()` to a function, which is out of scope here. `IOScanco` is the only module whose `DESCRIPTION` contains a `;`.

</details>

<details>
<summary>Verification</summary>

Reconfigured an existing ITK build tree (`cmake .`) with and without the change:

- Before: the `Unknown argument [ writes ISQ and AIM.]` warning is emitted.
- After: no `Unknown argument` warning, configure clean.

`pre-commit run --all-files` passes.

</details>

<!--
provenance: claude-code session 2026-07-26
regression_from: PR #6700 (commit d08e4bcac0, 2026-07-24) "DOC: Update IOScanco module description"
file: Modules/IO/IOScanco/itk-module.cmake:19
macro_site: CMake/ITKModuleMacros.cmake:73 (foreach(arg ${ARGN})), warning at :112
followup_idea: convert itk_module() macro -> function so DESCRIPTION may contain ';'
-->
