### PR TITLE
STYLE: Use GetNumberOfPixels() for STAPLE pixel count

### DIFF
--- a/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
+++ b/Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx
@@ -107,8 +107,8 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
 
   // Divide sum by num of files, calculate the estimate of g_t
 
-  double N = 0.0;
-  double g_t = 0.0;
+  const SizeValueType N = W->GetRequestedRegion().GetNumberOfPixels();
+  double              g_t = 0.0;
   {
     ImageScanlineIterator out(W, W->GetRequestedRegion());
     while (!out.IsAtEnd())
@@ -117,12 +117,11 @@ STAPLEImageFilter<TInputImage, TOutputImage>::GenerateData()
       {
         out.Set(out.Get() / static_cast<double>(number_of_input_files));
         g_t += out.Get();
-        N = N + 1.0;
         ++out;
       } // end of scanline
       out.NextLine();
     }
-    g_t = (g_t / N) * m_ConfidenceWeight;
+    g_t = (g_t / static_cast<double>(N)) * m_ConfidenceWeight;
   }
   unsigned int iter = 0;
   for (; iter < m_MaximumIterations; ++iter)


### PR DESCRIPTION
Replaces a per-pixel `double` accumulator with `GetRequestedRegion().GetNumberOfPixels()` in `STAPLEImageFilter::GenerateData()`. No behavior change — cleanup only, closing #6763.

<details>
<summary>Why this is cleanup and not a bug fix</summary>

`N` was accumulated as `N = N + 1.0` inside the scanline loop. `double` carries a 53-bit mantissa, so the increment stays exact to 2^53 pixels and the counter never actually breaks. Filed and fixed only because it is the same idiom as the `float` counter in #6759, where it *is* a live defect (`float` saturates at 2^24 = 16,777,216, reached easily by a 3D image), so anyone auditing for that pattern lands here and has to re-derive that this instance is benign.

The change also removes one add from the inner loop.

</details>

<details>
<summary>What else in the file was checked and deliberately left alone</summary>

- `g_t` accumulates fractional per-pixel values, not counts — stays `double`.
- `p_num` / `p_denom` / `q_num` / `q_denom` accumulate `W_i` and `1 - W_i` over all pixels. Fractional, already `double`, not counters.
- The initial averaging loop's `out.Set(out.Get() + 1.0)` is bounded by the input file count, so it carries no precision risk.
- `alpha1` / `beta1` are per-pixel products, not accumulations.

`itkLabelVotingImageFilter` was checked separately and already counts votes in `unsigned int`.

</details>

<details>
<summary>Local verification</summary>

```
ninja ITKImageCompareTestDriver ITKImageCompareGTestDriver   # clean, no warnings
ctest -R STAPLE                                             # 11/11 passed
```

Includes `itkSTAPLEImageFilterTest`, which is a baseline image comparison — the filter's output is bit-identical to before.

`pre-commit run --all-files` exits 0 on this tree.

</details>

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any)
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

<!--
provenance: claude-code session 2026-08-13
issue: #6763 (filed same session)
related: #6759 (float variant in MultiLabelSTAPLEImageFilter — the live defect)
file: Modules/Filtering/ImageCompare/include/itkSTAPLEImageFilter.hxx L110-L125
local_build: /Users/johnsonhj/src/ITK/build — ctest -R STAPLE 11/11
-->
