### PR TITLE
ENH: set a flag when DICOM ambiguous ordering fallback is used

### DIFF
--- a/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
+++ b/Modules/IO/GDCM/include/itkGDCMSeriesFileNames.h
@@ -42,7 +42,8 @@ namespace itk
  *      orientation), an exception is thrown by default; see
  *      FailOnAmbiguousOrdering. When FailOnAmbiguousOrdering is false, the
  *      ordering falls back to 'Instance Number' when unique, else to
- *      lexicographic filename order.
+ *      lexicographic filename order (and in either case, DidUseAmbiguousOrdering
+ *      is set to true).
  *
  *  If multiple volumes are being grouped as a single series for your
  *    DICOM objects, you may want to try calling SetUseSeriesDetails(true)
@@ -172,7 +173,7 @@ public:
   void
   AddSeriesRestriction(const std::string & tag);
 
-  /** Throw an exception when a series cannot be ordered geometrically by
+  /** When true, throw an exception when a series cannot be ordered geometrically by
    * gdcm::IPPSorter (duplicate ImagePositionPatient, inconsistent
    * orientation). When false, fall back to the legacy SerieHelper
    * heuristics: Instance Number when unique, else lexicographic filename
@@ -182,6 +183,11 @@ public:
   itkSetMacro(FailOnAmbiguousOrdering, bool);
   itkGetConstMacro(FailOnAmbiguousOrdering, bool);
   itkBooleanMacro(FailOnAmbiguousOrdering);
+  /** @ITKEndGrouping */
+
+  /** If ambiguous ordering is encountered, this is set to true. */
+  /** @ITKStartGrouping */
+  itkGetConstMacro(DidUseAmbiguousOrdering, bool);
   /** @ITKEndGrouping */
 
   /** No effect with the gdcm::Scanner backend (retained for source
@@ -256,6 +262,7 @@ private:
 
   bool m_UseSeriesDetails = false;
   bool m_FailOnAmbiguousOrdering = true;
+  bool m_DidUseAmbiguousOrdering = false;
   bool m_Recursive = false;
   bool m_LoadSequences = false;
   bool m_LoadPrivateTags = false;

--- a/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
+++ b/Modules/IO/GDCM/src/itkGDCMSeriesFileNames.cxx
@@ -218,7 +218,12 @@ GDCMSeriesFileNames::OrderSeries(SeriesEntry & entry)
   // acquisitions (see issue #6468).
   gdcm::IPPSorter sorter;
   sorter.SetComputeZSpacing(false);
-  if (sorter.Sort(entry.Files))
+  bool wasSortingAchieved = sorter.Sort(entry.Files);
+
+  // Set a public flag so that callers know this fallback occurred, and can show a warning.
+  m_DidUseAmbiguousOrdering = !wasSortingAchieved;
+
+  if (wasSortingAchieved)
   {
     entry.Files = sorter.GetFilenames();
     entry.Ordered = true;
@@ -230,6 +235,7 @@ GDCMSeriesFileNames::OrderSeries(SeriesEntry & entry)
                       "orientation, see issue #6468). Set FailOnAmbiguousOrdering to false to accept the legacy "
                       "non-standard ordering heuristics.");
   }
+
   // Legacy SerieHelper heuristics (Instance Number, then lexicographic),
   // kept only for determinism and backward compatibility: an untrustworthy,
   // non-standard hack whose output should not be trusted.
@@ -412,6 +418,7 @@ GDCMSeriesFileNames::PrintSelf(std::ostream & os, Indent indent) const
 
   itkPrintSelfBooleanMacro(UseSeriesDetails);
   itkPrintSelfBooleanMacro(FailOnAmbiguousOrdering);
+  itkPrintSelfBooleanMacro(DidUseAmbiguousOrdering);
   itkPrintSelfBooleanMacro(Recursive);
   itkPrintSelfBooleanMacro(LoadSequences);
   itkPrintSelfBooleanMacro(LoadPrivateTags);


### PR DESCRIPTION
This flag can be used by callers to know the fallback happened, and warn end users.

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

## PR Checklist
- [ ] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [ ] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [ ] Added test (or behavior not changed)
- [ ] Updated API documentation (or API not changed)
- [ ] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [ ] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [ ] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
