### PR TITLE
COMP: Pin proxTV to an immutable commit hash

### DIFF
--- a/Modules/ThirdParty/proxTV/proxTVGitTag.cmake
+++ b/Modules/ThirdParty/proxTV/proxTVGitTag.cmake
@@ -3,4 +3,4 @@ set(
   proxTV_GIT_REPOSITORY
   "https://github.com/InsightSoftwareConsortium/proxTV.git"
 )
-set(proxTV_GIT_TAG "for/itk-proxtv-3.3.0-69062fe5")
+set(proxTV_GIT_TAG "0903e7c1675d402c3b8be02a06782a08b12f3945") # for/itk-proxtv-3.3.0-69062fe5-r1


### PR DESCRIPTION
`proxTV_GIT_TAG` named the anchor *branch* `for/itk-proxtv-3.3.0-69062fe5`, so advancing that branch changed what ITK builds without any change landing here. Pin the commit hash `0903e7c` instead, with the overlay ref in a trailing comment — the form already used by [`DCMTKGitTag.cmake`](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake#L46).

The pinned commit also brings in the GCC warning cleanup merged as InsightSoftwareConsortium/proxTV#1.

<details>
<summary>Why a hash rather than a tag name</summary>

This is a *live* reference: `FetchContent` resolves it on every configure. A branch is mutable by design, and a tag — while conventionally immutable — can still be deleted and re-pushed. Only the hash is pinned outright, so it is the right form for anything fetched at build time. Ref names used once by a human (the fork's `welcome` update procedure, `UpdateFromUpstream.sh`-style scripts) are unaffected and keep using branch names.

This introduces no new naming convention: `DCMTKGitTag.cmake:46` is `set(DCMTK_GIT_TAG "554b744…") # for/itk-dcmtk-3.7.0-ccfd10b`, and this change makes proxTV match it.

The anchor branch `for/itk-proxtv-3.3.0-69062fe5` still exists and still points at `0903e7c`; it remains the update target per the fork's `welcome` procedure. The annotated tag `for/itk-proxtv-3.3.0-69062fe5-r1` also points there and is named in the comment, but ITK no longer depends on either name resolving.

</details>

<details>
<summary>What the pinned overlay contains</summary>

Three commits on the ITK proxTV overlay, all compiler-warning fixes in the vendored C sources:

- `34af3b0` — guard `#pragma omp` behind `#ifdef _OPENMP` and the MSVC `warning(suppress:)` pragmas behind `#ifdef _MSC_VER`
- `f726e32` — `size_t` loop counters where compared against `size_t` bounds (`-Wsign-compare`), and a `-Wmisleading-indentation` fix
- `0903e7c` — reject `n < 2` in `more_TV2`/`morePG_TV2` and `npen < 1` in `PD_TV`/`PDR_TV` before those values reach `memcpy`/`calloc` size arguments (`-Wstringop-overflow`, `-Walloc-size-larger-than`)

Upstream base is unchanged: albarji/proxTV 3.3.0, commit `69062fe5`. The overlay is a fast-forward, `4c53ae7` → `0903e7c`.

The same fixes were offered upstream as albarji/proxTV#63, but upstream has merged nothing since 2018, so the overlay remains the source of truth.

</details>

<details>
<summary>Verification</summary>

`git ls-remote` confirms the branch head, the peeled annotated tag, and this pin are all the same commit, so the build result is unchanged by this PR:

```
refs/heads/for/itk-proxtv-3.3.0-69062fe5      -> 0903e7c1675d402c3b8be02a06782a08b12f3945
refs/tags/for/itk-proxtv-3.3.0-69062fe5-r1^{} -> 0903e7c1675d402c3b8be02a06782a08b12f3945
```

CI on this PR is the end-to-end test: it exercises the fetch at the new pin on every platform that builds `ITKTotalVariation`.

</details>

<!--
provenance: claude-code session 2026-08-13 (hjmjohnson), revised from 2026-08-05
review: blowekamp asked that live refs use the hash with the branch name in a comment,
  and objected to introducing an -rN naming convention without discussion/documentation.
  Switching to the hash makes the -rN name non-load-bearing, so no convention change
  and no fork-wide doc sweep is required. DCMTKGitTag.cmake:46 is the in-tree precedent.
fork refs (unchanged by this PR):
  branch refs/heads/for/itk-proxtv-3.3.0-69062fe5      -> 0903e7c
  tag    refs/tags/for/itk-proxtv-3.3.0-69062fe5-r1    -> 0903e7c (annotated, object a1676911)
upstream offer: albarji/proxTV#63 (draft)
related: the eigen fork has one ref existing as BOTH a branch and a tag -
  the ambiguous-refname case ThirdPartyForkConventions.md warns about; separate cleanup candidate.
-->
