### PR TITLE
COMP: Mangle znzlib symbols, as niftilib already is

### DIFF
--- a/Modules/ThirdParty/NIFTI/src/nifti/znzlib/itk_znzlib_mangle.h
+++ b/Modules/ThirdParty/NIFTI/src/nifti/znzlib/itk_znzlib_mangle.h
@@ -1,0 +1,32 @@
+#ifndef itk_znzlib_mangle_h
+#define itk_znzlib_mangle_h
+
+/*
+This header file mangles all symbols exported from the znzlib library.
+It is intended to be included by ITK's version "znzlib.h".
+
+It is the counterpart of itk_nifti_mangle.h: without it ITKznz exports the
+plain znzlib names, which collide with any other znzlib in the same process
+(e.g. a system nifti_clib pulled in by another library).
+
+Note: znzclose() is a macro over Xznzclose(), so only Xznzclose is mangled;
+the macro expands to the mangled name at the call site.
+*/
+
+#define Xznzclose itk_Xznzclose
+#define znzdopen itk_znzdopen
+#define znzeof itk_znzeof
+#define znzflush itk_znzflush
+#define znzgetc itk_znzgetc
+#define znzgets itk_znzgets
+#define znzopen itk_znzopen
+#define znzprintf itk_znzprintf
+#define znzputc itk_znzputc
+#define znzputs itk_znzputs
+#define znzread itk_znzread
+#define znzrewind itk_znzrewind
+#define znzseek itk_znzseek
+#define znztell itk_znztell
+#define znzwrite itk_znzwrite
+
+#endif

--- a/Modules/ThirdParty/NIFTI/src/nifti/znzlib/znzlib.h
+++ b/Modules/ThirdParty/NIFTI/src/nifti/znzlib/znzlib.h
@@ -36,6 +36,9 @@ NB: seeks for writable files with compression are quite restricted
 */
 
 
+// Name mangling, specific to the version of znzlib included with ITK.
+#include "itk_znzlib_mangle.h"
+
 /*=================*/
 #ifdef  __cplusplus
 extern "C" {


### PR DESCRIPTION
## Summary

`ITKniftiio` has had its symbols renamed to `itk_*` since 2017 (b33d9978, `itk_nifti_mangle.h`, included from ITK's `nifti1.h`). `ITKznz` never got the same treatment, so it still exports the plain `znzlib` names:

```
Xznzclose  znzdopen  znzeof   znzflush  znzgetc  znzgets  znzopen
znzprintf  znzputc   znzputs  znzread   znzrewind  znzseek  znztell  znzwrite
```

Any application that links ITK alongside a second copy of znzlib — most obviously a system `nifti_clib` pulled in by another library — ends up with two definitions of each.

## Why it matters

Nothing fails at link time. ITK's copies are pulled into the executable and land in its **dynamic** symbol table, where they interpose over the other znzlib; that library then runs ITK's znz layer for every read.

Measured with ITK `release-4.14`'s `znzlib.c` built as a static archive and linked into a program that also uses a shared system `nifti_clib`:

| `ITKznz` | unmangled exports | znz names in executable `.dynsym` |
| --- | --- | --- |
| as-is | 15 | 8 |
| with this patch | 0 | 0 |

The two implementations are close enough that this usually goes unnoticed on LP64. But it is one definition of each function silently replacing another, and they have already drifted:

- `znzseek`/`znztell` take and return `long` here, while `nifti_clib` 3.x uses `znz_off_t`. On ILP32 with `_FILE_OFFSET_BITS=64` the caller passes 8 bytes where the callee reads 4 (`sizeof(long)`=4, `sizeof(off_t)`=8 — measured under `-m32`).
- `sizeof(struct znzptr)` differs between any two builds that disagree on `HAVE_ZLIB`, since `gzFile zfptr` is conditional.

## The change

Adds `itk_znzlib_mangle.h` covering the fifteen exported symbols, and includes it from `znzlib.h` at the same point `nifti1.h` includes `itk_nifti_mangle.h` — after the descriptive comment, before the `extern "C"` block.

`znzclose` is a macro over `Xznzclose`, which is mangled, so it expands to the mangled name at the call site. ITK's only consumer, `Modules/IO/NIFTI/src/itkNiftiImageIO.cxx`, reaches znz through `<nifti1_io.h>` → `<znzlib.h>` and so picks the mangling up automatically; there are no free-standing `extern` declarations of these functions to update.

## Verification

Building this `znzlib.c` before and after the patch: 15 unmangled exports become 0, with no other symbols affected. The A/B link test above goes from 8 interposing symbols to none, and reads through the system `nifti_clib` continue to work in both cases.

## Note on other branches

`main` and `v5.4.x` are affected more broadly. `itk_nifti_mangle.h` was removed there in 0cdb1dd5 (2018-12-16, *"ENH: Manually update nifti version from github"*) when the vendored nifti was refreshed and `NIFTI_PACKAGE_PREFIX` was adopted — but that setting renames CMake targets, not C symbols, so those branches now export the full unmangled nifti **and** znzlib API. Happy to open a companion PR restoring both there if that is wanted; this one is deliberately scoped to `release-4.14`, where the niftiio half is still in place and only znzlib is missing.

Found while building [minc-toolkit-v2](https://github.com/BIC-MNI/minc-toolkit-v2), which links ITK and libminc into the same tools and currently has to carry its own symbol prefixing to keep the two nifti copies apart.