### PR TITLE
STYLE: Use itk.int64_t and itk.uint64_t instead of `if os.name == "nt"`

### DIFF
--- a/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
@@ -48,10 +48,7 @@ def test_point_set_serialization(use_unsafe_SetPoints_overload: bool = False):
 
     # Set Points in the PointSet
     PointType = itk.Point[itk.F, 3]
-    if os.name == "nt":
-        v_point = itk.VectorContainer[itk.ULL, PointType].New()
-    else:
-        v_point = itk.VectorContainer[itk.UL, PointType].New()
+    v_point = itk.VectorContainer[itk.uint64_t, PointType].New()
     v_point.Reserve(NumberOfPoints)
 
     point = PointType()

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -45,10 +45,7 @@ def test_mesh_serialization(use_unsafe_SetPoints_overload: bool = False):
 
     # Set Points in the Mesh
     PointType = itk.Point[itk.F, 3]
-    if os.name == "nt":
-        v_point = itk.VectorContainer[itk.ULL, PointType].New()
-    else:
-        v_point = itk.VectorContainer[itk.UL, PointType].New()
+    v_point = itk.VectorContainer[itk.uint64_t, PointType].New()
     v_point.Reserve(NumberOfPoints)
 
     point = PointType()

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -268,18 +268,12 @@ def _get_itk_pixelid(numpy_array_type):
 
     import itk
 
-    def _long_type():
-        if os.name == "nt":
-            return itk.ULL
-        else:
-            return itk.UL
-
     # This is a Mapping from numpy array types to itk pixel types.
     _np_itk = {
         np.dtype(np.uint8): itk.UC,
         np.dtype(np.uint16): itk.US,
         np.dtype(np.uint32): itk.UI,
-        np.dtype(np.uint64): _long_type(),
+        np.dtype(np.uint64): itk.uint64_t,
         np.dtype(np.int8): itk.SC,
         np.dtype(np.int16): itk.SS,
         np.dtype(np.int32): itk.SI,
@@ -551,10 +545,7 @@ def vector_container_from_array(arr: ArrayLike, ttype=None) -> itkt.VectorContai
         arr = np.asarray(arr)
 
     # Return VectorContainer with 64-bit index type
-    if os.name == "nt":
-        IndexType = itk.ULL
-    else:
-        IndexType = itk.UL
+    IndexType = itk.uint64_t
 
     # Find container type
     if ttype is not None:
@@ -907,10 +898,7 @@ def dict_from_mesh(mesh: itkt.Mesh) -> dict:
     else:
         cell_data_numpy = itk.array_from_vector_container(cell_data)
 
-    if os.name == "nt":
-        cell_component_type = python_to_js(itk.ULL)
-    else:
-        cell_component_type = python_to_js(itk.UL)
+    cell_component_type = python_to_js(itk.uint64_t)
 
     point_component_type = python_to_js(itk.F)
 
@@ -982,10 +970,7 @@ def dict_from_pointset(pointset: itkt.PointSet) -> dict:
     else:
         point_data_numpy = itk.array_from_vector_container(point_data)
 
-    if os.name == "nt":
-        cell_component_type = python_to_js(itk.ULL)
-    else:
-        cell_component_type = python_to_js(itk.UL)
+    cell_component_type = python_to_js(itk.uint64_t)
 
     point_component_type = python_to_js(itk.F)
 

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -158,13 +158,9 @@ int32_t = SI
 int64_t = SL if SL.dtype.itemsize == 8 else SLL
 
 # Aliases for SizeValueType, IdentifierType, OffsetType
-ST = UL
-IT = UL
-OT = SL
-if os.name == "nt":
-    ST = ULL
-    IT = ULL
-    OT = SLL
+ST = uint64_t
+IT = uint64_t
+OT = int64_t
 
 # Type aliases to avoid expensive import, circular references. Use with forward references.
 if TYPE_CHECKING:


### PR DESCRIPTION
Replaced `if os.name == "nt"` statements which used `itk.SL`, `itk.SLL`, `itk.UL`, or `itk.ULL` with the equivalent code, using just `itk.int64_t` or `itk.uint64_t`.

Aims to improve code readability and remove OS-specific code.

- Follow-up to pull request #6762 commit dc0ea28fe9af0503ac572c44839506daaf0329b1
