### PR TITLE
Bruker 2dseq reader: ParaVision on-disk format conformance

### DIFF
--- a/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
+++ b/Modules/IO/Bruker/include/itkBruker2dseqImageIO.h
@@ -135,7 +135,7 @@ private:
   void
   SwapBytesIfNecessary(void * buff, SizeValueType components);
 
-  IOComponentEnum m_OnDiskComponentType{ IOComponentEnum::UCHAR };
+  IOComponentEnum m_OnDiskComponentType = IOComponentEnum::UCHAR;
   IOByteOrderEnum m_MachineByteOrder{};
 };
 

--- a/Modules/IO/Bruker/itk-module.cmake
+++ b/Modules/IO/Bruker/itk-module.cmake
@@ -8,6 +8,7 @@ itk_module(
   TEST_DEPENDS
     ITKTestKernel
     ITKIOMeta
+    ITKGoogleTest
   FACTORY_NAMES
     ImageIO::Bruker2dseq
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -1022,8 +1022,7 @@ Bruker2dseqImageIO::ReadImageInformation()
           }
         }
       }
-      // Frame groups without FG_SLICE (e.g. FG_ISA maps) describe one slice;
-      // without frame groups fall back to the position count (3 coordinates each)
+      // Frame groups without FG_SLICE (e.g. FG_ISA maps) describe a single slice
       const SizeType positionCount = position.size() / 3;
       if (sliceLength > 0)
       {
@@ -1035,10 +1034,7 @@ Bruker2dseqImageIO::ReadImageInformation()
       }
       if (sizeZ > 1 && positionCount > 1)
       {
-        // FrameThickness does not include the slice gap and ParaVision sometimes
-        // writes SliceDist as 0, so measure the step between slice positions.
-        // Positions may be stored per-slice or per-frame (frame groups before
-        // FG_SLICE vary faster), so step by the frame count per slice increment.
+        // Frame groups before FG_SLICE vary faster than the slice index, so step over them
         const SizeType positionStride = (positionCount > sizeZ) ? framesPerSlice : 1;
         if (3 * (positionStride + 1) <= static_cast<SizeType>(position.size()))
         {
@@ -1048,8 +1044,15 @@ Bruker2dseqImageIO::ReadImageInformation()
           spacingZ = sliceDiff.magnitude();
         }
       }
+      // A step well below the slice thickness lies inside one slice, so its sign is noise
+      if (spacingZ < 0.5 * ReadDoubleArray(dict, "VisuCoreFrameThickness", 0.0)[0])
+      {
+        sliceDiff.fill(0.0);
+        spacingZ = 0;
+      }
       if (spacingZ == 0)
       {
+        // FrameThickness excludes the slice gap, so it is only a fallback
         spacingZ = GetParameter<std::vector<double>>(dict, "VisuCoreFrameThickness")[0];
       }
       halfStep[2] = 0; // Slice position will be correct

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -24,6 +24,8 @@
 #include "itkStringConvert.h"
 #include "itkPrintHelper.h"
 
+#include <cctype>
+
 namespace itk
 {
 
@@ -159,6 +161,272 @@ CastCopy(float * to, void * from, size_t pixelCount)
   }
 }
 
+// Marks every character inside a <...> string, brackets included
+std::vector<bool>
+MaskStrings(const std::string & s)
+{
+  std::vector<bool> mask(s.size(), false);
+  bool              inString = false;
+  for (std::string::size_type i = 0; i < s.size(); ++i)
+  {
+    if (s[i] == '<')
+    {
+      inString = true;
+    }
+    mask[i] = inString;
+    if (s[i] == '>')
+    {
+      inString = false;
+    }
+  }
+  return mask;
+}
+
+// Expands ParaVision 360 run-length encoded tokens: @N*(value) -> N copies of value
+std::string
+ExpandRLE(const std::string & s)
+{
+  if (s.find("*(") == std::string::npos)
+  {
+    return s;
+  }
+  const std::vector<bool> mask = MaskStrings(s);
+  std::string             expanded;
+  expanded.reserve(s.size());
+  std::string::size_type i = 0;
+  while (i < s.size())
+  {
+    if (s[i] == '@' && !mask[i])
+    {
+      std::string::size_type j = i + 1;
+      while (j < s.size() && std::isdigit(static_cast<unsigned char>(s[j])))
+      {
+        ++j;
+      }
+      if (j > i + 1 && j + 1 < s.size() && s[j] == '*' && s[j + 1] == '(')
+      {
+        const std::string::size_type close = s.find(')', j + 2);
+        if (close != std::string::npos)
+        {
+          const int         count = std::stoi(s.substr(i + 1, j - (i + 1)));
+          const std::string value = s.substr(j + 2, close - (j + 2));
+          for (int c = 0; c < count; ++c)
+          {
+            expanded += value;
+            expanded += ' ';
+          }
+          i = close + 1;
+          continue;
+        }
+      }
+    }
+    expanded += s[i];
+    ++i;
+  }
+  return expanded;
+}
+
+std::string
+Trim(const std::string & s)
+{
+  const std::string::size_type begin = s.find_first_not_of(" \t");
+  if (begin == std::string::npos)
+  {
+    return {};
+  }
+  return s.substr(begin, s.find_last_not_of(" \t") - begin + 1);
+}
+
+// Splits a struct array into its parenthesized tuples, ignoring characters inside strings
+std::vector<std::string>
+SplitTuples(const std::string & s)
+{
+  const std::vector<bool>  mask = MaskStrings(s);
+  std::vector<std::string> tuples;
+  int                      depth = 0;
+  std::string::size_type   start = 0;
+  for (std::string::size_type i = 0; i < s.size(); ++i)
+  {
+    if (mask[i])
+    {
+      continue;
+    }
+    if (s[i] == '(')
+    {
+      if (depth == 0)
+      {
+        start = i + 1;
+      }
+      ++depth;
+    }
+    else if (s[i] == ')' && depth > 0)
+    {
+      --depth;
+      if (depth == 0)
+      {
+        tuples.push_back(s.substr(start, i - start));
+      }
+    }
+  }
+  return tuples;
+}
+
+// Splits struct fields on commas, ignoring commas inside strings
+std::vector<std::string>
+SplitFields(const std::string & s)
+{
+  const std::vector<bool>  mask = MaskStrings(s);
+  std::vector<std::string> fields;
+  std::string::size_type   start = 0;
+  for (std::string::size_type i = 0; i <= s.size(); ++i)
+  {
+    if (i == s.size() || (s[i] == ',' && !mask[i]))
+    {
+      fields.push_back(Trim(s.substr(start, i - start)));
+      start = i + 1;
+    }
+  }
+  return fields;
+}
+
+std::vector<double>
+ParseDoubles(const std::string & s)
+{
+  std::istringstream  stream(s);
+  std::vector<double> values;
+  double              value = 0.0;
+  while (stream >> value)
+  {
+    values.push_back(value);
+    if (stream.peek() == ',')
+    {
+      stream.ignore();
+    }
+  }
+  return values;
+}
+
+void
+ParseJCAMPDXRecord(const std::string & record, MetaDataDictionary & dict)
+{
+  const std::string::size_type epos = record.find('=');
+  if (epos == std::string::npos)
+  {
+    itkGenericExceptionMacro("Invalid Bruker JCAMPDX parameter record (Missing =): " << record);
+  }
+  const std::string parname = record.substr(0, epos);
+  std::string       value = record.substr(epos + 1);
+
+  // A leading "( N )" or "( N, M )" written with spaces is a dimension indicator;
+  // "(v, v)" without them is a scalar struct value
+  bool hasDims = false;
+  if (value.compare(0, 2, "( ") == 0)
+  {
+    const std::string::size_type close = value.find(')');
+    if (close != std::string::npos && value.find_first_not_of("0123456789, ", 2) == close)
+    {
+      hasDims = true;
+      value = value.substr(close + 1);
+    }
+  }
+  value = Trim(ExpandRLE(value));
+
+  const std::vector<bool> mask = MaskStrings(value);
+  bool                    hasStruct = false;
+  for (std::string::size_type i = 0; i < value.size(); ++i)
+  {
+    if (value[i] == '(' && !mask[i])
+    {
+      hasStruct = true;
+      break;
+    }
+  }
+
+  if (hasStruct)
+  {
+    const std::vector<std::string> tuples = SplitTuples(value);
+    if (value.find('<') != std::string::npos)
+    {
+      std::vector<std::vector<std::string>> stringArrayArray;
+      for (const std::string & tuple : tuples)
+      {
+        stringArrayArray.push_back(SplitFields(tuple));
+      }
+      EncapsulateMetaData(dict, parname, stringArrayArray);
+    }
+    else
+    {
+      std::vector<std::vector<double>> doubleArrayArray;
+      for (const std::string & tuple : tuples)
+      {
+        doubleArrayArray.push_back(ParseDoubles(tuple));
+      }
+      EncapsulateMetaData(dict, parname, doubleArrayArray);
+    }
+  }
+  else if (hasDims && value.find('<') != std::string::npos)
+  {
+    std::vector<std::string> stringArray;
+    std::string::size_type   left = value.find('<');
+    while (left != std::string::npos)
+    {
+      const std::string::size_type right = value.find('>', left + 1);
+      if (right == std::string::npos)
+      {
+        break;
+      }
+      stringArray.push_back(value.substr(left + 1, right - (left + 1)));
+      left = value.find('<', right + 1);
+    }
+    EncapsulateMetaData(dict, parname, stringArray);
+  }
+  else if (hasDims)
+  {
+    const std::vector<double> values = ParseDoubles(value);
+    if (values.empty() && !value.empty())
+    {
+      // Enum arrays hold bare symbolic names, e.g. ( 3 ) spatial spatial spatial
+      std::istringstream       stream(value);
+      std::vector<std::string> tokens;
+      std::string              token;
+      while (stream >> token)
+      {
+        tokens.push_back(token);
+      }
+      if (tokens.size() == 1)
+      {
+        EncapsulateMetaData(dict, parname, tokens[0]);
+      }
+      else
+      {
+        EncapsulateMetaData(dict, parname, tokens);
+      }
+    }
+    else
+    {
+      EncapsulateMetaData(dict, parname, values);
+    }
+  }
+  else
+  {
+    const std::vector<double> values = ParseDoubles(value);
+    const bool                allNumeric = value.find_first_not_of("0123456789+-.eE, \t") == std::string::npos;
+    if (allNumeric && values.size() == 1)
+    {
+      EncapsulateMetaData(dict, parname, values[0]);
+    }
+    else if (allNumeric && values.size() > 1)
+    {
+      // Fixed-length array with omitted dimension indicator (legacy datasets)
+      EncapsulateMetaData(dict, parname, values);
+    }
+    else
+    {
+      EncapsulateMetaData(dict, parname, value);
+    }
+  }
+}
+
 // Internal function to read a JCAMPDX parameter file
 void
 ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
@@ -166,165 +434,49 @@ ReadJCAMPDX(const std::string & filename, MetaDataDictionary & dict)
   std::ifstream paramsStream(filename.c_str());
 
   std::string line;
-  // First five lines are 'comments' starting with ##
-  std::getline(paramsStream, line);
-  std::getline(paramsStream, line);
-  std::getline(paramsStream, line);
-  std::getline(paramsStream, line);
-  std::getline(paramsStream, line);
-
-  // Then three lines starting with $$
-  std::getline(paramsStream, line);
-  std::getline(paramsStream, line);
-  std::getline(paramsStream, line);
-
-  // Now process parameters starting with ##$
+  std::string record;
   while (std::getline(paramsStream, line))
   {
-    // Check start of line
-    if (line.substr(0, 2) == "$$")
+    if (!line.empty() && line.back() == '\r')
     {
-      // Comment line
+      line.pop_back();
+    }
+    if (line.compare(0, 2, "$$") == 0)
+    {
+      // Comment lines may appear anywhere, including inside a wrapped value block
       continue;
     }
-    if (line.substr(0, 5) == "##END")
+    if (line.compare(0, 2, "##") == 0)
     {
-      // There should be one comment line after this line in the file
-      continue;
+      if (!record.empty())
+      {
+        ParseJCAMPDXRecord(record, dict);
+        record.clear();
+      }
+      if (line.compare(0, 5, "##END") == 0)
+      {
+        // The file may continue after ##END= with a "$$ File finished" trailer
+        break;
+      }
+      if (line.compare(0, 3, "##$") == 0)
+      {
+        record = line.substr(3);
+      }
+      // Standard JCAMP labels (##TITLE= etc.) carry no image information
     }
-    else if (line.substr(0, 3) != "##$")
+    else if (!record.empty())
     {
-      itkGenericExceptionMacro("Failed to parse Bruker JCAMPDX: " + line);
+      // Values wrap near column 80; wrapped lines keep their trailing space
+      if (record.back() != ' ')
+      {
+        record += ' ';
+      }
+      record += line;
     }
-
-    const std::string::size_type epos = line.find('=', 3);
-    if (epos == std::string::npos)
-    {
-      itkGenericExceptionMacro("Invalid Bruker JCAMPDX parameter line (Missing =): " << line);
-    }
-
-    const std::string parname = line.substr(3, epos - 3);
-    std::string       par = line.substr(epos + 1);
-    if (par[0] == '(')
-    {
-      // Array value
-      // The array sizes appear to be entirely meaningless. 65 means a string, except when it doesn't and actually gives
-      // the length of the string Skip to next line, process lines until we hit a comment or new parameter Then process
-      // all lines together and look for strings or numbers
-      par.clear();
-      std::string lines;
-      while (paramsStream.peek() != '#' && paramsStream.peek() != '$')
-      {
-        std::getline(paramsStream, line);
-        lines.append(line);
-      }
-
-      std::string::size_type leftBracket = lines.find('(');
-      if (leftBracket == std::string::npos)
-      {
-        // Now check for array of strings marked with <>
-        std::string::size_type left = lines.find('<');
-        if (left != std::string::npos)
-        {
-          std::vector<std::string> stringArray;
-          while (left != std::string::npos)
-          {
-            const std::string::size_type right = lines.find('>', left + 1);
-            stringArray.push_back(lines.substr(left + 1, right - (left + 1)));
-            left = lines.find('<', right + 1);
-          }
-          EncapsulateMetaData(dict, parname, stringArray);
-        }
-        else
-        {
-          // An array of numbers
-          std::stringstream   lineStream(lines);
-          double              doubleValue = NAN;
-          std::vector<double> doubleArray;
-          while (lineStream >> doubleValue)
-          {
-            doubleArray.push_back(doubleValue);
-            if (lineStream.peek() == ',')
-            {
-              // Ignore commas
-              lineStream.ignore();
-            }
-          }
-          EncapsulateMetaData(dict, parname, doubleArray);
-        }
-      }
-      else
-      {
-        // An array of arrays
-        std::string::size_type rightBracket = lines.find(')', leftBracket);
-
-        if (lines.find('<') != std::string::npos)
-        {
-          // Array of array of strings (and maybe doubles, but let's keep it sane)
-          std::vector<std::vector<std::string>> stringArrayArray;
-          while (leftBracket != std::string::npos)
-          {
-            std::string::size_type   stringStart = leftBracket + 1;
-            std::string::size_type   stringEnd = lines.find(',', stringStart);
-            std::vector<std::string> stringArray;
-            while (stringStart < rightBracket)
-            {
-              stringArray.push_back(lines.substr(stringStart, stringEnd - stringStart));
-              stringStart = stringEnd + 2; // Eat comma + space character
-              stringEnd = lines.find(',', stringStart + 1);
-              if (stringEnd > rightBracket)
-              {
-                stringEnd = rightBracket;
-              }
-            }
-            stringArrayArray.push_back(stringArray);
-            leftBracket = lines.find('(', rightBracket);
-            rightBracket = lines.find(')', leftBracket);
-          }
-          EncapsulateMetaData(dict, parname, stringArrayArray);
-        }
-        else
-        {
-          // Array of array of numbers
-          std::vector<std::vector<double>> doubleArrayArray;
-          while (leftBracket != std::string::npos)
-          {
-            std::istringstream  arrayStream(lines.substr(leftBracket, rightBracket - leftBracket));
-            std::vector<double> doubleArray;
-            double              doubleValue = NAN;
-            while (arrayStream >> doubleValue)
-            {
-              doubleArray.push_back(doubleValue);
-              if (arrayStream && (arrayStream.peek() == ','))
-              {
-                // Ignore commas. Some arrays have them, others don't
-                arrayStream.ignore();
-              }
-            }
-            doubleArrayArray.push_back(doubleArray);
-            leftBracket = lines.find('(', rightBracket);
-            rightBracket = lines.find(')', leftBracket);
-          }
-          EncapsulateMetaData(dict, parname, doubleArrayArray);
-        }
-      }
-    }
-    else
-    {
-      // A single value
-      std::istringstream streamPar(par);
-      double             value = NAN;
-      streamPar >> value;
-      if (streamPar.fail())
-      {
-        // Didn't read a valid number, so it's a string
-        EncapsulateMetaData(dict, parname, par);
-      }
-      else
-      {
-        EncapsulateMetaData(dict, parname, value);
-      }
-    }
+  }
+  if (!record.empty())
+  {
+    ParseJCAMPDXRecord(record, dict);
   }
 }
 } // namespace

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -54,9 +54,9 @@ GetParameter(const itk::MetaDataDictionary & dict, const std::string & name)
   return value;
 }
 
-// Scaling parameters may be absent, hold a single value for all frames, or one value per frame
+// Parameter may be absent, hold a single value for all frames, or one value per frame
 std::vector<double>
-ReadScaling(const MetaDataDictionary & dict, const char * name, double defaultValue)
+ReadDoubleArray(const MetaDataDictionary & dict, const char * name, double defaultValue)
 {
   std::vector<double> values;
   if (ExposeMetaData(dict, name, values) && !values.empty())
@@ -80,9 +80,8 @@ Rescale(T *                         buffer,
   SizeType i = 0;
   for (SizeType f = 0; f < frameCount; ++f)
   {
-    // A single slope/offset value applies to every frame
-    const double slope = (f < static_cast<SizeType>(slopes.size())) ? slopes[f] : slopes.front();
-    const double offset = (f < static_cast<SizeType>(offsets.size())) ? offsets[f] : offsets.front();
+    const double slope = slopes[slopes.size() == 1 ? 0 : f];
+    const double offset = offsets[offsets.size() == 1 ? 0 : f];
     for (SizeType v = 0; v < frameSize; ++v, ++i)
     {
       const double tmp = static_cast<double>(buffer[i]) * slope + offset;
@@ -725,11 +724,20 @@ Bruker2dseqImageIO::Read(void * buffer)
   }
 
   const MetaDataDictionary & dict = this->GetMetaDataDictionary();
-  const std::vector<double>  slopes = ReadScaling(dict, "VisuCoreDataSlope", 1.0);
-  const std::vector<double>  offsets = ReadScaling(dict, "VisuCoreDataOffs", 0.0);
+  const std::vector<double>  slopes = ReadDoubleArray(dict, "VisuCoreDataSlope", 1.0);
+  const std::vector<double>  offsets = ReadDoubleArray(dict, "VisuCoreDataOffs", 0.0);
   const SizeType             frameCount = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreFrameCount"));
   const SizeType             frameDim = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreDim"));
   SizeType                   frameSize = this->GetDimensions(0) * this->GetDimensions(1);
+
+  if (slopes.size() != 1 && slopes.size() != frameCount)
+  {
+    itkExceptionMacro("VisuCoreDataSlope has " << slopes.size() << " values, expected 1 or " << frameCount);
+  }
+  if (offsets.size() != 1 && offsets.size() != frameCount)
+  {
+    itkExceptionMacro("VisuCoreDataOffs has " << offsets.size() << " values, expected 1 or " << frameCount);
+  }
 
   if (frameDim == 3)
   {

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -65,7 +65,7 @@ ReadScaling(const MetaDataDictionary & dict, const char * name, double defaultVa
   }
   double value = defaultValue;
   ExposeMetaData(dict, name, value);
-  return std::vector<double>{ value };
+  return std::vector<double>(1, value);
 }
 
 // Internal function to rescale pixel according to slope & intercept

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -225,9 +225,22 @@ ExpandRLE(const std::string & s)
         const std::string::size_type close = s.find(')', j + 2);
         if (close != std::string::npos)
         {
-          const int         count = std::stoi(s.substr(i + 1, j - (i + 1)));
+          // The repetition count comes from the file; bound it so a corrupt or
+          // hostile record cannot exhaust memory
+          constexpr std::string::size_type maxExpandedSize = std::string::size_type{ 1 } << 26;
+          if (j - (i + 1) > 9)
+          {
+            itkGenericExceptionMacro("Bruker JCAMPDX RLE count out of range: " << s.substr(i, close + 1 - i));
+          }
+          const auto        count = static_cast<std::string::size_type>(std::stoi(s.substr(i + 1, j - (i + 1))));
           const std::string value = s.substr(j + 2, close - (j + 2));
-          for (int c = 0; c < count; ++c)
+          const std::string::size_type remaining =
+            (expanded.size() < maxExpandedSize) ? maxExpandedSize - expanded.size() : 0;
+          if (count > remaining / (value.size() + 1))
+          {
+            itkGenericExceptionMacro("Bruker JCAMPDX RLE expansion exceeds " << maxExpandedSize << " bytes");
+          }
+          for (std::string::size_type c = 0; c < count; ++c)
           {
             expanded += value;
             expanded += ' ';

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -54,6 +54,20 @@ GetParameter(const itk::MetaDataDictionary & dict, const std::string & name)
   return value;
 }
 
+// Scaling parameters may be absent, hold a single value for all frames, or one value per frame
+std::vector<double>
+ReadScaling(const MetaDataDictionary & dict, const char * name, double defaultValue)
+{
+  std::vector<double> values;
+  if (ExposeMetaData(dict, name, values) && !values.empty())
+  {
+    return values;
+  }
+  double value = defaultValue;
+  ExposeMetaData(dict, name, value);
+  return std::vector<double>{ value };
+}
+
 // Internal function to rescale pixel according to slope & intercept
 template <typename T>
 void
@@ -66,9 +80,12 @@ Rescale(T *                         buffer,
   SizeType i = 0;
   for (SizeType f = 0; f < frameCount; ++f)
   {
+    // A single slope/offset value applies to every frame
+    const double slope = (f < static_cast<SizeType>(slopes.size())) ? slopes[f] : slopes.front();
+    const double offset = (f < static_cast<SizeType>(offsets.size())) ? offsets[f] : offsets.front();
     for (SizeType v = 0; v < frameSize; ++v, ++i)
     {
-      const double tmp = static_cast<double>(buffer[i]) * slopes[f] + offsets[f];
+      const double tmp = static_cast<double>(buffer[i]) * slope + offset;
       buffer[i] = static_cast<T>(tmp);
     }
   }
@@ -695,8 +712,8 @@ Bruker2dseqImageIO::Read(void * buffer)
   }
 
   const MetaDataDictionary & dict = this->GetMetaDataDictionary();
-  const auto                 slopes = GetParameter<std::vector<double>>(dict, "VisuCoreDataSlope");
-  const auto                 offsets = GetParameter<std::vector<double>>(dict, "VisuCoreDataOffs");
+  const std::vector<double>  slopes = ReadScaling(dict, "VisuCoreDataSlope", 1.0);
+  const std::vector<double>  offsets = ReadScaling(dict, "VisuCoreDataOffs", 0.0);
   const SizeType             frameCount = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreFrameCount"));
   const SizeType             frameDim = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreDim"));
   SizeType                   frameSize = this->GetDimensions(0) * this->GetDimensions(1);

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -730,13 +730,15 @@ Bruker2dseqImageIO::Read(void * buffer)
   const SizeType             frameDim = static_cast<SizeType>(GetParameter<double>(dict, "VisuCoreDim"));
   SizeType                   frameSize = this->GetDimensions(0) * this->GetDimensions(1);
 
-  if (slopes.size() != 1 && slopes.size() != frameCount)
+  const auto slopeCount = static_cast<SizeType>(slopes.size());
+  const auto offsetCount = static_cast<SizeType>(offsets.size());
+  if (slopeCount != 1 && slopeCount != frameCount)
   {
-    itkExceptionMacro("VisuCoreDataSlope has " << slopes.size() << " values, expected 1 or " << frameCount);
+    itkExceptionMacro("VisuCoreDataSlope has " << slopeCount << " values, expected 1 or " << frameCount);
   }
-  if (offsets.size() != 1 && offsets.size() != frameCount)
+  if (offsetCount != 1 && offsetCount != frameCount)
   {
-    itkExceptionMacro("VisuCoreDataOffs has " << offsets.size() << " values, expected 1 or " << frameCount);
+    itkExceptionMacro("VisuCoreDataOffs has " << offsetCount << " values, expected 1 or " << frameCount);
   }
 
   if (frameDim == 3)

--- a/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
+++ b/Modules/IO/Bruker/src/itkBruker2dseqImageIO.cxx
@@ -973,64 +973,65 @@ Bruker2dseqImageIO::ReadImageInformation()
     vnl_vector<double> halfStep(3);
     halfStep[0] = FoV[0] / (2 * size[0]);
     halfStep[1] = FoV[1] / (2 * size[1]);
-    SizeType sizeZ = 1;
-    SizeType sizeT = 1;
-    double   spacingZ = 1;
-    double   reverseZ = 1;
+    SizeType           sizeZ = 1;
+    SizeType           sizeT = 1;
+    double             spacingZ = 0;
+    vnl_vector<double> sliceDiff(3, 0.0);
     if (brukerDim == 2)
     {
-      // The obvious way to get number of slices is sum of SlicePacksSlices - but single-slice images do not store this!
-      // The easiest way is divide the length of Position by 3 (3 co-ordinates per slice position)
-      sizeZ = position.size() / 3;
-      if (sizeZ == 1)
-      { // Special case for single-slice, because that doesn't store SliceDist
-        spacingZ = GetParameter<std::vector<double>>(dict, "VisuCoreFrameThickness")[0];
-      }
-      else
-      {
-        // FrameThickness does not include slice gap
-        // You would think that we could use the SliceDist field for multi-slice, but ParaVision
-        // has a bug that sometimes sets SliceDist to 0
-        // So - calculate this manually from the SlicePosition field
-        const vnl_vector<double> slice1(&position[0], 3);
-        const vnl_vector<double> slice2(&position[3], 3);
-        const vnl_vector<double> diff = slice2 - slice1;
-        spacingZ = diff.magnitude();
-      }
+      SizeType sliceLength = 0;
+      SizeType framesPerSlice = 1;
       if (dict.HasKey("VisuFGOrderDesc"))
       {
-        // Find the FG_CYCLE field
-        sizeT = 1;
         for (auto & i : GetParameter<std::vector<std::vector<std::string>>>(dict, "VisuFGOrderDesc"))
         {
-          // Anything dimension that isn't a slice needs to be collapsed into the 4th dimension
-          if (i[1] != "<FG_SLICE>")
+          const auto length = static_cast<SizeType>(StringToInt32(i[0], "Bruker 2dseq VisuFGOrderDesc size"));
+          if (i[1] == "<FG_SLICE>")
           {
-            sizeT *= itk::StringToInt32(i[0], "Bruker 2dseq VisuFGOrderDesc non-slice size");
+            sliceLength = length;
+          }
+          else
+          {
+            // Any dimension that isn't a slice is collapsed into the 4th dimension
+            sizeT *= length;
+            if (sliceLength == 0)
+            {
+              framesPerSlice *= length;
+            }
           }
         }
       }
+      // Frame groups without FG_SLICE (e.g. FG_ISA maps) describe one slice;
+      // without frame groups fall back to the position count (3 coordinates each)
+      const SizeType positionCount = position.size() / 3;
+      if (sliceLength > 0)
+      {
+        sizeZ = sliceLength;
+      }
       else
       {
-        itkGenericExceptionMacro("Could not find order description field");
+        sizeZ = dict.HasKey("VisuFGOrderDesc") ? 1 : positionCount;
       }
-      halfStep[2] = 0; // Slice position will be correct
-
-      if (sizeZ > 1)
-      { // There appears to be a bug in 2dseq orientations for Coronal 2D slices.
-        // This code checks if we have coronal slices and reverses the Z-direction
-        // further down, which makes the images appear correct in FSL View.
-        // The acquisition orientation is not stored in visu_pars so work out if
-        // this is coronal by checking if the Y component of the slice positions is
-        // changing.
-        const vnl_vector<double> corner1(&position[0], 3);
-        const vnl_vector<double> corner2(&position[3], 3);
-        vnl_vector<double>       diff = corner2 - corner1;
-        if (diff[1] != 0)
+      if (sizeZ > 1 && positionCount > 1)
+      {
+        // FrameThickness does not include the slice gap and ParaVision sometimes
+        // writes SliceDist as 0, so measure the step between slice positions.
+        // Positions may be stored per-slice or per-frame (frame groups before
+        // FG_SLICE vary faster), so step by the frame count per slice increment.
+        const SizeType positionStride = (positionCount > sizeZ) ? framesPerSlice : 1;
+        if (3 * (positionStride + 1) <= static_cast<SizeType>(position.size()))
         {
-          reverseZ = -1;
+          const vnl_vector<double> slice1(&position[0], 3);
+          const vnl_vector<double> slice2(&position[3 * positionStride], 3);
+          sliceDiff = slice2 - slice1;
+          spacingZ = sliceDiff.magnitude();
         }
       }
+      if (spacingZ == 0)
+      {
+        spacingZ = GetParameter<std::vector<double>>(dict, "VisuCoreFrameThickness")[0];
+      }
+      halfStep[2] = 0; // Slice position will be correct
     }
     else
     {
@@ -1070,7 +1071,8 @@ Bruker2dseqImageIO::ReadImageInformation()
     const vnl_matrix<double> dirMatrix(&orient[0], 3, 3);
     this->SetDirection(0, dirMatrix.get_row(0));
     this->SetDirection(1, dirMatrix.get_row(1));
-    // See note above for apparent bug in 2D coronal acquisitions
+    // 2D slices are sometimes stored against the orientation's slice axis; flip to match
+    const double reverseZ = (dot_product(sliceDiff, dirMatrix.get_row(2)) < 0) ? -1 : 1;
     this->SetDirection(2, reverseZ * dirMatrix.get_row(2));
 
     // Now work out the correct ITK origin including the half-voxel offset

--- a/Modules/IO/Bruker/test/CMakeLists.txt
+++ b/Modules/IO/Bruker/test/CMakeLists.txt
@@ -3,6 +3,10 @@ set(ITKIOBrukerTests itkBrukerImageTest.cxx)
 
 createtestdriver(ITKIOBruker "${ITKIOBruker-Test_LIBRARIES}" "${ITKIOBrukerTests}")
 
+set(ITKIOBrukerGTests itkBruker2dseqImageIOGTest.cxx)
+
+creategoogletestdriver(ITKIOBruker "${ITKIOBruker-Test_LIBRARIES}" "${ITKIOBrukerGTests}")
+
 ExternalData_Expand_Arguments(
   ITKData
   ExpandedData # Ignore output variable

--- a/Modules/IO/Bruker/test/CMakeLists.txt
+++ b/Modules/IO/Bruker/test/CMakeLists.txt
@@ -6,6 +6,11 @@ createtestdriver(ITKIOBruker "${ITKIOBruker-Test_LIBRARIES}" "${ITKIOBrukerTests
 set(ITKIOBrukerGTests itkBruker2dseqImageIOGTest.cxx)
 
 creategoogletestdriver(ITKIOBruker "${ITKIOBruker-Test_LIBRARIES}" "${ITKIOBrukerGTests}")
+target_compile_definitions(
+  ITKIOBrukerGTestDriver
+  PRIVATE
+    "ITK_TEST_OUTPUT_DIR=${ITK_TEST_OUTPUT_DIR}"
+)
 
 ExternalData_Expand_Arguments(
   ITKData

--- a/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
+++ b/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
@@ -177,3 +177,27 @@ TEST(Bruker2dseqImageIO, ReadParaVision360Dataset)
   ASSERT_EQ(slicePacksDef.size(), 1u);
   EXPECT_EQ(slicePacksDef[0], std::vector<double>({ 1.0, 1.0 }));
 }
+
+TEST(Bruker2dseqImageIO, RejectOversizedRLEExpansion)
+{
+  const std::string dir = testing::TempDir() + "/bruker2dseq_rle/pdata/1";
+  ASSERT_TRUE(itksys::SystemTools::MakeDirectory(dir));
+  std::string                  visu = MakeVisuPars();
+  const std::string::size_type slopePos = visu.find("@12*(2)");
+  ASSERT_NE(slopePos, std::string::npos);
+  visu.replace(slopePos, 7, "@999999999*(2)");
+  {
+    std::ofstream visuStream(dir + "/visu_pars");
+    visuStream << visu;
+  }
+  {
+    std::ofstream dataStream(dir + "/2dseq", std::ios::binary);
+    dataStream << '\0';
+  }
+
+  auto io = itk::Bruker2dseqImageIO::New();
+  auto reader = itk::ImageFileReader<itk::Image<float, 4>>::New();
+  reader->SetImageIO(io);
+  reader->SetFileName(dir + "/2dseq");
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}

--- a/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
+++ b/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
@@ -225,3 +225,26 @@ TEST(Bruker2dseqImageIO, RejectScalingArrayOfUnexpectedLength)
 {
   ExpectReadThrows("bruker2dseq_slope_count", VisuParsWithSlope("@3*(2)"));
 }
+
+TEST(Bruker2dseqImageIO, IgnoreSliceStepSmallerThanThickness)
+{
+  std::string visu = MakeVisuPars();
+  // Slice positions a ten-thousandth of the 1.5 mm thickness apart carry no direction
+  const std::string::size_type positionPos = visu.find("0 0 -1.5 \n");
+  ASSERT_NE(positionPos, std::string::npos);
+  visu.replace(positionPos, 10, "0 0 -0.0001 \n");
+  const std::string::size_type lastPos = visu.find("0 0 -3\n");
+  ASSERT_NE(lastPos, std::string::npos);
+  visu.replace(lastPos, 7, "0 0 -0.0002\n");
+
+  const std::string path = WriteDataset("bruker2dseq_flat_slices", visu, 12);
+  ASSERT_FALSE(path.empty());
+  auto io = itk::Bruker2dseqImageIO::New();
+  auto reader = itk::ImageFileReader<itk::Image<float, 4>>::New();
+  reader->SetImageIO(io);
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  EXPECT_DOUBLE_EQ(reader->GetOutput()->GetSpacing()[2], 1.5);
+  EXPECT_DOUBLE_EQ(reader->GetOutput()->GetDirection()(2, 2), 1.0);
+}

--- a/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
+++ b/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
@@ -1,0 +1,179 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkBruker2dseqImageIO.h"
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkMetaDataObject.h"
+#include "itksys/SystemTools.hxx"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+// A minimal ParaVision 360 style visu_pars: run-length encoded arrays, enum
+// arrays, a value block interrupted by a $$ comment, a string wrapped across
+// lines (trailing space kept), a comma inside a string, and a trailer after
+// ##END=. 4x2 pixels, 3 slices, 4 movie frames, movie varying fastest, slice
+// positions stored against the orientation's third axis.
+std::string
+MakeVisuPars()
+{
+  std::string visu;
+  visu += "##TITLE=Parameter List, ParaVision 360 V3.6\n";
+  visu += "##JCAMPDX=4.24\n";
+  visu += "##DATATYPE=Parameter Values\n";
+  visu += "##ORIGIN=Bruker BioSpin GmbH & Co. KG\n";
+  visu += "##OWNER=nmrsu\n";
+  visu += "$$ Write Options: Symbolic Enums, RLE encoded arrays, symbol visibility\n";
+  visu += "$$ 2024-07-25 09:18:04.415 +0200  nmrsu@host\n";
+  visu += "$$ /opt/nmrdata/PV-360.3.6/data/test/visu_pars\n";
+  visu += "$$ process parxserver\n";
+  visu += "##$VisuVersion=8\n";
+  visu += "##$VisuCreationDate=<2024-07-25T09:18:04,238+0200>\n";
+  visu += "##$VisuCoreFrameCount=12\n";
+  visu += "##$VisuCoreDim=2\n";
+  visu += "##$VisuCoreSize=( 2 )\n";
+  visu += "4 2\n";
+  visu += "##$VisuCoreDimDesc=( 2 )\n";
+  visu += "spatial spatial\n";
+  visu += "##$VisuCoreExtent=( 2 )\n";
+  visu += "4 2\n";
+  visu += "##$VisuCoreFrameThickness=( 1 )\n";
+  visu += "1.5\n";
+  visu += "##$VisuCoreUnits=( 2, 65 )\n";
+  visu += "<mm> <mm>\n";
+  visu += "##$VisuCoreOrientation=( 3, 9 )\n";
+  visu += "1 0 0 0 1 0 0 0 1 \n";
+  visu += "1 0 0 0 1 0 0 0 1 \n";
+  visu += "1 0 0 0 1 0 0 0 1\n";
+  visu += "##$VisuCorePosition=( 3, 3 )\n";
+  visu += "0 0 0 \n";
+  visu += "$$ @vis= VisuCoreOrientation VisuCorePosition\n";
+  visu += "0 0 -1.5 \n";
+  visu += "0 0 -3\n";
+  visu += "##$VisuCoreSlicePacksDef=(1, 1)\n";
+  visu += "##$VisuCoreDataOffs=( 1 )\n";
+  visu += "10\n";
+  visu += "##$VisuCoreDataSlope=( 12 )\n";
+  visu += "@12*(2)\n";
+  visu += "##$VisuCoreFrameType=( 1 )\n";
+  visu += "MAGNITUDE_IMAGE\n";
+  visu += "##$VisuCoreWordType=_16BIT_SGN_INT\n";
+  visu += "##$VisuCoreByteOrder=littleEndian\n";
+  visu += "##$VisuCoreDiskSliceOrder=( 1 )\n";
+  visu += "disk_normal_slice_order\n";
+  visu += "##$VisuFGOrderDescDim=2\n";
+  visu += "##$VisuFGOrderDesc=( 2 )\n";
+  visu += "(4, <FG_MOVIE>, <maps, \n";
+  visu += "fitted>, 0, 0) (3, <FG_SLICE>, <>, 0, 1)\n";
+  visu += "##$VisuGroupDepVals=( 1 )\n";
+  visu += "(<VisuCorePosition>, 0)\n";
+  visu += "##$VisuAcqRepetitionTime=( 1 )\n";
+  visu += "2000\n";
+  visu += "##END=\n";
+  visu += "$$ File finished by PARX at 2024-07-25 09:18:04.417 +0200\n";
+  return visu;
+}
+} // namespace
+
+TEST(Bruker2dseqImageIO, ReadParaVision360Dataset)
+{
+  const std::string dir = testing::TempDir() + "/bruker2dseq_pv360/pdata/1";
+  ASSERT_TRUE(itksys::SystemTools::MakeDirectory(dir));
+  {
+    std::ofstream visuStream(dir + "/visu_pars");
+    visuStream << MakeVisuPars();
+  }
+  {
+    // 12 frames of 4x2 int16 little-endian pixels, values 0..95
+    std::ofstream dataStream(dir + "/2dseq", std::ios::binary);
+    for (int i = 0; i < 96; ++i)
+    {
+      const char bytes[2] = { static_cast<char>(i & 0xff), static_cast<char>((i >> 8) & 0xff) };
+      dataStream.write(bytes, 2);
+    }
+  }
+
+  using ImageType = itk::Image<float, 4>;
+  auto io = itk::Bruker2dseqImageIO::New();
+  auto reader = itk::ImageFileReader<ImageType>::New();
+  reader->SetImageIO(io);
+  reader->SetFileName(dir + "/2dseq");
+  ASSERT_NO_THROW(reader->Update());
+
+  const ImageType::Pointer image = reader->GetOutput();
+  const auto               size = image->GetLargestPossibleRegion().GetSize();
+  EXPECT_EQ(size[0], 4u);
+  EXPECT_EQ(size[1], 2u);
+  EXPECT_EQ(size[2], 3u);
+  EXPECT_EQ(size[3], 4u);
+
+  const ImageType::SpacingType spacing = image->GetSpacing();
+  EXPECT_DOUBLE_EQ(spacing[0], 1.0);
+  EXPECT_DOUBLE_EQ(spacing[1], 1.0);
+  EXPECT_DOUBLE_EQ(spacing[2], 1.5);
+  EXPECT_DOUBLE_EQ(spacing[3], 2.0);
+
+  const ImageType::PointType origin = image->GetOrigin();
+  EXPECT_DOUBLE_EQ(origin[0], 0.5);
+  EXPECT_DOUBLE_EQ(origin[1], 0.5);
+  EXPECT_DOUBLE_EQ(origin[2], 0.0);
+
+  // Slice positions run along -z while the orientation's third row is +z
+  EXPECT_DOUBLE_EQ(image->GetDirection()(2, 2), -1.0);
+
+  // Stored frame order is movie-fastest; the reader reorders to slice-fastest,
+  // then applies the RLE slope (2) and the broadcast single offset (10)
+  for (itk::IndexValueType t = 0; t < 4; ++t)
+  {
+    for (itk::IndexValueType z = 0; z < 3; ++z)
+    {
+      for (itk::IndexValueType y = 0; y < 2; ++y)
+      {
+        for (itk::IndexValueType x = 0; x < 4; ++x)
+        {
+          const itk::Index<4> index = { { x, y, z, t } };
+          const float         expected = 2.0f * static_cast<float>((t + 4 * z) * 8 + y * 4 + x) + 10.0f;
+          EXPECT_FLOAT_EQ(image->GetPixel(index), expected) << "at " << index;
+        }
+      }
+    }
+  }
+
+  const itk::MetaDataDictionary & dict = io->GetMetaDataDictionary();
+  std::vector<double>             slopes;
+  ASSERT_TRUE(itk::ExposeMetaData(dict, "VisuCoreDataSlope", slopes));
+  EXPECT_EQ(slopes.size(), 12u);
+  std::string diskSliceOrder;
+  ASSERT_TRUE(itk::ExposeMetaData(dict, "VisuCoreDiskSliceOrder", diskSliceOrder));
+  EXPECT_EQ(diskSliceOrder, "disk_normal_slice_order");
+  std::vector<std::vector<std::string>> frameGroups;
+  ASSERT_TRUE(itk::ExposeMetaData(dict, "VisuFGOrderDesc", frameGroups));
+  ASSERT_EQ(frameGroups.size(), 2u);
+  ASSERT_EQ(frameGroups[0].size(), 5u);
+  EXPECT_EQ(frameGroups[0][2], "<maps, fitted>");
+  std::vector<std::vector<double>> slicePacksDef;
+  ASSERT_TRUE(itk::ExposeMetaData(dict, "VisuCoreSlicePacksDef", slicePacksDef));
+  ASSERT_EQ(slicePacksDef.size(), 1u);
+  EXPECT_EQ(slicePacksDef[0], std::vector<double>({ 1.0, 1.0 }));
+}

--- a/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
+++ b/Modules/IO/Bruker/test/itkBruker2dseqImageIOGTest.cxx
@@ -28,8 +28,36 @@
 #include <string>
 #include <vector>
 
+#define _STRING(s) #s
+#define TOSTRING(s) std::string(_STRING(s))
+
 namespace
 {
+// Writes a minimal ParaVision reconstruction and returns the path of its 2dseq
+std::string
+WriteDataset(const std::string & name, const std::string & visu, int frameCount)
+{
+  const std::string dir = TOSTRING(ITK_TEST_OUTPUT_DIR) + "/" + name + "/pdata/1";
+  if (!itksys::SystemTools::MakeDirectory(dir))
+  {
+    return std::string();
+  }
+  {
+    std::ofstream visuStream(dir + "/visu_pars");
+    visuStream << visu;
+  }
+  {
+    // int16 little-endian pixels of 4x2 frames, values counting up from zero
+    std::ofstream dataStream(dir + "/2dseq", std::ios::binary);
+    for (int i = 0; i < 8 * frameCount; ++i)
+    {
+      const char bytes[2] = { static_cast<char>(i & 0xff), static_cast<char>((i >> 8) & 0xff) };
+      dataStream.write(bytes, 2);
+    }
+  }
+  return dir + "/2dseq";
+}
+
 // A minimal ParaVision 360 style visu_pars: run-length encoded arrays, enum
 // arrays, a value block interrupted by a $$ comment, a string wrapped across
 // lines (trailing space kept), a comma inside a string, and a trailer after
@@ -94,31 +122,40 @@ MakeVisuPars()
   visu += "$$ File finished by PARX at 2024-07-25 09:18:04.417 +0200\n";
   return visu;
 }
+
+// Replaces the run-length encoded slope array of the ParaVision 360 dataset
+std::string
+VisuParsWithSlope(const std::string & slopeRecord)
+{
+  std::string                  visu = MakeVisuPars();
+  const std::string::size_type slopePos = visu.find("@12*(2)");
+  visu.replace(slopePos, 7, slopeRecord);
+  return visu;
+}
+
+void
+ExpectReadThrows(const std::string & name, const std::string & visu)
+{
+  const std::string path = WriteDataset(name, visu, 12);
+  ASSERT_FALSE(path.empty());
+  auto io = itk::Bruker2dseqImageIO::New();
+  auto reader = itk::ImageFileReader<itk::Image<float, 4>>::New();
+  reader->SetImageIO(io);
+  reader->SetFileName(path);
+  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+}
 } // namespace
 
 TEST(Bruker2dseqImageIO, ReadParaVision360Dataset)
 {
-  const std::string dir = testing::TempDir() + "/bruker2dseq_pv360/pdata/1";
-  ASSERT_TRUE(itksys::SystemTools::MakeDirectory(dir));
-  {
-    std::ofstream visuStream(dir + "/visu_pars");
-    visuStream << MakeVisuPars();
-  }
-  {
-    // 12 frames of 4x2 int16 little-endian pixels, values 0..95
-    std::ofstream dataStream(dir + "/2dseq", std::ios::binary);
-    for (int i = 0; i < 96; ++i)
-    {
-      const char bytes[2] = { static_cast<char>(i & 0xff), static_cast<char>((i >> 8) & 0xff) };
-      dataStream.write(bytes, 2);
-    }
-  }
+  const std::string path = WriteDataset("bruker2dseq_pv360", MakeVisuPars(), 12);
+  ASSERT_FALSE(path.empty());
 
   using ImageType = itk::Image<float, 4>;
   auto io = itk::Bruker2dseqImageIO::New();
   auto reader = itk::ImageFileReader<ImageType>::New();
   reader->SetImageIO(io);
-  reader->SetFileName(dir + "/2dseq");
+  reader->SetFileName(path);
   ASSERT_NO_THROW(reader->Update());
 
   const ImageType::Pointer image = reader->GetOutput();
@@ -180,24 +217,11 @@ TEST(Bruker2dseqImageIO, ReadParaVision360Dataset)
 
 TEST(Bruker2dseqImageIO, RejectOversizedRLEExpansion)
 {
-  const std::string dir = testing::TempDir() + "/bruker2dseq_rle/pdata/1";
-  ASSERT_TRUE(itksys::SystemTools::MakeDirectory(dir));
-  std::string                  visu = MakeVisuPars();
-  const std::string::size_type slopePos = visu.find("@12*(2)");
-  ASSERT_NE(slopePos, std::string::npos);
-  visu.replace(slopePos, 7, "@999999999*(2)");
-  {
-    std::ofstream visuStream(dir + "/visu_pars");
-    visuStream << visu;
-  }
-  {
-    std::ofstream dataStream(dir + "/2dseq", std::ios::binary);
-    dataStream << '\0';
-  }
+  ExpectReadThrows("bruker2dseq_rle_bytes", VisuParsWithSlope("@999999999*(2)"));
+  ExpectReadThrows("bruker2dseq_rle_digits", VisuParsWithSlope("@1000000000*(2)"));
+}
 
-  auto io = itk::Bruker2dseqImageIO::New();
-  auto reader = itk::ImageFileReader<itk::Image<float, 4>>::New();
-  reader->SetImageIO(io);
-  reader->SetFileName(dir + "/2dseq");
-  EXPECT_THROW(reader->Update(), itk::ExceptionObject);
+TEST(Bruker2dseqImageIO, RejectScalingArrayOfUnexpectedLength)
+{
+  ExpectReadThrows("bruker2dseq_slope_count", VisuParsWithSlope("@3*(2)"));
 }


### PR DESCRIPTION
Parse the JCAMP-DX forms ParaVision writes (PV5.1 headers, PV360 RLE and enum arrays, strings with commas), fix frame-scaling cardinality, and derive slice count and direction from frame groups. Adds synthetic PV360 GTests, no new external test data.

<details>
<summary>Defects fixed, per commit</summary>

- **Parser**: the fixed five-`##`/three-`$$` header assumption went out of step on PV5.1 files, which write two `$$` lines, so the reader consumed `VisuVersion` as a header line. It could not read ParaVision 360 files at all: `@N*(value)` run-length encoded arrays, `$$ @vis=` comments inside wrapped value blocks, commas inside `<>` strings such as `<Parameter maps T2 relaxation, bg: Otsu.>`, enum values stored as sized arrays (`( 1 )` then `disk_normal_slice_order`), and scalar struct values on the parameter line.
- **Scaling**: `VisuCoreDataSlope` and `VisuCoreDataOffs` hold either one value for all frames or one value per frame. Per-frame indexing read out of bounds when the file stored a single value. Neither parameter can depend on a frame group, so the reader now rejects any other count instead of reusing element 0.
- **Geometry**: 2D datasets whose frame groups lack `FG_SLICE`, such as `FG_ISA` parameter maps, hold a single slice. Taking the slice count from identical per-frame positions gave a zero slice spacing. The slice axis now follows the sign of the slice-position step along the orientation's third row, which generalizes the earlier coronal-only Y-component heuristic to oblique stacks. A step below half the frame thickness lies inside one slice and no longer flips the axis.
- **RLE bound**: the file controls the repetition count, so the reader bounds the expansion before it appends anything.

</details>

<details>
<summary>Why the reader measures the slice axis instead of reading it from the orientation</summary>

The format notes linked in the first comment reconstruct `VisuCoreOrientation` from `ACQ_grad_matrix` and the `ACQ_*_offset` values as `[ −d_r ; −d_p ; ±d_s ]`. The third row is the right-handed completion of the first two, not the direction in which the slice offsets grow. It therefore carries either sign, and the slice order has to come from `VisuCorePosition`.

`VisuCoreDiskSliceOrder` cannot supply it either. ParaVision writes that parameter for 3D frames, not for the 2D multi-slice case this code path handles.

</details>

<details>
<summary>Test results</summary>

- The existing `itkBruker2dseq_PV5.1_FSE_INT16` and `PV6.0_FLASH_*` regression tests pass against unchanged baselines.
- The `Bruker2dseqImageIO` GTests cover RLE arrays, wrapped strings with embedded commas, mid-value comments, broadcast scaling, frame-group reordering, a reversed slice axis, an out-of-range scaling count, an oversized and an over-long RLE count, and a slice step too small to carry a direction.
- The reader loads every dataset in a local ParaVision collection spanning PV5.1, PV6.0.1, PV7, and PV360 3.4-3.7, except zero-byte placeholder files, which it rejects with a clean exception.

</details>

<details>
<summary>AI assistance</summary>

- Tool: Claude Code
- Role: wrote the parser rewrite and the geometry fixes against the Bruker ParaVision file-format specification, which derives from Bruker's D01/D12 File Formats manuals and from ParaVision headers.
- I reviewed, built, and tested all code locally before committing.

</details>

<!--
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DneJhe9aQQ2Ay2STAPwVxX
-->
