### PR TITLE
BUG: Invoking SetData method with wrong parameter types

### DIFF
--- a/Modules/Core/Common/test/itkArrayGTest.cxx
+++ b/Modules/Core/Common/test/itkArrayGTest.cxx
@@ -78,12 +78,12 @@ TEST(Array, MemoryManagement)
   float                  buffer[n];
   FloatArrayType         notMyOwnBoss;
   notMyOwnBoss.SetSize(n);
-  notMyOwnBoss.SetData(buffer, false);
+  notMyOwnBoss.SetData(buffer, n, false);
   notMyOwnBoss.Fill(4.0);
 
   FloatArrayType notMyOwnBossToo;
   notMyOwnBossToo.SetSize(n);
-  notMyOwnBossToo.SetData(buffer, false);
+  notMyOwnBossToo.SetData(buffer, n, false);
 
   // Copy an itk::Array which manages its own memory
   const FloatArrayType test1 = myOwnBoss;


### PR DESCRIPTION
The signature is `void SetData(TValue * datain, SizeValueType sz, bool LetArrayManageMemory)`

This, by itself, is not a big problem. However, it might be a symptom of a larger problem.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
