### PR TITLE
BUG: Use label integers instead of float to count pixels

### DIFF
--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.h
@@ -309,7 +309,7 @@ private:
   InitializePriorProbabilities();
 
   std::vector<ConfusionMatrixType> m_ConfusionMatrixArray{};
-  std::vector<ConfusionMatrixType> m_UpdatedConfusionMatrixArray{};
+  std::vector<Array2D<double>>     m_UpdatedConfusionMatrixArray{};
 
   void
   AllocateConfusionMatrixArray();

--- a/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
+++ b/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx
@@ -141,9 +141,13 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
   using VotingIteratorType = ImageRegionConstIterator<VotingImageType>;
   VotingIteratorType out(votingOutput, votingOutput->GetRequestedRegion());
 
+  const SizeValueType    numRows = static_cast<SizeValueType>(this->m_TotalLabelCount) + 1;
+  const SizeValueType    numCols = static_cast<SizeValueType>(this->m_TotalLabelCount);
+  Array2D<SizeValueType> counts(numRows, numCols);
+
   for (unsigned int k = 0; k < numberOfInputs; ++k)
   {
-    this->m_ConfusionMatrixArray[k].Fill(0.0);
+    counts.Fill(0);
 
     InputConstIteratorType in(this->GetInput(k), votingOutput->GetRequestedRegion());
 
@@ -151,30 +155,32 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializeConf
     {
       if (out.Get() != votingUndecidedLabel)
       {
-        ++(this->m_ConfusionMatrixArray[k][in.Get()][out.Get()]);
+        ++counts[in.Get()][out.Get()];
       }
     }
-  }
 
-  // normalize matrix rows to unit probability sum
-  for (unsigned int k = 0; k < numberOfInputs; ++k)
-  {
-    for (size_t inLabel = 0; inLabel < this->m_TotalLabelCount + 1; ++inLabel)
+    // convert counts to normalized row probabilities
+    for (SizeValueType inRow = 0; inRow < numRows; ++inRow)
     {
-      const auto inRow = static_cast<unsigned int>(inLabel);
-      // compute sum over all output labels for given input label
-      WeightsType sum = 0;
-      for (size_t outLabel = 0; outLabel < this->m_TotalLabelCount; ++outLabel)
+      SizeValueType rowSum = 0;
+      for (SizeValueType outLabel = 0; outLabel < numCols; ++outLabel)
       {
-        sum += this->m_ConfusionMatrixArray[k][inRow][outLabel];
+        rowSum += counts[inRow][outLabel];
       }
-      // make sure that this input label did in fact show up in the input!!
-      if (sum > 0)
+      if (rowSum > 0)
       {
-        // normalize
-        for (size_t outLabel = 0; outLabel < this->m_TotalLabelCount; ++outLabel)
+        const auto rowSumW = static_cast<WeightsType>(rowSum);
+        for (SizeValueType outLabel = 0; outLabel < numCols; ++outLabel)
         {
-          this->m_ConfusionMatrixArray[k][inRow][outLabel] /= sum;
+          this->m_ConfusionMatrixArray[k][inRow][outLabel] =
+            static_cast<WeightsType>(counts[inRow][outLabel]) / rowSumW;
+        }
+      }
+      else
+      {
+        for (SizeValueType outLabel = 0; outLabel < numCols; ++outLabel)
+        {
+          this->m_ConfusionMatrixArray[k][inRow][outLabel] = 0;
         }
       }
     }
@@ -197,27 +203,31 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::InitializePrio
   }
   else
   {
-    this->m_PriorProbabilities.SetSize(1 + static_cast<SizeValueType>(this->m_TotalLabelCount));
-    this->m_PriorProbabilities.Fill(0.0);
+    const auto totalLabelCount = this->m_TotalLabelCount;
 
-    const size_t numberOfInputs = this->GetNumberOfInputs();
-    for (size_t k = 0; k < numberOfInputs; ++k)
+    std::vector<SizeValueType> labelCounts(1 + totalLabelCount, 0);
+
+    const SizeValueType numberOfInputs = this->GetNumberOfInputs();
+    for (SizeValueType k = 0; k < numberOfInputs; ++k)
     {
       InputConstIteratorType in(this->GetInput(k), this->GetOutput()->GetRequestedRegion());
       for (in.GoToBegin(); !in.IsAtEnd(); ++in)
       {
-        ++(this->m_PriorProbabilities[in.Get()]);
+        ++labelCounts[in.Get()];
       }
     }
 
-    WeightsType totalProbMass = 0.0;
-    for (size_t l = 0; l < this->m_TotalLabelCount; ++l)
+    SizeValueType totalCount = 0;
+    for (SizeValueType l = 0; l < totalLabelCount; ++l)
     {
-      totalProbMass += this->m_PriorProbabilities[l];
+      totalCount += labelCounts[l];
     }
-    for (size_t l = 0; l < this->m_TotalLabelCount; ++l)
+
+    this->m_PriorProbabilities.SetSize(1 + static_cast<SizeValueType>(totalLabelCount));
+    this->m_PriorProbabilities.Fill(0.0);
+    for (SizeValueType l = 0; l < totalLabelCount; ++l)
     {
-      this->m_PriorProbabilities[l] /= totalProbMass;
+      this->m_PriorProbabilities[l] = static_cast<WeightsType>(labelCounts[l]) / static_cast<WeightsType>(totalCount);
     }
   }
 }
@@ -335,7 +345,7 @@ MultiLabelSTAPLEImageFilter<TInputImage, TOutputImage, TWeights>::GenerateData()
       // compute sum over all output classifications
       for (size_t ci = 0; ci < this->m_TotalLabelCount; ++ci)
       {
-        WeightsType sumW = this->m_UpdatedConfusionMatrixArray[k][0][ci];
+        double sumW = this->m_UpdatedConfusionMatrixArray[k][0][ci];
         for (size_t j = 1; j < 1 + this->m_TotalLabelCount; ++j)
         {
           sumW += this->m_UpdatedConfusionMatrixArray[k][static_cast<unsigned int>(j)][ci];


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

The original count uses ++ on a `WeightsType`, which defaults to float, to count pixels. 
When there are more than ~ 16.7 million pixels to be counted, which happens quickly in 3D images (times number of inputs), the ++ has no more effect as 16,777,217 has the same float representation as 16,777,216. 

The fix is simple: Do the counting in integers (`size_t`) and then the final operation 
```
label_frequency = label_count / total_count
```
in float (`WeightsType`). 

<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
