### PR TITLE
ENH: Tier the Eigen-backed convenience numerics as itk::bridge

### DIFF
--- a/Documentation/Doxygen/BridgeNumerics.dox
+++ b/Documentation/Doxygen/BridgeNumerics.dox
@@ -1,0 +1,57 @@
+/**
+   \page BridgeNumericsPage The itk::bridge Numerics Namespace
+
+   \section BridgeNumericsIntent Intent
+
+   \c itk::bridge holds convenience wrappers over third-party numerical
+   solvers, currently Eigen. They exist to ease the initial migration of code
+   away from the deprecated VNL algorithms: a call site that used
+   \c vnl_svd can be moved to \c itk::bridge::Math::SVD as a mechanical,
+   low-risk edit, without the caller first learning Eigen's API.
+
+   \section BridgeNumericsNotCore Not part of the core ITK mission
+
+   These are a migration aid, not a numerics library. ITK does not undertake to
+   maintain, validate, optimize, or preserve the API or ABI of anything in
+   \c itk::bridge to the standard it applies to the rest of the toolkit.
+   Specifically:
+
+   \li The interfaces may change or be removed between releases without the
+       deprecation cycle that core ITK API changes receive.
+   \li The numerical behavior is that of the underlying backend. ITK does not
+       independently validate accuracy, conditioning, or convergence, and does
+       not guarantee bit-for-bit stability across backend versions.
+   \li Coverage is limited to what ITK's own migration needed. Absent
+       functionality will not necessarily be added.
+
+   \section BridgeNumericsDownstream Guidance for downstream users
+
+   \b Prefer \b calling \b Eigen \b directly. Downstream projects should depend
+   on Eigen (or another numerical library of their choosing) rather than on the
+   API or ABI of these convenience wrappers. Using \c itk::bridge as a
+   transitional step while retiring VNL is reasonable; treating it as a
+   permanent dependency is not.
+
+   Code that needs a long-lived, supported numerical interface should call the
+   backend directly, where the API contract, versioning policy, and
+   documentation are those of the numerical library itself.
+
+   \sa itk::bridge::Math::SVD
+   \sa itk::bridge::SymmetricEigenDecomposition
+*/
+
+/**
+   \namespace itk::bridge
+   \brief Convenience wrappers over third-party numerical backends, provided as
+   a migration aid rather than as supported ITK API.
+
+   Anything in this namespace eases the initial move off the deprecated VNL
+   algorithms. It is not part of the core ITK mission to maintain or validate:
+   the API and ABI may change without the usual deprecation cycle, and the
+   numerical behavior is the backend's, not ITK's.
+
+   Downstream users should prefer calling Eigen (or another numerical library)
+   directly rather than depending on these wrappers.
+
+   \see \ref BridgeNumericsPage
+*/

--- a/Documentation/docs/migration_guides/itk_6_migration_guide.md
+++ b/Documentation/docs/migration_guides/itk_6_migration_guide.md
@@ -751,26 +751,51 @@ removed. The default (non-FFTW) FFT backend is now PocketFFT
 - `vnl_fft_prime_factors`, `gpfa`-family symbols, and the vxl
   `vnl_algo_test_fft*`/`test_convolve` tests are gone from the vendored tree.
 
+## The `itk::bridge` namespace: a migration aid, not supported ITK API
+
+The Eigen-backed replacements named throughout this guide live in
+`itk::bridge`. That namespace holds **convenience wrappers intended to ease the
+initial burden of moving off the deprecated VNL algorithms** — a `vnl_svd` call
+site can become `itk::bridge::Math::SVD` as a mechanical edit, without the
+caller first learning Eigen's API.
+
+These wrappers are **not part of the core ITK mission to maintain or validate**:
+
+- The API and ABI may change, or be removed, without the deprecation cycle that
+  core ITK API changes receive.
+- The numerical behavior is the backend's. ITK does not independently validate
+  accuracy, conditioning, or convergence, and does not guarantee bit-for-bit
+  stability across backend versions.
+- Coverage extends only to what ITK's own migration required; missing
+  functionality will not necessarily be added.
+
+**Downstream users should prefer depending on Eigen (or another numerical
+library) directly** rather than on the API/ABI of these wrappers. Using
+`itk::bridge` as a transitional step while retiring VNL is reasonable; treating
+it as a permanent dependency is not. Code that needs a long-lived, supported
+numerical interface should call the backend directly, where the API contract,
+versioning policy, and documentation are the numerical library's own.
+
 ## Eigen-backed eigendecompositions replace netlib EISPACK `vnl_*_eigensystem`
 
 `vnl_real_eigensystem`, `vnl_symmetric_eigensystem`, and
 `vnl_generalized_eigensystem` (netlib EISPACK `rg`/`rs`/`rsg`), and the only
 other client `vnl_scatter_3x3`, are deprecated in favor of Eigen-backed
-`itk::RealEigenDecomposition`, `itk::SymmetricEigenDecomposition`, and
-`itk::GeneralizedEigenDecomposition`. Under `ITK_FUTURE_LEGACY_REMOVE` these
+`itk::bridge::RealEigenDecomposition`, `itk::bridge::SymmetricEigenDecomposition`, and
+`itk::bridge::GeneralizedEigenDecomposition`. Under `ITK_FUTURE_LEGACY_REMOVE` these
 classes and the entire `v3p/netlib/eispack/` subdirectory are excluded from the
 build.
 
 ### What you need to do
 
-- Replace `vnl_symmetric_eigensystem<T>` with `itk::SymmetricEigenDecomposition<T>`
+- Replace `vnl_symmetric_eigensystem<T>` with `itk::bridge::SymmetricEigenDecomposition<T>`
   (it mirrors the `V`/`D` members and `get_eigenvector`/`get_eigenvalue`
   accessors, so most call sites change only the type name and the include:
-  `itkSymmetricEigenDecomposition.h`). Use `itk::RealEigenDecomposition` and
-  `itk::GeneralizedEigenDecomposition` for the non-symmetric and
+  `itkBridgeSymmetricEigenDecomposition.h`). Use `itk::bridge::RealEigenDecomposition` and
+  `itk::bridge::GeneralizedEigenDecomposition` for the non-symmetric and
   symmetric-definite generalized problems.
 - For the eigenvalues/eigenvectors of a 3x3 scatter matrix, build the matrix
-  directly and feed `itk::SymmetricEigenDecomposition`.
+  directly and feed `itk::bridge::SymmetricEigenDecomposition`.
 
 ### A different correct representation — not a regression
 
@@ -800,14 +825,14 @@ representation of the same result, not an indication of a failure.** Update such
 expected values to the new (now platform-stable) representatives; the migrated
 ITK tests have been updated this way.
 
-## Optional Eigen-backed `itk::Math::SVD`
+## Optional Eigen-backed `itk::bridge::Math::SVD`
 
-A new opt-in, header-only `itk::Math::SVD` (`itkMathSVD.h`) provides an
+A new opt-in, header-only `itk::bridge::Math::SVD` (`itkBridgeMathSVD.h`) provides an
 Eigen-backed singular value decomposition. It returns `U`, `W`, `V` as vnl types
 plus `PseudoInverse()`, `Solve()`, `Rank()` and `Recompose()` -- the dominant `vnl_svd`
 operations. `vnl_svd` is unchanged by this addition, but the direction is to
-migrate ITK and downstream code onto `itk::Math::SVD` and ultimately **deprecate
-and remove** the `vnl_svd` path. Prefer `itk::Math::SVD` in new code.
+migrate ITK and downstream code onto `itk::bridge::Math::SVD` and ultimately **deprecate
+and remove** the `vnl_svd` path. Prefer `itk::bridge::Math::SVD` in new code.
 
 A runtime-sized `vnl_matrix` of any shape is accepted: square inputs take a fast
 JacobiSVD/BDCSVD path; rectangular inputs use BDCSVD with thin U/V (`U` is m x k,
@@ -818,7 +843,7 @@ signature.
 
 ### What you need to do
 
-Nothing is required immediately, but prefer `itk::Math::SVD` in new code. The
+Nothing is required immediately, but prefer `itk::bridge::Math::SVD` in new code. The
 `vnl_svd`-only operations (`nullvector`, `well_condition`, `singularities`) have
 no remaining callers in ITK, so the new API already covers every ITK use; the few
 remaining `vnl_svd` call sites are slated for migration as part of the broader
@@ -854,7 +879,7 @@ accuracy.
 
 ### Deterministic signs -- a different correct representation
 
-Like the eigendecomposition classes above, `itk::Math::SVD` canonicalizes the
+Like the eigendecomposition classes above, `itk::bridge::Math::SVD` canonicalizes the
 singular-vector signs by default (reproducible across platforms and SIMD width),
 whereas `vnl_svd`'s signs depend on solver internals. Sign-invariant operations
 -- `U * V^T`, `PseudoInverse()`, `Solve()` -- are stable across the swap; code that

--- a/Examples/RegistrationITKv4/ImageRegistration9.cxx
+++ b/Examples/RegistrationITKv4/ImageRegistration9.cxx
@@ -73,7 +73,7 @@
 //  that will monitor the evolution of the registration process.
 //
 #include "itkCommand.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 class CommandIterationUpdate : public itk::Command
 {
 public:
@@ -113,7 +113,7 @@ public:
     p[0][1] = static_cast<double>(optimizer->GetCurrentPosition()[1]);
     p[1][0] = static_cast<double>(optimizer->GetCurrentPosition()[2]);
     p[1][1] = static_cast<double>(optimizer->GetCurrentPosition()[3]);
-    const auto         svd = itk::Math::SVD(p);
+    const auto         svd = itk::bridge::Math::SVD(p);
     vnl_matrix<double> r(2, 2);
     r = svd.U * svd.V.transpose();
     const double angle = std::asin(r[1][0]);
@@ -412,7 +412,7 @@ main(int argc, char * argv[])
   p[0][1] = static_cast<double>(finalParameters[1]);
   p[1][0] = static_cast<double>(finalParameters[2]);
   p[1][1] = static_cast<double>(finalParameters[3]);
-  const auto         svd = itk::Math::SVD(p);
+  const auto         svd = itk::bridge::Math::SVD(p);
   vnl_matrix<double> r(2, 2);
   r = svd.U * svd.V.transpose();
   const double angle = std::asin(r[1][0]);

--- a/Modules/Core/Common/include/itkBridgeCholeskySolve.h
+++ b/Modules/Core/Common/include/itkBridgeCholeskySolve.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkCholeskySolve_h
-#define itkCholeskySolve_h
+#ifndef itkBridgeCholeskySolve_h
+#define itkBridgeCholeskySolve_h
 
 #include "itkMacro.h"
 #include "vnl/vnl_matrix.h"
@@ -24,7 +24,7 @@
 #include "itk_eigen.h"
 #include ITK_EIGEN(Dense)
 
-namespace itk
+namespace itk::bridge
 {
 namespace Math
 {
@@ -85,6 +85,6 @@ CholeskyLowerTriangle(const vnl_matrix<T> & A)
 }
 
 } // namespace Math
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkCholeskySolve_h
+#endif // itkBridgeCholeskySolve_h

--- a/Modules/Core/Common/include/itkBridgeEigenDecompositionSignConvention.h
+++ b/Modules/Core/Common/include/itkBridgeEigenDecompositionSignConvention.h
@@ -15,13 +15,13 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkEigenDecompositionSignConvention_h
-#define itkEigenDecompositionSignConvention_h
+#ifndef itkBridgeEigenDecompositionSignConvention_h
+#define itkBridgeEigenDecompositionSignConvention_h
 
 #include "vnl/vnl_matrix.h"
 #include <cmath>
 
-namespace itk::detail
+namespace itk::bridge::detail
 {
 
 /** Canonicalize the sign of every eigenvector column of \a V so that its
@@ -90,6 +90,6 @@ CanonicalizeColumnSignsPaired(TMatrixU & u, TMatrixV & paired)
   }
 }
 
-} // namespace itk::detail
+} // namespace itk::bridge::detail
 
-#endif // itkEigenDecompositionSignConvention_h
+#endif // itkBridgeEigenDecompositionSignConvention_h

--- a/Modules/Core/Common/include/itkBridgeEigenDecompositionSolverInfo.h
+++ b/Modules/Core/Common/include/itkBridgeEigenDecompositionSolverInfo.h
@@ -15,13 +15,13 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkEigenDecompositionSolverInfo_h
-#define itkEigenDecompositionSolverInfo_h
+#ifndef itkBridgeEigenDecompositionSolverInfo_h
+#define itkBridgeEigenDecompositionSolverInfo_h
 
 #include "itk_eigen.h"
 #include ITK_EIGEN(Dense)
 
-namespace itk::detail
+namespace itk::bridge::detail
 {
 
 /** Human-readable name and likely cause for an Eigen solver status, so a
@@ -43,6 +43,6 @@ EigenComputationInfoString(Eigen::ComputationInfo info)
   return "an unrecognized Eigen::ComputationInfo value";
 }
 
-} // namespace itk::detail
+} // namespace itk::bridge::detail
 
-#endif // itkEigenDecompositionSolverInfo_h
+#endif // itkBridgeEigenDecompositionSolverInfo_h

--- a/Modules/Core/Common/include/itkBridgeGeneralizedEigenDecomposition.h
+++ b/Modules/Core/Common/include/itkBridgeGeneralizedEigenDecomposition.h
@@ -15,18 +15,18 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkGeneralizedEigenDecomposition_h
-#define itkGeneralizedEigenDecomposition_h
+#ifndef itkBridgeGeneralizedEigenDecomposition_h
+#define itkBridgeGeneralizedEigenDecomposition_h
 
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector.h"
-#include "itkEigenDecompositionSignConvention.h"
-#include "itkEigenDecompositionSolverInfo.h"
+#include "itkBridgeEigenDecompositionSignConvention.h"
+#include "itkBridgeEigenDecompositionSolverInfo.h"
 #include "itkMacro.h"
 #include "itk_eigen.h"
 #include ITK_EIGEN(Dense)
 
-namespace itk
+namespace itk::bridge
 {
 
 /** \class GeneralizedEigenDecomposition
@@ -105,6 +105,6 @@ private:
   MatrixType m_Eigenvectors;
 };
 
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkGeneralizedEigenDecomposition_h
+#endif // itkBridgeGeneralizedEigenDecomposition_h

--- a/Modules/Core/Common/include/itkBridgeMathDeterminant.h
+++ b/Modules/Core/Common/include/itkBridgeMathDeterminant.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkMathDeterminant_h
-#define itkMathDeterminant_h
+#ifndef itkBridgeMathDeterminant_h
+#define itkBridgeMathDeterminant_h
 
 #include "itkMacro.h"
 #include "vnl/vnl_matrix.h"
@@ -31,7 +31,10 @@ namespace itk
 // with itkMatrix.h; its body instantiates only where itk::Matrix is complete.
 template <typename T, unsigned int VRows, unsigned int VColumns>
 class Matrix;
+} // namespace itk
 
+namespace itk::bridge
+{
 namespace Math
 {
 namespace detail
@@ -104,7 +107,7 @@ Determinant(const vnl_matrix<TReal> & A)
   const unsigned int rows = A.rows();
   if (rows != A.cols())
   {
-    itkGenericExceptionMacro("itk::Math::Determinant requires a square matrix.");
+    itkGenericExceptionMacro("itk::bridge::Math::Determinant requires a square matrix.");
   }
   return detail::DynamicDeterminantEigen<TReal>(A.data_block(), rows);
 }
@@ -121,6 +124,6 @@ Determinant(const vnl_matrix_fixed<TReal, VRows, VColumns> & A)
 }
 
 } // namespace Math
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkMathDeterminant_h
+#endif // itkBridgeMathDeterminant_h

--- a/Modules/Core/Common/include/itkBridgeMathLDLT.h
+++ b/Modules/Core/Common/include/itkBridgeMathLDLT.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkMathLDLT_h
-#define itkMathLDLT_h
+#ifndef itkBridgeMathLDLT_h
+#define itkBridgeMathLDLT_h
 
 #include "itkMacro.h"
 #include "itkArray.h"
@@ -36,19 +36,19 @@
 /** Capability macro. Downstream code selects the Eigen-backed symmetric solve
  * with, e.g.:
  * \code
- *   #if __has_include(<itkMathLDLT.h>)
- *   #  include <itkMathLDLT.h>
+ *   #if __has_include(<itkBridgeMathLDLT.h>)
+ *   #  include <itkBridgeMathLDLT.h>
  *   #endif
- *   #ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
- *     x = itk::Math::SolveSymmetric(A, b);        // itk::Array2D, itk::Array
+ *   #ifdef ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC
+ *     x = itk::bridge::Math::SolveSymmetric(A, b);        // itk::Array2D, itk::Array
  *   #else
  *     x = vnl_cholesky(A.as_ref()).solve(b);      // legacy vnl fallback
  *   #endif
  * \endcode
  */
-#define ITK_MATH_HAS_SOLVE_SYMMETRIC 1
+#define ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC 1
 
-namespace itk
+namespace itk::bridge
 {
 namespace Math
 {
@@ -71,7 +71,7 @@ SolveSymmetricLDLTEigen(const TReal * aData, const TReal * bData, unsigned int n
   const Eigen::LDLT<ColMajor> ldlt(aMap);
   if (ldlt.info() != Eigen::Success)
   {
-    itkGenericExceptionMacro("itk::Math::SolveSymmetric failed; input is likely non-finite (NaN/Inf).");
+    itkGenericExceptionMacro("itk::bridge::Math::SolveSymmetric failed; input is likely non-finite (NaN/Inf).");
   }
   Eigen::Map<Vector>(xData, n) = ldlt.solve(bMap);
 }
@@ -93,7 +93,7 @@ SolveSymmetricMatrixLDLTEigen(const TReal * aData, const TReal * bData, unsigned
   const Eigen::LDLT<ColMajor> ldlt(aMap);
   if (ldlt.info() != Eigen::Success)
   {
-    itkGenericExceptionMacro("itk::Math::SolveSymmetric failed; input is likely non-finite (NaN/Inf).");
+    itkGenericExceptionMacro("itk::bridge::Math::SolveSymmetric failed; input is likely non-finite (NaN/Inf).");
   }
   Eigen::Map<RowMajor>(xData, n, m) = ldlt.solve(bMap);
 }
@@ -112,13 +112,13 @@ InverseSymmetricLDLTEigen(const TReal * aData, unsigned int n, TReal * invData)
   const Eigen::LDLT<ColMajor> ldlt(aMap);
   if (ldlt.info() != Eigen::Success)
   {
-    itkGenericExceptionMacro("itk::Math::InverseSymmetric failed; input is likely non-finite (NaN/Inf).");
+    itkGenericExceptionMacro("itk::bridge::Math::InverseSymmetric failed; input is likely non-finite (NaN/Inf).");
   }
   const auto  dAbs = ldlt.vectorD().cwiseAbs().eval();
   const TReal dMax = dAbs.maxCoeff();
   if (dMax == TReal{ 0 } || dAbs.minCoeff() <= dMax * static_cast<TReal>(n) * std::numeric_limits<TReal>::epsilon())
   {
-    itkGenericExceptionMacro("itk::Math::InverseSymmetric failed; input matrix is singular.");
+    itkGenericExceptionMacro("itk::bridge::Math::InverseSymmetric failed; input matrix is singular.");
   }
   Eigen::Map<RowMajor>(invData, n, n) = ldlt.solve(ColMajor::Identity(n, n));
 }
@@ -148,7 +148,7 @@ SolveSymmetric(const Array2D<TReal> & A, const Array<TReal> & b)
   const unsigned int n = A.rows();
   if (n == 0 || A.cols() != n || b.size() != n)
   {
-    itkGenericExceptionMacro("itk::Math::SolveSymmetric requires a non-empty square A and a matching b.");
+    itkGenericExceptionMacro("itk::bridge::Math::SolveSymmetric requires a non-empty square A and a matching b.");
   }
   Array<TReal> x(n);
   detail::SolveSymmetricLDLTEigen<TReal>(A.data_block(), b.data_block(), n, x.data_block());
@@ -179,7 +179,7 @@ SolveSymmetric(const vnl_matrix<TReal> & A, const vnl_vector<TReal> & b)
   const unsigned int n = A.rows();
   if (n == 0 || A.cols() != n || b.size() != n)
   {
-    itkGenericExceptionMacro("itk::Math::SolveSymmetric requires a non-empty square A and a matching b.");
+    itkGenericExceptionMacro("itk::bridge::Math::SolveSymmetric requires a non-empty square A and a matching b.");
   }
   vnl_vector<TReal> x(n);
   detail::SolveSymmetricLDLTEigen<TReal>(A.data_block(), b.data_block(), n, x.data_block());
@@ -208,7 +208,7 @@ SolveSymmetric(const Array2D<TReal> & A, const Array2D<TReal> & B)
   const unsigned int n = A.rows();
   if (n == 0 || A.cols() != n || B.rows() != n)
   {
-    itkGenericExceptionMacro("itk::Math::SolveSymmetric requires a non-empty square A and a matching B.");
+    itkGenericExceptionMacro("itk::bridge::Math::SolveSymmetric requires a non-empty square A and a matching B.");
   }
   Array2D<TReal> X(n, B.cols());
   detail::SolveSymmetricMatrixLDLTEigen<TReal>(A.data_block(), B.data_block(), n, B.cols(), X.data_block());
@@ -231,7 +231,7 @@ InverseSymmetric(const Array2D<TReal> & A)
   const unsigned int n = A.rows();
   if (n == 0 || A.cols() != n)
   {
-    itkGenericExceptionMacro("itk::Math::InverseSymmetric requires a non-empty square A.");
+    itkGenericExceptionMacro("itk::bridge::Math::InverseSymmetric requires a non-empty square A.");
   }
   Array2D<TReal> inv(n, n);
   detail::InverseSymmetricLDLTEigen<TReal>(A.data_block(), n, inv.data_block());
@@ -246,7 +246,7 @@ SolveSymmetric(const vnl_matrix<TReal> & A, const vnl_matrix<TReal> & B)
   const unsigned int n = A.rows();
   if (n == 0 || A.cols() != n || B.rows() != n)
   {
-    itkGenericExceptionMacro("itk::Math::SolveSymmetric requires a non-empty square A and a matching B.");
+    itkGenericExceptionMacro("itk::bridge::Math::SolveSymmetric requires a non-empty square A and a matching B.");
   }
   vnl_matrix<TReal> X(n, B.cols());
   detail::SolveSymmetricMatrixLDLTEigen<TReal>(A.data_block(), B.data_block(), n, B.cols(), X.data_block());
@@ -261,7 +261,7 @@ InverseSymmetric(const vnl_matrix<TReal> & A)
   const unsigned int n = A.rows();
   if (n == 0 || A.cols() != n)
   {
-    itkGenericExceptionMacro("itk::Math::InverseSymmetric requires a non-empty square A.");
+    itkGenericExceptionMacro("itk::bridge::Math::InverseSymmetric requires a non-empty square A.");
   }
   vnl_matrix<TReal> inv(n, n);
   detail::InverseSymmetricLDLTEigen<TReal>(A.data_block(), n, inv.data_block());
@@ -269,6 +269,6 @@ InverseSymmetric(const vnl_matrix<TReal> & A)
 }
 
 } // namespace Math
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkMathLDLT_h
+#endif // itkBridgeMathLDLT_h

--- a/Modules/Core/Common/include/itkBridgeMathSVD.h
+++ b/Modules/Core/Common/include/itkBridgeMathSVD.h
@@ -15,11 +15,11 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkMathSVD_h
-#define itkMathSVD_h
+#ifndef itkBridgeMathSVD_h
+#define itkBridgeMathSVD_h
 
 #include "itkMacro.h"
-#include "itkEigenDecompositionSignConvention.h"
+#include "itkBridgeEigenDecompositionSignConvention.h"
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_matrix_fixed.h"
 #include "vnl/vnl_vector.h"
@@ -33,12 +33,15 @@
 
 namespace itk
 {
-// Forward-declared to break the itkMatrix.h <-> itkMathSVD.h include cycle; the
-// itk::Matrix SVD overload needs the complete type only at instantiation, where
-// the caller has already included itkMatrix.h.
+// Forward-declared to break the itkMatrix.h <-> itkBridgeMathSVD.h include
+// cycle; the itk::Matrix SVD overload needs the complete type only at
+// instantiation, where the caller has already included itkMatrix.h.
 template <typename T, unsigned int VRows, unsigned int VColumns>
 class Matrix;
+} // namespace itk
 
+namespace itk::bridge
+{
 namespace Math
 {
 
@@ -410,7 +413,7 @@ DynamicSquareSVDEigen(const TReal * inData, unsigned int n, TReal * uData, TReal
   const auto extract = [&](const auto & svd) {
     if (svd.info() != Eigen::Success)
     {
-      itkGenericExceptionMacro("itk::Math::SVD failed; input is likely non-finite (NaN/Inf).");
+      itkGenericExceptionMacro("itk::bridge::Math::SVD failed; input is likely non-finite (NaN/Inf).");
     }
     uMap = svd.matrixU();
     vMap = svd.matrixV();
@@ -453,7 +456,7 @@ SquareSVDEigen(const TReal * inData, TReal * uData, TReal * wData, TReal * vData
     const Eigen::JacobiSVD<ColMajor, options> svd(inMap);
     if (svd.info() != Eigen::Success)
     {
-      itkGenericExceptionMacro("itk::Math::SVD failed; input is likely non-finite (NaN/Inf).");
+      itkGenericExceptionMacro("itk::bridge::Math::SVD failed; input is likely non-finite (NaN/Inf).");
     }
 
     Eigen::Map<RowMajor> uMap(uData);
@@ -488,7 +491,7 @@ RectangularSVDEigen(const TReal * inData,
   const Eigen::BDCSVD<ColMajor, thin> svd(inMap);
   if (svd.info() != Eigen::Success)
   {
-    itkGenericExceptionMacro("itk::Math::SVD failed; input is likely non-finite (NaN/Inf).");
+    itkGenericExceptionMacro("itk::bridge::Math::SVD failed; input is likely non-finite (NaN/Inf).");
   }
   Eigen::Map<RowMajor> uMap(uData, rows, k);
   Eigen::Map<RowMajor> vMap(vData, cols, k);
@@ -504,7 +507,7 @@ RectangularSVDEigen(const TReal * inData,
 // The Eigen JacobiSVD/BDCSVD instantiations behind the detail engines dominate
 // compile memory: without pre-instantiation, GCC needs ~2 GB per translation unit
 // that inverts an itk::Matrix. Declare the common specializations extern and define
-// them once in itkMathSVD.cxx so consumers link instead of re-instantiating them.
+// them once in itkBridgeMathSVD.cxx so consumers link instead of re-instantiating them.
 #if defined(ITKCommon_EXPORTS)
 #  define ITKCommon_EXPORT_EXPLICIT ITK_TEMPLATE_EXPORT
 #else
@@ -577,7 +580,7 @@ SVD(const vnl_matrix_fixed<TReal, VDim, VDim> & A, bool canonicalizeSigns = true
   detail::SquareSVDEigen<VDim>(A.data_block(), result.U.data_block(), result.W.data_block(), result.V.data_block());
   if (canonicalizeSigns)
   {
-    itk::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
+    itk::bridge::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
   }
   return result;
 }
@@ -602,7 +605,7 @@ SVD(const vnl_matrix_fixed<TReal, VRows, VCols> & A, bool canonicalizeSigns = tr
     A.data_block(), VRows, VCols, result.U.data_block(), result.W.data_block(), result.V.data_block());
   if (canonicalizeSigns)
   {
-    itk::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
+    itk::bridge::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
   }
   return result;
 }
@@ -626,7 +629,7 @@ SVD(const vnl_matrix<TReal> & A, bool canonicalizeSigns = true)
   const unsigned int cols = A.cols();
   if (rows == 0 || cols == 0)
   {
-    itkGenericExceptionMacro("itk::Math::SVD requires a non-empty matrix.");
+    itkGenericExceptionMacro("itk::bridge::Math::SVD requires a non-empty matrix.");
   }
   const unsigned int k = (rows < cols) ? rows : cols;
   SVDResult<TReal>   result;
@@ -645,12 +648,12 @@ SVD(const vnl_matrix<TReal> & A, bool canonicalizeSigns = true)
   }
   if (canonicalizeSigns)
   {
-    itk::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
+    itk::bridge::detail::CanonicalizeColumnSignsPaired(result.U, result.V);
   }
   return result;
 }
 
 } // namespace Math
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkMathSVD_h
+#endif // itkBridgeMathSVD_h

--- a/Modules/Core/Common/include/itkBridgeQRDecomposition.h
+++ b/Modules/Core/Common/include/itkBridgeQRDecomposition.h
@@ -15,8 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkQRDecomposition_h
-#define itkQRDecomposition_h
+#ifndef itkBridgeQRDecomposition_h
+#define itkBridgeQRDecomposition_h
 
 #include "itkMacro.h"
 #include "vnl/vnl_matrix.h"
@@ -24,7 +24,7 @@
 #include "itk_eigen.h"
 #include ITK_EIGEN(Dense)
 
-namespace itk
+namespace itk::bridge
 {
 
 /** \class QRDecomposition
@@ -165,6 +165,6 @@ private:
   bool       m_Square{ false };
 };
 
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkQRDecomposition_h
+#endif // itkBridgeQRDecomposition_h

--- a/Modules/Core/Common/include/itkBridgeRealEigenDecomposition.h
+++ b/Modules/Core/Common/include/itkBridgeRealEigenDecomposition.h
@@ -15,18 +15,18 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkRealEigenDecomposition_h
-#define itkRealEigenDecomposition_h
+#ifndef itkBridgeRealEigenDecomposition_h
+#define itkBridgeRealEigenDecomposition_h
 
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector.h"
 #include <complex>
-#include "itkEigenDecompositionSolverInfo.h"
+#include "itkBridgeEigenDecompositionSolverInfo.h"
 #include "itkMacro.h"
 #include "itk_eigen.h"
 #include ITK_EIGEN(Dense)
 
-namespace itk
+namespace itk::bridge
 {
 
 /** \class RealEigenDecomposition
@@ -98,6 +98,6 @@ private:
   ComplexMatrixType m_Eigenvectors;
 };
 
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkRealEigenDecomposition_h
+#endif // itkBridgeRealEigenDecomposition_h

--- a/Modules/Core/Common/include/itkBridgeSymmetricEigenDecomposition.h
+++ b/Modules/Core/Common/include/itkBridgeSymmetricEigenDecomposition.h
@@ -15,19 +15,19 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkSymmetricEigenDecomposition_h
-#define itkSymmetricEigenDecomposition_h
+#ifndef itkBridgeSymmetricEigenDecomposition_h
+#define itkBridgeSymmetricEigenDecomposition_h
 
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector.h"
 #include "vnl/vnl_diag_matrix.h"
-#include "itkEigenDecompositionSignConvention.h"
-#include "itkEigenDecompositionSolverInfo.h"
+#include "itkBridgeEigenDecompositionSignConvention.h"
+#include "itkBridgeEigenDecompositionSolverInfo.h"
 #include "itkMacro.h"
 #include "itk_eigen.h"
 #include ITK_EIGEN(Dense)
 
-namespace itk
+namespace itk::bridge
 {
 
 /** \class SymmetricEigenDecomposition
@@ -125,6 +125,6 @@ public:
   }
 };
 
-} // namespace itk
+} // namespace itk::bridge
 
-#endif // itkSymmetricEigenDecomposition_h
+#endif // itkBridgeSymmetricEigenDecomposition_h

--- a/Modules/Core/Common/include/itkExtractImageFilter.hxx
+++ b/Modules/Core/Common/include/itkExtractImageFilter.hxx
@@ -19,7 +19,7 @@
 #define itkExtractImageFilter_hxx
 
 #include "itkImageAlgorithm.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 #include "itkObjectFactory.h"
 #include "itkProgressReporter.h"
 
@@ -194,7 +194,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       break;
       case DirectionCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
       {
-        if (Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
+        if (bridge::Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
         {
           itkExceptionStringMacro("Invalid submatrix extracted for collapsed direction.");
         }
@@ -202,7 +202,7 @@ ExtractImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
       break;
       case DirectionCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
       {
-        if (Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
+        if (bridge::Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
         {
           outputDirection.SetIdentity();
         }

--- a/Modules/Core/Common/include/itkHexahedronCell.hxx
+++ b/Modules/Core/Common/include/itkHexahedronCell.hxx
@@ -19,7 +19,7 @@
 #define itkHexahedronCell_hxx
 #include "itkMath.h"
 #include "vnl/vnl_matrix_fixed.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 #include <algorithm> // For copy_n.
 
@@ -398,7 +398,7 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     }
 
     // ONLY 3x3 determinants are supported.
-    const double d = Math::Determinant(mat);
+    const double d = bridge::Math::Determinant(mat);
     // spell-check-disable
     // d=vtkMath::Determinant3x3(rcol,scol,tcol);
     // spell-check-enable
@@ -431,9 +431,9 @@ HexahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
       mat3.put(2, i, fcol[i]);
     }
     double params[Self::CellDimension3D]{ 0.5, 0.5, 0.5 };
-    pcoords[0] = params[0] - Math::Determinant(mat1) / d;
-    pcoords[1] = params[1] - Math::Determinant(mat2) / d;
-    pcoords[2] = params[2] - Math::Determinant(mat3) / d;
+    pcoords[0] = params[0] - bridge::Math::Determinant(mat1) / d;
+    pcoords[1] = params[1] - bridge::Math::Determinant(mat2) / d;
+    pcoords[2] = params[2] - bridge::Math::Determinant(mat3) / d;
 
     if (pcoord)
     {

--- a/Modules/Core/Common/include/itkImageBase.hxx
+++ b/Modules/Core/Common/include/itkImageBase.hxx
@@ -34,7 +34,7 @@
 #include "itkSpatialOrientation.h"
 #include <cstring>
 #include "itkMath.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 namespace itk
 {
@@ -134,7 +134,7 @@ ImageBase<VImageDimension>::SetDirection(const DirectionType & direction)
 {
   bool modified = false;
 
-  if (Math::Determinant(direction.GetVnlMatrix()) == 0.0)
+  if (bridge::Math::Determinant(direction.GetVnlMatrix()) == 0.0)
   {
     itkExceptionMacro("Bad direction, determinant is 0. Refusing to change direction from " << this->m_Direction
                                                                                             << " to " << direction);

--- a/Modules/Core/Common/include/itkMatrix.h
+++ b/Modules/Core/Common/include/itkMatrix.h
@@ -24,10 +24,10 @@
 #include <vxl_version.h>
 #include "vnl/vnl_matrix_fixed.hxx" // Get the templates
 #include "vnl/vnl_transpose.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "vnl/vnl_matrix.h"
 
-// GetInverse is Eigen-backed via itk::Math::SVD, but ITK 5.4 exposed
+// GetInverse is Eigen-backed via itk::bridge::Math::SVD, but ITK 5.4 exposed
 // vnl_matrix_inverse (and through it vnl_svd / vnl_diag_matrix) transitively to
 // every itkMatrix.h consumer. Retain that surface for release-5.4 source
 // compatibility in default builds; ITK proper includes what it uses, so
@@ -38,8 +38,8 @@
 #  include "vnl/algo/vnl_matrix_inverse.h"
 #  undef ITK_VNL_SVD_TRANSITIONAL_INCLUDE
 #endif
-#include "itkMathDeterminant.h"
-// GetInverse's singular check is Eigen-backed via itk::Math::Determinant, but
+#include "itkBridgeMathDeterminant.h"
+// GetInverse's singular check is Eigen-backed via itk::bridge::Math::Determinant, but
 // ITK 5.4 exposed vnl_determinant transitively through this header; keep it
 // reachable during the deprecation window so downstream code still compiles.
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
@@ -329,11 +329,11 @@ public:
   [[nodiscard]] inline vnl_matrix_fixed<T, VColumns, VRows>
   GetInverse() const
   {
-    if (Math::Determinant(m_Matrix) == T{})
+    if (bridge::Math::Determinant(m_Matrix) == T{})
     {
       itkGenericExceptionMacro("Singular matrix. Determinant is 0.");
     }
-    return vnl_matrix_fixed<T, VColumns, VRows>{ Math::SVD(m_Matrix.as_ref()).PseudoInverse() };
+    return vnl_matrix_fixed<T, VColumns, VRows>{ bridge::Math::SVD(m_Matrix.as_ref()).PseudoInverse() };
   }
 
   /** Return the transposed matrix. */

--- a/Modules/Core/Common/include/itkQuadrilateralCell.hxx
+++ b/Modules/Core/Common/include/itkQuadrilateralCell.hxx
@@ -18,7 +18,7 @@
 #ifndef itkQuadrilateralCell_hxx
 #define itkQuadrilateralCell_hxx
 #include "itkMath.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 #include <algorithm> // For copy_n.
 
@@ -333,7 +333,7 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
       mat.put(1, i, scol[i]);
     }
 
-    const double d = Math::Determinant(mat);
+    const double d = bridge::Math::Determinant(mat);
     // spell-check-disable
     // d=vtkMath::Determinant2x2(rcol,scol);
     // spell-check-enable
@@ -356,8 +356,8 @@ QuadrilateralCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
       mat2.put(1, i, fcol[i]);
     }
 
-    pcoords[0] = params[0] - Math::Determinant(mat1) / d;
-    pcoords[1] = params[1] - Math::Determinant(mat2) / d;
+    pcoords[0] = params[0] - bridge::Math::Determinant(mat1) / d;
+    pcoords[1] = params[1] - bridge::Math::Determinant(mat2) / d;
 
     if (pcoord)
     {

--- a/Modules/Core/Common/include/itkTetrahedronCell.hxx
+++ b/Modules/Core/Common/include/itkTetrahedronCell.hxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 #ifndef itkTetrahedronCell_hxx
 #define itkTetrahedronCell_hxx
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 #include <algorithm> // For copy_n.
 
@@ -106,7 +106,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     mat.put(1, i, c2[i]);
     mat.put(2, i, c3[i]);
   }
-  const double det = Math::Determinant(mat);
+  const double det = bridge::Math::Determinant(mat);
   if (det == 0.0)
   {
     return false;
@@ -119,7 +119,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     mat.put(2, i, c3[i]);
   }
 
-  pcoords[0] = Math::Determinant(mat) / det;
+  pcoords[0] = bridge::Math::Determinant(mat) / det;
 
   for (unsigned int i = 0; i < PointDimension; ++i)
   {
@@ -128,7 +128,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     mat.put(2, i, c3[i]);
   }
 
-  pcoords[1] = Math::Determinant(mat) / det;
+  pcoords[1] = bridge::Math::Determinant(mat) / det;
 
   for (unsigned int i = 0; i < PointDimension; ++i)
   {
@@ -137,7 +137,7 @@ TetrahedronCell<TCellInterface>::EvaluatePosition(CoordinateType *          x,
     mat.put(2, i, rhs[i]);
   }
 
-  pcoords[2] = Math::Determinant(mat) / det;
+  pcoords[2] = bridge::Math::Determinant(mat) / det;
 
   const double p4 = 1.0 - pcoords[0] - pcoords[1] - pcoords[2];
 

--- a/Modules/Core/Common/include/itkVariableSizeMatrix.h
+++ b/Modules/Core/Common/include/itkVariableSizeMatrix.h
@@ -21,7 +21,7 @@
 #include "itkPoint.h"
 #include "itkCovariantVector.h"
 #include "vnl/vnl_matrix_fixed.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
 #endif
@@ -212,7 +212,7 @@ public:
   [[nodiscard]] inline vnl_matrix<T>
   GetInverse() const
   {
-    return itk::Math::SVD(m_Matrix).PseudoInverse();
+    return itk::bridge::Math::SVD(m_Matrix).PseudoInverse();
   }
 
   /** Return the transposed matrix. */

--- a/Modules/Core/Common/include/itkVersor.hxx
+++ b/Modules/Core/Common/include/itkVersor.hxx
@@ -20,7 +20,7 @@
 
 #include "itkNumericTraits.h"
 #include "itkMath.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 namespace itk
 {
@@ -327,12 +327,13 @@ Versor<T>::Set(const MatrixType & mat)
       itk::Math::Absolute(I[2][0]) > epsilon || itk::Math::Absolute(I[2][1]) > epsilon ||
       itk::Math::Absolute(I[0][0] - itk::NumericTraits<T>::OneValue()) > epsilonDiff ||
       itk::Math::Absolute(I[1][1] - itk::NumericTraits<T>::OneValue()) > epsilonDiff ||
-      itk::Math::Absolute(I[2][2] - itk::NumericTraits<T>::OneValue()) > epsilonDiff || Math::Determinant(I) < 0)
+      itk::Math::Absolute(I[2][2] - itk::NumericTraits<T>::OneValue()) > epsilonDiff ||
+      bridge::Math::Determinant(I) < 0)
   {
     itkGenericExceptionMacro("The following matrix does not represent rotation to within an epsion of "
                              << epsilon << '.' << std::endl
                              << m << std::endl
-                             << "det(m * m transpose) is: " << Math::Determinant(I) << std::endl
+                             << "det(m * m transpose) is: " << bridge::Math::Determinant(I) << std::endl
                              << "m * m transpose is:" << std::endl
                              << I);
   }

--- a/Modules/Core/Common/src/CMakeLists.txt
+++ b/Modules/Core/Common/src/CMakeLists.txt
@@ -95,7 +95,7 @@ set(
   itkLoggerOutput.cxx
   itkLoggerThreadWrapper.cxx
   itkLogOutput.cxx
-  itkMathSVD.cxx
+  itkBridgeMathSVD.cxx
   itkMemoryProbe.cxx
   itkMemoryProbesCollectorBase.cxx
   itkMemoryUsageObserver.cxx

--- a/Modules/Core/Common/src/itkBridgeMathSVD.cxx
+++ b/Modules/Core/Common/src/itkBridgeMathSVD.cxx
@@ -15,12 +15,12 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 
-// Define once here the Eigen JacobiSVD/BDCSVD specializations that itkMathSVD.h
+// Define once here the Eigen JacobiSVD/BDCSVD specializations that itkBridgeMathSVD.h
 // declares extern, so consumer translation units link instead of paying the
 // per-TU Eigen instantiation cost.
-namespace itk
+namespace itk::bridge
 {
 namespace Math
 {
@@ -47,4 +47,4 @@ RectangularSVDEigen<double>(const double *, unsigned int, unsigned int, double *
 ITK_GCC_PRAGMA_DIAG_POP()
 } // namespace detail
 } // namespace Math
-} // namespace itk
+} // namespace itk::bridge

--- a/Modules/Core/Common/test/CMakeLists.txt
+++ b/Modules/Core/Common/test/CMakeLists.txt
@@ -1429,7 +1429,7 @@ set(
   itkBSplineKernelFunctionGTest.cxx
   itkBuildInformationGTest.cxx
   itkByteSwapGTest.cxx
-  itkCholeskySolveGTest.cxx
+  itkBridgeCholeskySolveGTest.cxx
   itkCommandObserverObjectGTest.cxx
   itkCommonTypeTraitsGTest.cxx
   itkCompensatedSummationGTest.cxx
@@ -1484,11 +1484,11 @@ set(
   itkMathGTest.cxx
   itkMathRoundGTest.cxx
   itkMathVnlParityGTest.cxx
-  itkMathSVDGTest.cxx
-  itkMathLDLTGTest.cxx
+  itkBridgeMathSVDGTest.cxx
+  itkBridgeMathLDLTGTest.cxx
   itkVnlCholeskyEngineGTest.cxx
   itkVnlMatlabReadGTest.cxx
-  itkMathDeterminantGTest.cxx
+  itkBridgeMathDeterminantGTest.cxx
   itkVnlSVDEngineGTest.cxx
   itkMatrixExponentialGTest.cxx
   itkMatrixGTest.cxx
@@ -1508,10 +1508,10 @@ set(
   itkPointSetGTest.cxx
   itkPrintHelperGTest.cxx
   itkPriorityQueueGTest.cxx
-  itkGeneralizedEigenDecompositionGTest.cxx
-  itkQRDecompositionGTest.cxx
-  itkRealEigenDecompositionGTest.cxx
-  itkSymmetricEigenDecompositionGTest.cxx
+  itkBridgeGeneralizedEigenDecompositionGTest.cxx
+  itkBridgeQRDecompositionGTest.cxx
+  itkBridgeRealEigenDecompositionGTest.cxx
+  itkBridgeSymmetricEigenDecompositionGTest.cxx
   itkRealTimeClockGTest.cxx
   itkRealTimeIntervalGTest.cxx
   itkRealTimeStampGTest.cxx

--- a/Modules/Core/Common/test/itkBridgeCholeskySolveGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeCholeskySolveGTest.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 // First include the header file to be tested:
-#include "itkCholeskySolve.h"
+#include "itkBridgeCholeskySolve.h"
 
 // Exercise the deprecated VNL engine for the old-vs-new equivalence checks.
 // The VNL symbol is unavailable under ITK_FUTURE_LEGACY_REMOVE.
@@ -55,7 +55,7 @@ MakeSPD(unsigned int n)
 
 
 // A x = b is recovered: residual ||A x - b|| is tiny.
-TEST(CholeskySolve, SolveResidual)
+TEST(BridgeCholeskySolve, SolveResidual)
 {
   const unsigned int       n = 5;
   const vnl_matrix<double> A = MakeSPD<double>(n);
@@ -65,18 +65,18 @@ TEST(CholeskySolve, SolveResidual)
     b[i] = static_cast<double>(i) - 1.5;
   }
 
-  const vnl_vector<double> x = itk::Math::SolveSymmetricPositiveDefinite(A, b);
+  const vnl_vector<double> x = itk::bridge::Math::SolveSymmetricPositiveDefinite(A, b);
   const vnl_vector<double> residual = A * x - b;
   EXPECT_LT(residual.two_norm() / b.two_norm(), 1e-12);
 }
 
 
 // CholeskyLowerTriangle returns L with A == L L'.
-TEST(CholeskySolve, LowerTriangleReconstructsMatrix)
+TEST(BridgeCholeskySolve, LowerTriangleReconstructsMatrix)
 {
   const unsigned int       n = 4;
   const vnl_matrix<double> A = MakeSPD<double>(n);
-  const vnl_matrix<double> L = itk::Math::CholeskyLowerTriangle(A);
+  const vnl_matrix<double> L = itk::bridge::Math::CholeskyLowerTriangle(A);
 
   // L is lower triangular.
   for (unsigned int i = 0; i < n; ++i)
@@ -94,7 +94,7 @@ TEST(CholeskySolve, LowerTriangleReconstructsMatrix)
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 // The Eigen-backed itk:: solve agrees with the native vnl_cholesky engine.
-TEST(CholeskySolve, EquivalentToVnlCholesky)
+TEST(BridgeCholeskySolve, EquivalentToVnlCholesky)
 {
   const unsigned int       n = 6;
   const vnl_matrix<double> A = MakeSPD<double>(n);
@@ -104,7 +104,7 @@ TEST(CholeskySolve, EquivalentToVnlCholesky)
     b[i] = std::cos(0.5 * (i + 1));
   }
 
-  const vnl_vector<double> xItk = itk::Math::SolveSymmetricPositiveDefinite(A, b);
+  const vnl_vector<double> xItk = itk::bridge::Math::SolveSymmetricPositiveDefinite(A, b);
 
   const vnl_cholesky       chol(A, vnl_cholesky::quiet);
   const vnl_vector<double> xVnl = chol.solve(b);
@@ -115,7 +115,7 @@ TEST(CholeskySolve, EquivalentToVnlCholesky)
 
 
 // Single-precision path solves correctly.
-TEST(CholeskySolve, FloatResidual)
+TEST(BridgeCholeskySolve, FloatResidual)
 {
   const unsigned int      n = 4;
   const vnl_matrix<float> A = MakeSPD<float>(n);
@@ -125,19 +125,19 @@ TEST(CholeskySolve, FloatResidual)
     b[i] = static_cast<float>(i) + 0.25f;
   }
 
-  const vnl_vector<float> x = itk::Math::SolveSymmetricPositiveDefinite(A, b);
+  const vnl_vector<float> x = itk::bridge::Math::SolveSymmetricPositiveDefinite(A, b);
   const vnl_vector<float> residual = A * x - b;
   EXPECT_LT(residual.two_norm() / b.two_norm(), 1e-4f);
 }
 
 
 // CholeskyLowerTriangle rejects a non-positive-definite matrix instead of returning a garbage factor.
-TEST(CholeskySolve, LowerTriangleRejectsNonPositiveDefinite)
+TEST(BridgeCholeskySolve, LowerTriangleRejectsNonPositiveDefinite)
 {
   vnl_matrix<double> A(2, 2);
   A(0, 0) = 1.0;
   A(0, 1) = 2.0;
   A(1, 0) = 2.0;
   A(1, 1) = 1.0; // symmetric but indefinite (eigenvalues 3, -1)
-  EXPECT_THROW(itk::Math::CholeskyLowerTriangle(A), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::CholeskyLowerTriangle(A), itk::ExceptionObject);
 }

--- a/Modules/Core/Common/test/itkBridgeGeneralizedEigenDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeGeneralizedEigenDecompositionGTest.cxx
@@ -15,7 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "itkGeneralizedEigenDecomposition.h"
+#include "itkBridgeGeneralizedEigenDecomposition.h"
 #include "itkConfigure.h"
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 #  define ITK_LEGACY_TEST
@@ -31,9 +31,9 @@ namespace
 // Frobenius residual of the generalized identity A V == B V D.
 template <typename TReal>
 TReal
-GeneralizedResidual(const vnl_matrix<TReal> &                         A,
-                    const vnl_matrix<TReal> &                         B,
-                    const itk::GeneralizedEigenDecomposition<TReal> & ge)
+GeneralizedResidual(const vnl_matrix<TReal> &                                 A,
+                    const vnl_matrix<TReal> &                                 B,
+                    const itk::bridge::GeneralizedEigenDecomposition<TReal> & ge)
 {
   const vnl_matrix<TReal> & V = ge.GetEigenvectors();
   vnl_matrix<TReal>         D(V.rows(), V.cols(), TReal{ 0 });
@@ -49,7 +49,7 @@ GeneralizedResidual(const vnl_matrix<TReal> &                         A,
 // Scavenged from VXL test_generalized_eigensystem: A x = lambda B x with A
 // symmetric, B symmetric positive-definite. (Roles match the vnl ctor's
 // (A, B) order; the VXL test's residual is C V - S V D for gev(C, S).)
-TEST(GeneralizedEigenDecomposition, SymmetricDefinitePencil)
+TEST(BridgeGeneralizedEigenDecomposition, SymmetricDefinitePencil)
 {
   const double Adata[36] = {
     30.0000, -3.4273, 13.9254, 13.7049, -2.4446, 20.2380, -3.4273, 13.7049, -2.4446, 1.3659,  3.6702,  -0.2282,
@@ -67,7 +67,7 @@ TEST(GeneralizedEigenDecomposition, SymmetricDefinitePencil)
   B(0, 1) = B(1, 0) = 1.0;
   B(2, 3) = B(3, 2) = -2.0;
 
-  const itk::GeneralizedEigenDecomposition<double> ge(A, B);
+  const itk::bridge::GeneralizedEigenDecomposition<double> ge(A, B);
 
   // Eigenvalues are real and ascending.
   for (unsigned int i = 1; i < 6; ++i)
@@ -79,7 +79,7 @@ TEST(GeneralizedEigenDecomposition, SymmetricDefinitePencil)
 
 // B = I reduces to the ordinary symmetric eigenproblem; this mirrors how
 // ImagePCAShapeModelEstimator invokes the solver.
-TEST(GeneralizedEigenDecomposition, IdentityPencilMatchesStandard)
+TEST(BridgeGeneralizedEigenDecomposition, IdentityPencilMatchesStandard)
 {
   vnl_matrix<double> A(3, 3, 0.0);
   A(0, 0) = 2.0;
@@ -94,7 +94,7 @@ TEST(GeneralizedEigenDecomposition, IdentityPencilMatchesStandard)
     I(i, i) = 1.0;
   }
 
-  const itk::GeneralizedEigenDecomposition<double> ge(A, I);
+  const itk::bridge::GeneralizedEigenDecomposition<double> ge(A, I);
   EXPECT_LT(GeneralizedResidual(A, I, ge), 1e-12);
 
   // For B = I the eigenvectors are orthonormal: V^T V == I.
@@ -108,7 +108,7 @@ TEST(GeneralizedEigenDecomposition, IdentityPencilMatchesStandard)
   }
 }
 
-TEST(GeneralizedEigenDecomposition, FloatInstantiation)
+TEST(BridgeGeneralizedEigenDecomposition, FloatInstantiation)
 {
   vnl_matrix<float> A(2, 2);
   A(0, 0) = 3.0f;
@@ -118,14 +118,14 @@ TEST(GeneralizedEigenDecomposition, FloatInstantiation)
   B(0, 0) = 2.0f;
   B(1, 1) = 4.0f;
 
-  const itk::GeneralizedEigenDecomposition<float> ge(A, B);
+  const itk::bridge::GeneralizedEigenDecomposition<float> ge(A, B);
   EXPECT_LT(GeneralizedResidual(A, B, ge), 1e-5f);
 }
 
 // Non-finite input leaves the Eigen solver in a non-Success state; the wrapper
 // turns that into an exception so callers do not silently consume a garbage
 // decomposition.
-TEST(GeneralizedEigenDecomposition, NonFiniteInputThrows)
+TEST(BridgeGeneralizedEigenDecomposition, NonFiniteInputThrows)
 {
   const double       nan = std::numeric_limits<double>::quiet_NaN();
   vnl_matrix<double> A(2, 2, 0.0);
@@ -137,7 +137,7 @@ TEST(GeneralizedEigenDecomposition, NonFiniteInputThrows)
   B(0, 1) = B(1, 0) = nan;
   try
   {
-    const itk::GeneralizedEigenDecomposition<double> ge(A, B);
+    const itk::bridge::GeneralizedEigenDecomposition<double> ge(A, B);
     FAIL() << "expected an exception for non-finite input";
   }
   catch (const itk::ExceptionObject & e)
@@ -155,7 +155,7 @@ TEST(GeneralizedEigenDecomposition, NonFiniteInputThrows)
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 // Equivalence: the Eigen-backed solver reproduces the eigenvalues of the
 // deprecated netlib vnl_generalized_eigensystem it replaces (both ascending).
-TEST(GeneralizedEigenDecomposition, MatchesDeprecatedVnlEngine)
+TEST(BridgeGeneralizedEigenDecomposition, MatchesDeprecatedVnlEngine)
 {
   vnl_matrix<double> A(3, 3, 0.0);
   A(0, 0) = 2.0;
@@ -169,8 +169,8 @@ TEST(GeneralizedEigenDecomposition, MatchesDeprecatedVnlEngine)
   B(2, 2) = 4.0;
   B(0, 1) = B(1, 0) = 0.5;
 
-  const vnl_generalized_eigensystem                vnlEngine(A, B);
-  const itk::GeneralizedEigenDecomposition<double> itkEngine(A, B);
+  const vnl_generalized_eigensystem                        vnlEngine(A, B);
+  const itk::bridge::GeneralizedEigenDecomposition<double> itkEngine(A, B);
 
   const vnl_vector<double>   vnlEigenvalues = vnlEngine.D.get_diagonal();
   const vnl_vector<double> & itkEigenvalues = itkEngine.GetEigenvalues();

--- a/Modules/Core/Common/test/itkBridgeMathDeterminantGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeMathDeterminantGTest.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 // First include the header file to be tested:
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 #include "itkMatrix.h"
 
@@ -52,41 +52,41 @@ FillMatrix(const double src[VDim][VDim])
 } // namespace
 
 // Closed-form 2x2 reference: ad - bc.
-TEST(MathDeterminant, TwoByTwoAnalytic)
+TEST(BridgeMathDeterminant, TwoByTwoAnalytic)
 {
   const auto   A = FillMatrix<double, 2>(kM2);
   const double expected = kM2[0][0] * kM2[1][1] - kM2[0][1] * kM2[1][0];
-  EXPECT_NEAR(itk::Math::Determinant(A), expected, 1e-14);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(A), expected, 1e-14);
 }
 
 // Closed-form 3x3 reference: cofactor expansion along the first row.
-TEST(MathDeterminant, ThreeByThreeAnalytic)
+TEST(BridgeMathDeterminant, ThreeByThreeAnalytic)
 {
   const auto   A = FillMatrix<double, 3>(kM3);
   const double expected = kM3[0][0] * (kM3[1][1] * kM3[2][2] - kM3[1][2] * kM3[2][1]) -
                           kM3[0][1] * (kM3[1][0] * kM3[2][2] - kM3[1][2] * kM3[2][0]) +
                           kM3[0][2] * (kM3[1][0] * kM3[2][1] - kM3[1][1] * kM3[2][0]);
-  EXPECT_NEAR(itk::Math::Determinant(A), expected, 1e-14);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(A), expected, 1e-14);
 }
 
 // The three overloads (itk::Matrix, vnl_matrix_fixed, vnl_matrix) return the
 // same value for the same data.
-TEST(MathDeterminant, OverloadConsistency)
+TEST(BridgeMathDeterminant, OverloadConsistency)
 {
   const auto                           A = FillMatrix<double, 3>(kM3);
   const vnl_matrix_fixed<double, 3, 3> fixedA = A.GetVnlMatrix();
   const vnl_matrix<double>             dynA = fixedA.as_matrix();
 
-  const double d = itk::Math::Determinant(A);
-  EXPECT_DOUBLE_EQ(itk::Math::Determinant(fixedA), d);
-  EXPECT_NEAR(itk::Math::Determinant(dynA), d, 1e-14);
+  const double d = itk::bridge::Math::Determinant(A);
+  EXPECT_DOUBLE_EQ(itk::bridge::Math::Determinant(fixedA), d);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(dynA), d, 1e-14);
 }
 
 // Identity has unit determinant; a diagonal matrix yields the product of its
 // diagonal; both stress the direct fixed-size path.
-TEST(MathDeterminant, IdentityAndDiagonal)
+TEST(BridgeMathDeterminant, IdentityAndDiagonal)
 {
-  EXPECT_DOUBLE_EQ(itk::Math::Determinant(itk::Matrix<double, 4, 4>::GetIdentity()), 1.0);
+  EXPECT_DOUBLE_EQ(itk::bridge::Math::Determinant(itk::Matrix<double, 4, 4>::GetIdentity()), 1.0);
 
   itk::Matrix<double, 4, 4> D;
   D.SetIdentity();
@@ -94,11 +94,11 @@ TEST(MathDeterminant, IdentityAndDiagonal)
   D(1, 1) = -3.0;
   D(2, 2) = 0.5;
   D(3, 3) = 4.0;
-  EXPECT_DOUBLE_EQ(itk::Math::Determinant(D), 2.0 * -3.0 * 0.5 * 4.0);
+  EXPECT_DOUBLE_EQ(itk::bridge::Math::Determinant(D), 2.0 * -3.0 * 0.5 * 4.0);
 }
 
 // A rank-deficient matrix (two identical rows) has a zero determinant.
-TEST(MathDeterminant, SingularIsZero)
+TEST(BridgeMathDeterminant, SingularIsZero)
 {
   itk::Matrix<double, 3, 3> A;
   A(0, 0) = 1.0;
@@ -110,12 +110,12 @@ TEST(MathDeterminant, SingularIsZero)
   A(2, 0) = 4.0;
   A(2, 1) = 5.0;
   A(2, 2) = 6.0;
-  EXPECT_NEAR(itk::Math::Determinant(A), 0.0, 1e-14);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(A), 0.0, 1e-14);
 }
 
 // Upper-triangular determinant is the product of the diagonal; exercises the
 // runtime PartialPivLU path at a size beyond the direct formulas.
-TEST(MathDeterminant, LargeTriangular)
+TEST(BridgeMathDeterminant, LargeTriangular)
 {
   constexpr unsigned int N = 6;
   vnl_matrix<double>     A(N, N, 0.0);
@@ -129,44 +129,44 @@ TEST(MathDeterminant, LargeTriangular)
       A(i, j) = 0.3 * (i + 1) + 0.7 * j; // upper triangle does not affect det
     }
   }
-  EXPECT_NEAR(itk::Math::Determinant(A), expected, 1e-10 * std::abs(expected));
+  EXPECT_NEAR(itk::bridge::Math::Determinant(A), expected, 1e-10 * std::abs(expected));
 }
 
 // det(cA) = c^n det(A) for an n x n matrix.
-TEST(MathDeterminant, ScalingLaw)
+TEST(BridgeMathDeterminant, ScalingLaw)
 {
   const auto                A = FillMatrix<double, 3>(kM3);
-  const double              base = itk::Math::Determinant(A);
+  const double              base = itk::bridge::Math::Determinant(A);
   itk::Matrix<double, 3, 3> scaled = A * 2.0;
-  EXPECT_NEAR(itk::Math::Determinant(scaled), 8.0 * base, 1e-13);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(scaled), 8.0 * base, 1e-13);
 }
 
 // float instantiation computes with float precision.
-TEST(MathDeterminant, FloatType)
+TEST(BridgeMathDeterminant, FloatType)
 {
   const auto  A = FillMatrix<float, 2>(kM2);
   const float expected = static_cast<float>(kM2[0][0] * kM2[1][1] - kM2[0][1] * kM2[1][0]);
-  EXPECT_NEAR(itk::Math::Determinant(A), expected, 1e-6f);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(A), expected, 1e-6f);
 }
 
 // A non-square dynamic matrix is a usage error.
-TEST(MathDeterminant, NonSquareThrows)
+TEST(BridgeMathDeterminant, NonSquareThrows)
 {
   const vnl_matrix<double> rect(2, 3, 1.0);
-  EXPECT_THROW(itk::Math::Determinant(rect), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::Determinant(rect), itk::ExceptionObject);
 }
 
 // Equivalence with the vnl engines being supplemented, on well- and
 // ill-conditioned inputs, by relative agreement.
-TEST(MathDeterminant, MatchesVnl)
+TEST(BridgeMathDeterminant, MatchesVnl)
 {
   const auto                           A3 = FillMatrix<double, 3>(kM3);
   const vnl_matrix_fixed<double, 3, 3> f3 = A3.GetVnlMatrix();
-  EXPECT_NEAR(itk::Math::Determinant(A3), vnl_det(f3), 1e-13);
+  EXPECT_NEAR(itk::bridge::Math::Determinant(A3), vnl_det(f3), 1e-13);
 
   const vnl_matrix<double> d3 = f3.as_matrix();
   const double             ref = vnl_determinant(d3);
-  EXPECT_NEAR(itk::Math::Determinant(d3), ref, 1e-13 * std::max(1.0, std::abs(ref)));
+  EXPECT_NEAR(itk::bridge::Math::Determinant(d3), ref, 1e-13 * std::max(1.0, std::abs(ref)));
 
   // Ill-conditioned: a scaled Hilbert-like matrix.
   constexpr unsigned int N = 8;
@@ -175,5 +175,5 @@ TEST(MathDeterminant, MatchesVnl)
     for (unsigned int j = 0; j < N; ++j)
       H(i, j) = 1.0 / (i + j + 1.0);
   const double refH = vnl_determinant(H);
-  EXPECT_NEAR(itk::Math::Determinant(H), refH, 1e-9 * std::max(1.0, std::abs(refH)));
+  EXPECT_NEAR(itk::bridge::Math::Determinant(H), refH, 1e-9 * std::max(1.0, std::abs(refH)));
 }

--- a/Modules/Core/Common/test/itkBridgeMathLDLTGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeMathLDLTGTest.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 // First include the header file to be tested:
-#include "itkMathLDLT.h"
+#include "itkBridgeMathLDLT.h"
 
 // Exercise the deprecated VNL engines as cross-check oracles.
 // They are unavailable under ITK_FUTURE_LEGACY_REMOVE.
@@ -55,11 +55,11 @@ MakeSPD(unsigned int n, T shift)
 } // namespace
 
 // The capability macro must be defined by the header.
-#ifndef ITK_MATH_HAS_SOLVE_SYMMETRIC
-#  error "itkMathLDLT.h must define ITK_MATH_HAS_SOLVE_SYMMETRIC"
+#ifndef ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC
+#  error "itkBridgeMathLDLT.h must define ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC"
 #endif
 
-TEST(MathLDLT, DynamicMatchesVnlCholeskyOnSPD)
+TEST(BridgeMathLDLT, DynamicMatchesVnlCholeskyOnSPD)
 {
   for (unsigned int n : { 1u, 2u, 3u, 6u, 12u, 20u })
   {
@@ -70,7 +70,7 @@ TEST(MathLDLT, DynamicMatchesVnlCholeskyOnSPD)
       b[i] = std::cos(0.3 * i + 1.0);
     }
 
-    const itk::Array<double> x = itk::Math::SolveSymmetric(A, b);
+    const itk::Array<double> x = itk::bridge::Math::SolveSymmetric(A, b);
     ASSERT_EQ(x.size(), n);
 #ifndef ITK_FUTURE_LEGACY_REMOVE
     // Reference: itk::Array2D / itk::Array upcast to their vnl bases.
@@ -86,7 +86,7 @@ TEST(MathLDLT, DynamicMatchesVnlCholeskyOnSPD)
   }
 }
 
-TEST(MathLDLT, FixedMatchesDynamic)
+TEST(BridgeMathLDLT, FixedMatchesDynamic)
 {
   constexpr unsigned int     VDim = 4;
   const itk::Array2D<double> Ad = MakeSPD<double>(VDim, 0.3);
@@ -103,8 +103,8 @@ TEST(MathLDLT, FixedMatchesDynamic)
     bf[i] = bd[i] = std::cos(0.3 * i + 1.0);
   }
 
-  const itk::Vector<double, VDim> xf = itk::Math::SolveSymmetric(Af, bf);
-  const itk::Array<double>        xd = itk::Math::SolveSymmetric(Ad, bd);
+  const itk::Vector<double, VDim> xf = itk::bridge::Math::SolveSymmetric(Af, bf);
+  const itk::Array<double>        xd = itk::bridge::Math::SolveSymmetric(Ad, bd);
   for (unsigned int i = 0; i < VDim; ++i)
   {
     EXPECT_NEAR(xf[i], xd[i], 1e-12) << "i=" << i;
@@ -113,7 +113,7 @@ TEST(MathLDLT, FixedMatchesDynamic)
 
 // LDLT solves indefinite symmetric systems where a plain Cholesky (SPD-only)
 // would fail -- the key robustness property motivating the JLF adoption.
-TEST(MathLDLT, HandlesIndefiniteSymmetric)
+TEST(BridgeMathLDLT, HandlesIndefiniteSymmetric)
 {
   constexpr unsigned int    n = 3;
   itk::Matrix<double, n, n> A;
@@ -127,14 +127,14 @@ TEST(MathLDLT, HandlesIndefiniteSymmetric)
   b[1] = 2.0;
   b[2] = -1.0;
 
-  const itk::Vector<double, n> x = itk::Math::SolveSymmetric(A, b);
+  const itk::Vector<double, n> x = itk::bridge::Math::SolveSymmetric(A, b);
   const itk::Vector<double, n> r = A * x - b;
   EXPECT_LT(r.GetNorm(), 1e-10);
 }
 
 // The vnl convenience overload (for consumers still holding vnl types, e.g. the
 // ANTs joint-label-fusion MxBar) must agree with the ITK-typed path.
-TEST(MathLDLT, VnlConvenienceMatchesItkTyped)
+TEST(BridgeMathLDLT, VnlConvenienceMatchesItkTyped)
 {
   constexpr unsigned int     n = 8;
   const itk::Array2D<double> A = MakeSPD<double>(n, 0.5);
@@ -147,8 +147,8 @@ TEST(MathLDLT, VnlConvenienceMatchesItkTyped)
   // vnl overload: A / b upcast to their vnl bases.
   const vnl_matrix<double> & Avnl = A;
   const vnl_vector<double> & bvnl = b;
-  const vnl_vector<double>   xvnl = itk::Math::SolveSymmetric(Avnl, bvnl);
-  const itk::Array<double>   xitk = itk::Math::SolveSymmetric(A, b);
+  const vnl_vector<double>   xvnl = itk::bridge::Math::SolveSymmetric(Avnl, bvnl);
+  const itk::Array<double>   xitk = itk::bridge::Math::SolveSymmetric(A, b);
 
   ASSERT_EQ(xvnl.size(), n);
   for (unsigned int i = 0; i < n; ++i)
@@ -157,12 +157,12 @@ TEST(MathLDLT, VnlConvenienceMatchesItkTyped)
   }
 }
 
-TEST(MathLDLT, InverseSymmetricMatchesVnl)
+TEST(BridgeMathLDLT, InverseSymmetricMatchesVnl)
 {
   for (unsigned int n : { 1u, 3u, 6u, 12u })
   {
     const itk::Array2D<double> A = MakeSPD<double>(n, 0.5);
-    const itk::Array2D<double> inv = itk::Math::InverseSymmetric(A);
+    const itk::Array2D<double> inv = itk::bridge::Math::InverseSymmetric(A);
     ASSERT_EQ(inv.rows(), n);
 #ifndef ITK_FUTURE_LEGACY_REMOVE
     const vnl_matrix<double> ref = vnl_matrix_inverse<double>(A).inverse();
@@ -186,24 +186,24 @@ TEST(MathLDLT, InverseSymmetricMatchesVnl)
   }
 }
 
-TEST(MathLDLT, InverseSymmetricThrowsOnSingular)
+TEST(BridgeMathLDLT, InverseSymmetricThrowsOnSingular)
 {
   // Rank-1 symmetric matrix [[1,2],[2,4]] is exactly singular.
   itk::Array2D<double> A(2, 2);
   A(0, 0) = 1.0;
   A(0, 1) = A(1, 0) = 2.0;
   A(1, 1) = 4.0;
-  EXPECT_THROW(itk::Math::InverseSymmetric(A), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::InverseSymmetric(A), itk::ExceptionObject);
 
   const vnl_matrix<double> & Avnl = A;
-  EXPECT_THROW(itk::Math::InverseSymmetric(Avnl), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::InverseSymmetric(Avnl), itk::ExceptionObject);
 
   itk::Array2D<double> zero(3, 3);
   zero.fill(0.0);
-  EXPECT_THROW(itk::Math::InverseSymmetric(zero), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::InverseSymmetric(zero), itk::ExceptionObject);
 }
 
-TEST(MathLDLT, MatrixRhsSolveMatchesColumnwise)
+TEST(BridgeMathLDLT, MatrixRhsSolveMatchesColumnwise)
 {
   constexpr unsigned int     n = 6;
   const itk::Array2D<double> A = MakeSPD<double>(n, 0.4);
@@ -216,7 +216,7 @@ TEST(MathLDLT, MatrixRhsSolveMatchesColumnwise)
     }
   }
 
-  const itk::Array2D<double> X = itk::Math::SolveSymmetric(A, B);
+  const itk::Array2D<double> X = itk::bridge::Math::SolveSymmetric(A, B);
   // A X == B
   const vnl_matrix<double> prod = A * X;
   for (unsigned int i = 0; i < n; ++i)
@@ -228,7 +228,7 @@ TEST(MathLDLT, MatrixRhsSolveMatchesColumnwise)
   }
 }
 
-TEST(MathLDLT, FloatPrecision)
+TEST(BridgeMathLDLT, FloatPrecision)
 {
   const itk::Array2D<float> A = MakeSPD<float>(5, 0.5f);
   itk::Array<float>         b(5);
@@ -236,7 +236,7 @@ TEST(MathLDLT, FloatPrecision)
   {
     b[i] = static_cast<float>(std::cos(0.3 * i));
   }
-  const itk::Array<float> x = itk::Math::SolveSymmetric(A, b);
+  const itk::Array<float> x = itk::bridge::Math::SolveSymmetric(A, b);
   const vnl_vector<float> r = A * x - b;
   EXPECT_LT(r.inf_norm(), 1e-4f);
 }

--- a/Modules/Core/Common/test/itkBridgeMathSVDGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeMathSVDGTest.cxx
@@ -18,7 +18,7 @@
 
 // First include the header file to be tested:
 #include "itkMatrix.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 
 // This test cross-checks against the vnl_svd reference engine; mark it so it keeps
 // compiling once vnl_svd is deprecated under ITK_LEGACY_REMOVE. The oracle is
@@ -48,11 +48,11 @@ MakeFixed()
 } // namespace
 
 // A == U diag(W) V^T for fixed-size square matrices, float and double.
-TEST(MathSVD, FixedReconstructs)
+TEST(BridgeMathSVD, FixedReconstructs)
 {
   {
     const auto A = MakeFixed<double, 3>();
-    const auto r = itk::Math::SVD(A);
+    const auto r = itk::bridge::Math::SVD(A);
     double     err{};
     for (unsigned int i = 0; i < 3; ++i)
       for (unsigned int j = 0; j < 3; ++j)
@@ -66,7 +66,7 @@ TEST(MathSVD, FixedReconstructs)
   }
   {
     const auto A = MakeFixed<float, 6>();
-    const auto r = itk::Math::SVD(A);
+    const auto r = itk::bridge::Math::SVD(A);
     float      err{};
     for (unsigned int i = 0; i < 6; ++i)
       for (unsigned int j = 0; j < 6; ++j)
@@ -82,10 +82,10 @@ TEST(MathSVD, FixedReconstructs)
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 // Singular values agree with vnl_svd (the engine being supplemented).
-TEST(MathSVD, SingularValuesMatchVnl)
+TEST(BridgeMathSVD, SingularValuesMatchVnl)
 {
   const auto            A = MakeFixed<double, 6>();
-  const auto            r = itk::Math::SVD(A);
+  const auto            r = itk::bridge::Math::SVD(A);
   const vnl_svd<double> ref(A.as_matrix());
   for (unsigned int i = 0; i < 6; ++i)
     EXPECT_NEAR(r.W[i], ref.W()(i, i), 1e-12);
@@ -94,10 +94,10 @@ TEST(MathSVD, SingularValuesMatchVnl)
 
 // Default canonicalization makes the largest-magnitude element of each U column
 // positive, giving a deterministic, build-independent sign convention.
-TEST(MathSVD, SignsCanonical)
+TEST(BridgeMathSVD, SignsCanonical)
 {
   const auto A = MakeFixed<double, 4>();
-  const auto r = itk::Math::SVD(A);
+  const auto r = itk::bridge::Math::SVD(A);
   for (unsigned int j = 0; j < 4; ++j)
   {
     unsigned int pivot = 0;
@@ -116,7 +116,7 @@ TEST(MathSVD, SignsCanonical)
 // U V^T is invariant to the SVD sign/basis ambiguity: it matches vnl_svd even
 // for a degenerate (repeated singular value) matrix. This is the property the
 // geometry call sites (orthogonalization) rely on.
-TEST(MathSVD, UVtransposeInvariantOnDegenerate)
+TEST(BridgeMathSVD, UVtransposeInvariantOnDegenerate)
 {
   // Rotation * diag(1,1,3): two equal singular values (degenerate subspace).
   vnl_matrix_fixed<double, 3, 3> R;
@@ -140,7 +140,7 @@ TEST(MathSVD, UVtransposeInvariantOnDegenerate)
     A(i, 2) = R(i, 2) * 3.0;
   }
 
-  const auto                           r = itk::Math::SVD(A, /*canonicalizeSigns=*/false);
+  const auto                           r = itk::bridge::Math::SVD(A, /*canonicalizeSigns=*/false);
   const vnl_svd<double>                ref(A.as_matrix());
   const vnl_matrix_fixed<double, 3, 3> rotEig = r.U * r.V.transpose();
   const vnl_matrix<double>             rotVnl = ref.U() * ref.V().transpose();
@@ -153,12 +153,12 @@ TEST(MathSVD, UVtransposeInvariantOnDegenerate)
 #endif // ITK_FUTURE_LEGACY_REMOVE
 
 // The itk::Matrix overload forwards to the same computation.
-TEST(MathSVD, ItkMatrixOverload)
+TEST(BridgeMathSVD, ItkMatrixOverload)
 {
   itk::Matrix<double, 3, 3> A;
   A.SetIdentity();
   A(0, 2) = 0.5;
-  const auto r = itk::Math::SVD(A);
+  const auto r = itk::bridge::Math::SVD(A);
   double     err{};
   for (unsigned int i = 0; i < 3; ++i)
     for (unsigned int j = 0; j < 3; ++j)
@@ -173,7 +173,7 @@ TEST(MathSVD, ItkMatrixOverload)
 
 // Runtime-sized square overload, exercising both the small (JacobiSVD) and large
 // (BDCSVD) engine branches.
-TEST(MathSVD, DynamicReconstructs)
+TEST(BridgeMathSVD, DynamicReconstructs)
 {
   for (const unsigned int n : { 3u, 6u, 7u, 20u }) // 6 -> JacobiSVD, 7 -> BDCSVD (crossover)
   {
@@ -182,7 +182,7 @@ TEST(MathSVD, DynamicReconstructs)
       for (unsigned int j = 0; j < n; ++j)
         A(i, j) = std::sin(0.7 * i + 1.3 * j) + (i == j ? 3.0 : 0.0);
 
-    const auto r = itk::Math::SVD(A);
+    const auto r = itk::bridge::Math::SVD(A);
     double     err{};
     for (unsigned int i = 0; i < n; ++i)
       for (unsigned int j = 0; j < n; ++j)
@@ -203,17 +203,17 @@ TEST(MathSVD, DynamicReconstructs)
 }
 
 // An empty runtime input is rejected.
-TEST(MathSVD, DynamicRejectsEmpty)
+TEST(BridgeMathSVD, DynamicRejectsEmpty)
 {
   const vnl_matrix<double> A(0, 0);
-  EXPECT_THROW(itk::Math::SVD(A), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::SVD(A), itk::ExceptionObject);
 }
 
 // PseudoInverse() agrees with vnl_svd and satisfies the Moore-Penrose identity.
-TEST(MathSVD, PseudoInverseMatchesVnl)
+TEST(BridgeMathSVD, PseudoInverseMatchesVnl)
 {
   const auto A = MakeFixed<double, 6>();
-  const auto pinv = itk::Math::SVD(A).PseudoInverse();
+  const auto pinv = itk::bridge::Math::SVD(A).PseudoInverse();
 #ifndef ITK_FUTURE_LEGACY_REMOVE
   const vnl_matrix<double> pinvVnl = vnl_svd<double>(A.as_matrix()).pinverse();
   double                   dInv = 0.0;
@@ -233,14 +233,14 @@ TEST(MathSVD, PseudoInverseMatchesVnl)
 }
 
 // Solve() returns the solution of A x = b for a well-conditioned A.
-TEST(MathSVD, SolveMatchesVnl)
+TEST(BridgeMathSVD, SolveMatchesVnl)
 {
   const auto                  A = MakeFixed<double, 4>();
   vnl_vector_fixed<double, 4> b;
   for (unsigned int i = 0; i < 4; ++i)
     b[i] = static_cast<double>(i + 1);
 
-  const auto x = itk::Math::SVD(A).Solve(b);
+  const auto x = itk::bridge::Math::SVD(A).Solve(b);
 
   // residual A x - b is ~0 for a full-rank A
   const vnl_vector_fixed<double, 4> residual = A * x - b;
@@ -256,18 +256,18 @@ TEST(MathSVD, SolveMatchesVnl)
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 // WellCondition() (sigma_min/sigma_max) agrees with vnl_svd::well_condition(),
 // the accessor the NIfTI direction-cosine check migrated onto.
-TEST(MathSVD, WellConditionMatchesVnl)
+TEST(BridgeMathSVD, WellConditionMatchesVnl)
 {
   const auto A = MakeFixed<double, 5>();
-  EXPECT_NEAR(itk::Math::SVD(A).WellCondition(), vnl_svd<double>(A.as_matrix()).well_condition(), 1e-12);
+  EXPECT_NEAR(itk::bridge::Math::SVD(A).WellCondition(), vnl_svd<double>(A.as_matrix()).well_condition(), 1e-12);
 }
 
 // DeterminantMagnitude() (product of singular values) agrees with
 // vnl_svd::determinant_magnitude(), the accessor the Mahalanobis check migrated onto.
-TEST(MathSVD, DeterminantMagnitudeMatchesVnl)
+TEST(BridgeMathSVD, DeterminantMagnitudeMatchesVnl)
 {
   const auto   A = MakeFixed<double, 5>();
-  const double itkDet = itk::Math::SVD(A).DeterminantMagnitude();
+  const double itkDet = itk::bridge::Math::SVD(A).DeterminantMagnitude();
   const double vnlDet = vnl_svd<double>(A.as_matrix()).determinant_magnitude();
   EXPECT_NEAR(itkDet, vnlDet, 1e-10 * std::abs(vnlDet));
 }
@@ -275,9 +275,9 @@ TEST(MathSVD, DeterminantMagnitudeMatchesVnl)
 
 // rank() reports full rank for a well-conditioned matrix and the reduced rank of
 // a deliberately rank-deficient one.
-TEST(MathSVD, Rank)
+TEST(BridgeMathSVD, Rank)
 {
-  EXPECT_EQ(itk::Math::SVD(MakeFixed<double, 6>()).Rank(), 6u);
+  EXPECT_EQ(itk::bridge::Math::SVD(MakeFixed<double, 6>()).Rank(), 6u);
 
   // Two identical rows -> rank 2 for a 3x3.
   vnl_matrix<double> A(3, 3, 0.0);
@@ -290,13 +290,13 @@ TEST(MathSVD, Rank)
   A(2, 0) = 4.0;
   A(2, 1) = 0.0;
   A(2, 2) = 1.0;
-  EXPECT_EQ(itk::Math::SVD(A).Rank(), 2u);
+  EXPECT_EQ(itk::bridge::Math::SVD(A).Rank(), 2u);
 }
 
 // Ill-conditioned input (6x6 Hilbert, condition ~1e7): reconstruction stays
 // accurate and the singular values still agree with vnl_svd. Stresses the engines
 // where Jacobi and BDC can diverge, which the well-conditioned fixtures do not.
-TEST(MathSVD, IllConditionedMatchesVnl)
+TEST(BridgeMathSVD, IllConditionedMatchesVnl)
 {
   constexpr unsigned int N = 6;
   vnl_matrix<double>     A(N, N);
@@ -304,7 +304,7 @@ TEST(MathSVD, IllConditionedMatchesVnl)
     for (unsigned int j = 0; j < N; ++j)
       A(i, j) = 1.0 / (i + j + 1.0); // Hilbert
 
-  const auto r = itk::Math::SVD(A);
+  const auto r = itk::bridge::Math::SVD(A);
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
   // singular values agree relative to the largest
@@ -329,7 +329,7 @@ TEST(MathSVD, IllConditionedMatchesVnl)
 
 // canonicalizeSigns actually controls the output (a test that fails if the flag
 // were ignored): true yields canonical signs and differs from the raw false result.
-TEST(MathSVD, CanonicalizeFlagControlsSigns)
+TEST(BridgeMathSVD, CanonicalizeFlagControlsSigns)
 {
   // Scan several matrices: true must always be canonical, false must preserve
   // Eigen's raw signs, and at least one raw column must be non-canonical (proving
@@ -344,8 +344,8 @@ TEST(MathSVD, CanonicalizeFlagControlsSigns)
       for (unsigned int j = 0; j < 4; ++j)
         A(i, j) = std::sin(0.37 * seed + 0.7 * i + 1.9 * j) + (i == j ? 1.0 : 0.0);
 
-    const auto rTrue = itk::Math::SVD(A, true);
-    const auto rFalse = itk::Math::SVD(A, false);
+    const auto rTrue = itk::bridge::Math::SVD(A, true);
+    const auto rFalse = itk::bridge::Math::SVD(A, false);
 
     for (unsigned int j = 0; j < 4; ++j)
     {
@@ -376,14 +376,14 @@ TEST(MathSVD, CanonicalizeFlagControlsSigns)
 }
 
 // The runtime overload also canonicalizes (the dynamic SvdFlip path).
-TEST(MathSVD, DynamicSignsCanonical)
+TEST(BridgeMathSVD, DynamicSignsCanonical)
 {
   vnl_matrix<double> A(5, 5);
   for (unsigned int i = 0; i < 5; ++i)
     for (unsigned int j = 0; j < 5; ++j)
       A(i, j) = std::sin(0.9 * i + 1.7 * j) + (i == j ? 2.0 : 0.0);
 
-  const auto r = itk::Math::SVD(A);
+  const auto r = itk::bridge::Math::SVD(A);
   for (unsigned int j = 0; j < 5; ++j)
   {
     unsigned int pivot = 0;
@@ -396,7 +396,7 @@ TEST(MathSVD, DynamicSignsCanonical)
 
 // Repeated singular values (degenerate spectrum) still reconstruct exactly, even
 // though the singular-vector basis within the degenerate subspace is arbitrary.
-TEST(MathSVD, DegenerateSpectrumReconstructs)
+TEST(BridgeMathSVD, DegenerateSpectrumReconstructs)
 {
   // diag(2,2,2,5): a triply-repeated singular value.
   vnl_matrix<double> A(4, 4, 0.0);
@@ -404,7 +404,7 @@ TEST(MathSVD, DegenerateSpectrumReconstructs)
   A(1, 1) = 2.0;
   A(2, 2) = 2.0;
   A(3, 3) = 5.0;
-  const auto r = itk::Math::SVD(A);
+  const auto r = itk::bridge::Math::SVD(A);
   double     err = 0.0;
   for (unsigned int i = 0; i < 4; ++i)
     for (unsigned int j = 0; j < 4; ++j)
@@ -419,10 +419,10 @@ TEST(MathSVD, DegenerateSpectrumReconstructs)
 
 // Recompose() with no truncation reconstructs A; a threshold zeroes the small
 // singular value, yielding the rank-reduced reconstruction.
-TEST(MathSVD, Recompose)
+TEST(BridgeMathSVD, Recompose)
 {
   const auto A = MakeFixed<double, 4>();
-  const auto recon = itk::Math::SVD(A).Recompose();
+  const auto recon = itk::bridge::Math::SVD(A).Recompose();
   double     err = 0.0;
   for (unsigned int i = 0; i < 4; ++i)
     for (unsigned int j = 0; j < 4; ++j)
@@ -434,7 +434,7 @@ TEST(MathSVD, Recompose)
   B(0, 0) = 5.0;
   B(1, 1) = 3.0;
   B(2, 2) = 1e-9;
-  const auto truncated = itk::Math::SVD(B).Recompose(1e-6);
+  const auto truncated = itk::bridge::Math::SVD(B).Recompose(1e-6);
   EXPECT_NEAR(truncated(0, 0), 5.0, 1e-10);
   EXPECT_NEAR(truncated(1, 1), 3.0, 1e-10);
   EXPECT_NEAR(truncated(2, 2), 0.0, 1e-12);
@@ -442,7 +442,7 @@ TEST(MathSVD, Recompose)
 
 // Rectangular (tall and wide): thin factors reconstruct A, shapes are correct,
 // and PseudoInverse()/Solve() match vnl_svd and satisfy the Moore-Penrose identity.
-TEST(MathSVD, Rectangular)
+TEST(BridgeMathSVD, Rectangular)
 {
   const unsigned int dims[2][2] = { { 5, 3 }, { 3, 5 } }; // tall, wide
   for (const auto & d : dims)
@@ -455,7 +455,7 @@ TEST(MathSVD, Rectangular)
       for (unsigned int j = 0; j < n; ++j)
         A(i, j) = std::sin(0.6 * i + 1.1 * j) + (i == j ? 1.0 : 0.0);
 
-    const auto r = itk::Math::SVD(A);
+    const auto r = itk::bridge::Math::SVD(A);
     EXPECT_EQ(r.U.rows(), m);
     EXPECT_EQ(r.U.cols(), k);
     EXPECT_EQ(r.V.rows(), n);
@@ -498,7 +498,7 @@ TEST(MathSVD, Rectangular)
 }
 
 // Rectangular least-squares Solve() matches vnl_svd (the BSpline refinement use).
-TEST(MathSVD, RectangularSolveMatchesVnl)
+TEST(BridgeMathSVD, RectangularSolveMatchesVnl)
 {
   vnl_matrix<double> A(5, 3); // overdetermined
   for (unsigned int i = 0; i < 5; ++i)
@@ -508,7 +508,7 @@ TEST(MathSVD, RectangularSolveMatchesVnl)
   for (unsigned int i = 0; i < 5; ++i)
     b[i] = static_cast<double>(i) - 1.5;
 
-  const vnl_vector<double> x = itk::Math::SVD(A).Solve(b);
+  const vnl_vector<double> x = itk::bridge::Math::SVD(A).Solve(b);
   EXPECT_EQ(x.size(), 3u);
 #ifndef ITK_FUTURE_LEGACY_REMOVE
   const vnl_vector<double> xVnl = vnl_svd<double>(A).solve(b);
@@ -517,7 +517,7 @@ TEST(MathSVD, RectangularSolveMatchesVnl)
 }
 
 // NullVector() matches vnl_svd::nullvector() up to sign, and lies in the nullspace.
-TEST(MathSVD, NullVector)
+TEST(BridgeMathSVD, NullVector)
 {
   // Rank-2 square 3x3: third row = row0 + row1.
   vnl_matrix<double> A(3, 3);
@@ -530,7 +530,7 @@ TEST(MathSVD, NullVector)
   for (unsigned int j = 0; j < 3; ++j)
     A(2, j) = A(0, j) + A(1, j);
 
-  const vnl_vector<double> nv = itk::Math::SVD(A).NullVector();
+  const vnl_vector<double> nv = itk::bridge::Math::SVD(A).NullVector();
   EXPECT_LT((A * nv).inf_norm(), 1e-12);
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
@@ -542,25 +542,25 @@ TEST(MathSVD, NullVector)
   // Fixed-size overload agrees.
   vnl_matrix_fixed<double, 3, 3> Af;
   Af.copy_in(A.data_block());
-  const vnl_vector_fixed<double, 3> nvf = itk::Math::SVD(Af).NullVector();
+  const vnl_vector_fixed<double, 3> nvf = itk::bridge::Math::SVD(Af).NullVector();
   EXPECT_LT((A * nvf.as_vector()).inf_norm(), 1e-12);
 }
 
 // NullVector() refuses an underdetermined input whose thin V cannot span the nullspace.
-TEST(MathSVD, NullVectorRejectsUnderdetermined)
+TEST(BridgeMathSVD, NullVectorRejectsUnderdetermined)
 {
   vnl_matrix<double> A(2, 4);
   A.fill(1.0);
   A(0, 1) = 2.0;
   A(1, 3) = 3.0;
-  EXPECT_THROW(itk::Math::SVD(A).NullVector(), itk::ExceptionObject);
+  EXPECT_THROW(itk::bridge::Math::SVD(A).NullVector(), itk::ExceptionObject);
 }
 
 // RecomposeWith() reproduces A for unmodified W and honors hand-edited values.
-TEST(MathSVD, RecomposeWith)
+TEST(BridgeMathSVD, RecomposeWith)
 {
   const auto Af = MakeFixed<double, 4>();
-  const auto r = itk::Math::SVD(Af);
+  const auto r = itk::bridge::Math::SVD(Af);
 
   const vnl_matrix_fixed<double, 4, 4> same = r.RecomposeWith(r.W);
   double                               err = 0.0;
@@ -593,7 +593,7 @@ TEST(MathSVD, RecomposeWith)
 
 // Fixed rectangular overload: factors match the dynamic path and the
 // pseudo-inverse matches the vnl_svd reference (the itkTransform Jacobian use).
-TEST(MathSVD, FixedRectangular)
+TEST(BridgeMathSVD, FixedRectangular)
 {
   constexpr unsigned int               rows = 5;
   constexpr unsigned int               cols = 3;
@@ -602,8 +602,8 @@ TEST(MathSVD, FixedRectangular)
     for (unsigned int j = 0; j < cols; ++j)
       Af(i, j) = std::cos(0.4 * i + 0.9 * j) + (i == j ? 2.0 : 0.0);
 
-  const auto rf = itk::Math::SVD(Af);
-  const auto rd = itk::Math::SVD(vnl_matrix<double>(Af.as_matrix()));
+  const auto rf = itk::bridge::Math::SVD(Af);
+  const auto rd = itk::bridge::Math::SVD(vnl_matrix<double>(Af.as_matrix()));
   for (unsigned int k = 0; k < 3; ++k)
     EXPECT_NEAR(rf.W[k], rd.W[k], 1e-12);
 
@@ -620,6 +620,6 @@ TEST(MathSVD, FixedRectangular)
   vnl_matrix_fixed<double, rows, cols> Adef = Af;
   for (unsigned int i = 0; i < rows; ++i)
     Adef(i, 2) = Adef(i, 0) + Adef(i, 1);
-  const vnl_vector_fixed<double, cols> nv = itk::Math::SVD(Adef).NullVector();
+  const vnl_vector_fixed<double, cols> nv = itk::bridge::Math::SVD(Adef).NullVector();
   EXPECT_LT((Adef.as_matrix() * nv.as_vector()).inf_norm(), 1e-12);
 }

--- a/Modules/Core/Common/test/itkBridgeQRDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeQRDecompositionGTest.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 
 // First include the header file to be tested:
-#include "itkQRDecomposition.h"
+#include "itkBridgeQRDecomposition.h"
 
 // Exercise the deprecated VNL engine for the old-vs-new equivalence checks.
 // The VNL symbol is unavailable under ITK_FUTURE_LEGACY_REMOVE.
@@ -45,28 +45,28 @@ MakeMatrix(unsigned int rows, unsigned int cols)
 
 
 // Q R reconstructs A.
-TEST(QRDecomposition, ReconstructsMatrix)
+TEST(BridgeQRDecomposition, ReconstructsMatrix)
 {
-  const vnl_matrix<double>           A = MakeMatrix<double>(5, 5);
-  const itk::QRDecomposition<double> qr(A);
-  const vnl_matrix<double>           reconstructed = qr.GetQ() * qr.GetR();
+  const vnl_matrix<double>                   A = MakeMatrix<double>(5, 5);
+  const itk::bridge::QRDecomposition<double> qr(A);
+  const vnl_matrix<double>                   reconstructed = qr.GetQ() * qr.GetR();
   EXPECT_LT((reconstructed - A).fro_norm() / A.fro_norm(), 1e-12);
 }
 
 
 // Q is orthonormal: Q^T Q == I.
-TEST(QRDecomposition, OrthonormalQ)
+TEST(BridgeQRDecomposition, OrthonormalQ)
 {
-  const vnl_matrix<double>           A = MakeMatrix<double>(6, 4);
-  const itk::QRDecomposition<double> qr(A);
-  vnl_matrix<double>                 ident(6, 6);
+  const vnl_matrix<double>                   A = MakeMatrix<double>(6, 4);
+  const itk::bridge::QRDecomposition<double> qr(A);
+  vnl_matrix<double>                         ident(6, 6);
   ident.set_identity();
   EXPECT_LT((qr.GetQ().transpose() * qr.GetQ() - ident).fro_norm(), 1e-12);
 }
 
 
 // A x = b solved; residual tiny.
-TEST(QRDecomposition, SolveResidual)
+TEST(BridgeQRDecomposition, SolveResidual)
 {
   const unsigned int       n = 5;
   const vnl_matrix<double> A = MakeMatrix<double>(n, n);
@@ -74,14 +74,14 @@ TEST(QRDecomposition, SolveResidual)
   for (unsigned int i = 0; i < n; ++i)
     b[i] = static_cast<double>(i) - 1.5;
 
-  const itk::QRDecomposition<double> qr(A);
-  const vnl_vector<double>           x = qr.Solve(b);
+  const itk::bridge::QRDecomposition<double> qr(A);
+  const vnl_vector<double>                   x = qr.Solve(b);
   EXPECT_LT((A * x - b).two_norm() / b.two_norm(), 1e-10);
 }
 
 
 // Multi-column RHS: each column solves against the one shared factorization.
-TEST(QRDecomposition, SolveMatrixRHS)
+TEST(BridgeQRDecomposition, SolveMatrixRHS)
 {
   const unsigned int       n = 5;
   const unsigned int       k = 3;
@@ -91,8 +91,8 @@ TEST(QRDecomposition, SolveMatrixRHS)
     for (unsigned int j = 0; j < k; ++j)
       B(i, j) = std::cos(0.3 * (i + 1) * (j + 2));
 
-  const itk::QRDecomposition<double> qr(A);
-  const vnl_matrix<double>           X = qr.Solve(B);
+  const itk::bridge::QRDecomposition<double> qr(A);
+  const vnl_matrix<double>                   X = qr.Solve(B);
   ASSERT_EQ(X.rows(), n);
   ASSERT_EQ(X.cols(), k);
   EXPECT_LT((A * X - B).fro_norm() / B.fro_norm(), 1e-10);
@@ -103,7 +103,7 @@ TEST(QRDecomposition, SolveMatrixRHS)
 
 // Overdetermined (rows > cols) multi-column solve yields the least-squares
 // solution, characterized by the normal equations A^T (A X - B) == 0.
-TEST(QRDecomposition, SolveMatrixRHSOverdetermined)
+TEST(BridgeQRDecomposition, SolveMatrixRHSOverdetermined)
 {
   const unsigned int       m = 6;
   const unsigned int       n = 3;
@@ -114,8 +114,8 @@ TEST(QRDecomposition, SolveMatrixRHSOverdetermined)
     for (unsigned int j = 0; j < k; ++j)
       B(i, j) = std::cos(0.35 * (i + 1) * (j + 2)) - 0.2 * (j + 1);
 
-  const itk::QRDecomposition<double> qr(A);
-  const vnl_matrix<double>           X = qr.Solve(B);
+  const itk::bridge::QRDecomposition<double> qr(A);
+  const vnl_matrix<double>                   X = qr.Solve(B);
   ASSERT_EQ(X.rows(), n);
   ASSERT_EQ(X.cols(), k);
   EXPECT_LT((A.transpose() * (A * X - B)).fro_norm() / (A.transpose() * B).fro_norm(), 1e-10);
@@ -126,7 +126,7 @@ TEST(QRDecomposition, SolveMatrixRHSOverdetermined)
 
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 // itk:: solve and determinant agree with the (sign-stable) legacy vnl_qr.
-TEST(QRDecomposition, EquivalentToVnlQR)
+TEST(BridgeQRDecomposition, EquivalentToVnlQR)
 {
   const unsigned int       n = 6;
   const vnl_matrix<double> A = MakeMatrix<double>(n, n);
@@ -134,8 +134,8 @@ TEST(QRDecomposition, EquivalentToVnlQR)
   for (unsigned int i = 0; i < n; ++i)
     b[i] = std::cos(0.5 * (i + 1));
 
-  const itk::QRDecomposition<double> qrItk(A);
-  vnl_qr<double>                     qrVnl(A);
+  const itk::bridge::QRDecomposition<double> qrItk(A);
+  vnl_qr<double>                             qrVnl(A);
 
   EXPECT_LT((qrItk.Solve(b) - qrVnl.solve(b)).two_norm() / qrVnl.solve(b).two_norm(), 1e-10);
   EXPECT_NEAR(qrItk.GetDeterminant(), qrVnl.determinant(), 1e-9 * std::abs(qrVnl.determinant()) + 1e-12);
@@ -144,7 +144,7 @@ TEST(QRDecomposition, EquivalentToVnlQR)
 
 // Multi-column solve matches legacy vnl_qr column-for-column. This is the exact
 // operation itkLandmarkBasedTransformInitializer relies on (square Q, matrix C).
-TEST(QRDecomposition, MatrixRHSEquivalentToVnlQR)
+TEST(BridgeQRDecomposition, MatrixRHSEquivalentToVnlQR)
 {
   for (const unsigned int n : { 3u, 4u, 6u })
   {
@@ -155,7 +155,7 @@ TEST(QRDecomposition, MatrixRHSEquivalentToVnlQR)
       for (unsigned int j = 0; j < k; ++j)
         B(i, j) = std::cos(0.4 * (i + 1) * (j + 2)) - 0.3 * (j + 1);
 
-    const vnl_matrix<double> xItk = itk::QRDecomposition<double>(A).Solve(B);
+    const vnl_matrix<double> xItk = itk::bridge::QRDecomposition<double>(A).Solve(B);
     const vnl_matrix<double> xVnl = vnl_qr<double>(A).solve(B);
     EXPECT_LT((xItk - xVnl).fro_norm() / xVnl.fro_norm(), 1e-10);
   }
@@ -163,12 +163,12 @@ TEST(QRDecomposition, MatrixRHSEquivalentToVnlQR)
 
 
 // Inverse matches legacy vnl_qr.inverse().
-TEST(QRDecomposition, InverseEquivalentToVnlQR)
+TEST(BridgeQRDecomposition, InverseEquivalentToVnlQR)
 {
   for (const unsigned int n : { 2u, 3u, 5u })
   {
     const vnl_matrix<double> A = MakeMatrix<double>(n, n);
-    const vnl_matrix<double> invItk = itk::QRDecomposition<double>(A).Inverse();
+    const vnl_matrix<double> invItk = itk::bridge::QRDecomposition<double>(A).Inverse();
     const vnl_matrix<double> invVnl = vnl_qr<double>(A).inverse();
     EXPECT_LT((invItk - invVnl).fro_norm() / invVnl.fro_norm(), 1e-10);
 
@@ -181,19 +181,19 @@ TEST(QRDecomposition, InverseEquivalentToVnlQR)
 
 
 // Single-precision path reconstructs.
-TEST(QRDecomposition, FloatReconstructs)
+TEST(BridgeQRDecomposition, FloatReconstructs)
 {
-  const vnl_matrix<float>           A = MakeMatrix<float>(4, 4);
-  const itk::QRDecomposition<float> qr(A);
+  const vnl_matrix<float>                   A = MakeMatrix<float>(4, 4);
+  const itk::bridge::QRDecomposition<float> qr(A);
   EXPECT_LT((qr.GetQ() * qr.GetR() - A).fro_norm() / A.fro_norm(), 1e-5f);
 }
 
 
 // Solve rejects an underdetermined system (rows < cols) instead of reading out of bounds.
-TEST(QRDecomposition, SolveRejectsUnderdetermined)
+TEST(BridgeQRDecomposition, SolveRejectsUnderdetermined)
 {
-  const vnl_matrix<double>           A = MakeMatrix<double>(3, 5);
-  const itk::QRDecomposition<double> qr(A);
-  const vnl_vector<double>           b(3, 1.0);
+  const vnl_matrix<double>                   A = MakeMatrix<double>(3, 5);
+  const itk::bridge::QRDecomposition<double> qr(A);
+  const vnl_vector<double>                   b(3, 1.0);
   EXPECT_THROW(qr.Solve(b), itk::ExceptionObject);
 }

--- a/Modules/Core/Common/test/itkBridgeRealEigenDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeRealEigenDecompositionGTest.cxx
@@ -15,7 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "itkRealEigenDecomposition.h"
+#include "itkBridgeRealEigenDecomposition.h"
 #include "itkConfigure.h"
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 #  define ITK_LEGACY_TEST // exercise the deprecated vnl class for equivalence
@@ -36,7 +36,7 @@ namespace
 // assert against (individual eigenvector signs are arbitrary).
 template <typename TReal>
 TReal
-EigenResidual(const vnl_matrix<TReal> & A, const itk::RealEigenDecomposition<TReal> & eig)
+EigenResidual(const vnl_matrix<TReal> & A, const itk::bridge::RealEigenDecomposition<TReal> & eig)
 {
   using Complex = std::complex<TReal>;
   const auto &       lambda = eig.GetEigenvalues();
@@ -62,15 +62,15 @@ EigenResidual(const vnl_matrix<TReal> & A, const itk::RealEigenDecomposition<TRe
 } // namespace
 
 // Scavenged from VXL test_real_eigensystem::test_6x6 (real spectrum).
-TEST(RealEigenDecomposition, SymmetricInputRealSpectrum)
+TEST(BridgeRealEigenDecomposition, SymmetricInputRealSpectrum)
 {
   const double Sdata[36] = {
     30.0000, -3.4273, 13.9254, 13.7049, -2.4446, 20.2380, -3.4273, 13.7049, -2.4446, 1.3659,  3.6702,  -0.2282,
     13.9254, -2.4446, 20.2380, 3.6702,  -0.2282, 28.6779, 13.7049, 1.3659,  3.6702,  12.5273, -1.6045, 3.9419,
     -2.4446, 3.6702,  -0.2282, -1.6045, 3.9419,  2.5821,  20.2380, -0.2282, 28.6779, 3.9419,  2.5821,  44.0636,
   };
-  const vnl_matrix<double>                  S(Sdata, 6, 6);
-  const itk::RealEigenDecomposition<double> eig(S);
+  const vnl_matrix<double>                          S(Sdata, 6, 6);
+  const itk::bridge::RealEigenDecomposition<double> eig(S);
 
   for (unsigned int i = 0; i < 6; ++i)
   {
@@ -80,17 +80,17 @@ TEST(RealEigenDecomposition, SymmetricInputRealSpectrum)
 }
 
 // Scavenged from VXL test_real_eigensystem::test_4x4 (general/unsympathetic).
-TEST(RealEigenDecomposition, GeneralMatrix)
+TEST(BridgeRealEigenDecomposition, GeneralMatrix)
 {
   const double             Xdata[16] = { 686, 526, 701, 47, 588, 91, 910, 736, 930, 653, 762, 328, 846, 415, 262, 632 };
   const vnl_matrix<double> X(Xdata, 4, 4);
-  const itk::RealEigenDecomposition<double> eig(X);
+  const itk::bridge::RealEigenDecomposition<double> eig(X);
   EXPECT_LT(EigenResidual(X, eig), 1e-10);
 }
 
 // A real matrix with a genuinely complex spectrum: 2-D rotation by theta has
 // eigenvalues exp(+/- i theta). Exercises the complex-conjugate path.
-TEST(RealEigenDecomposition, ComplexSpectrumRotation)
+TEST(BridgeRealEigenDecomposition, ComplexSpectrumRotation)
 {
   const double       theta = 0.7;
   vnl_matrix<double> R(2, 2);
@@ -99,7 +99,7 @@ TEST(RealEigenDecomposition, ComplexSpectrumRotation)
   R(1, 0) = std::sin(theta);
   R(1, 1) = std::cos(theta);
 
-  const itk::RealEigenDecomposition<double> eig(R);
+  const itk::bridge::RealEigenDecomposition<double> eig(R);
   EXPECT_LT(EigenResidual(R, eig), 1e-13);
 
   double maxImag = 0;
@@ -110,14 +110,14 @@ TEST(RealEigenDecomposition, ComplexSpectrumRotation)
   EXPECT_NEAR(maxImag, std::sin(theta), 1e-13);
 }
 
-TEST(RealEigenDecomposition, Identity)
+TEST(BridgeRealEigenDecomposition, Identity)
 {
   vnl_matrix<double> I(3, 3, 0.0);
   for (unsigned int i = 0; i < 3; ++i)
   {
     I(i, i) = 1.0;
   }
-  const itk::RealEigenDecomposition<double> eig(I);
+  const itk::bridge::RealEigenDecomposition<double> eig(I);
   for (unsigned int i = 0; i < 3; ++i)
   {
     EXPECT_NEAR(std::real(eig.GetEigenvalues()[i]), 1.0, 1e-14);
@@ -125,17 +125,17 @@ TEST(RealEigenDecomposition, Identity)
   }
 }
 
-TEST(RealEigenDecomposition, FloatInstantiation)
+TEST(BridgeRealEigenDecomposition, FloatInstantiation)
 {
-  const float                              data[4] = { 2.0f, 0.0f, 0.0f, 3.0f };
-  const vnl_matrix<float>                  A(data, 2, 2);
-  const itk::RealEigenDecomposition<float> eig(A);
+  const float                                      data[4] = { 2.0f, 0.0f, 0.0f, 3.0f };
+  const vnl_matrix<float>                          A(data, 2, 2);
+  const itk::bridge::RealEigenDecomposition<float> eig(A);
   EXPECT_LT(EigenResidual(A, eig), 1e-5f);
 }
 
 // Non-finite input leaves the Eigen solver in a non-Success state; the wrapper
 // surfaces that as an exception rather than returning a garbage decomposition.
-TEST(RealEigenDecomposition, NonFiniteInputThrows)
+TEST(BridgeRealEigenDecomposition, NonFiniteInputThrows)
 {
   const double       nan = std::numeric_limits<double>::quiet_NaN();
   vnl_matrix<double> M(2, 2, 0.0);
@@ -144,7 +144,7 @@ TEST(RealEigenDecomposition, NonFiniteInputThrows)
   M(0, 1) = M(1, 0) = nan;
   try
   {
-    const itk::RealEigenDecomposition<double> eig{ M };
+    const itk::bridge::RealEigenDecomposition<double> eig{ M };
     FAIL() << "expected an exception for non-finite input";
   }
   catch (const itk::ExceptionObject & e)
@@ -163,13 +163,13 @@ TEST(RealEigenDecomposition, NonFiniteInputThrows)
 // Equivalence: the Eigen-backed solver yields the same (complex) spectrum as
 // the deprecated netlib vnl_real_eigensystem. General eigenvalues are unsorted,
 // so compare as multisets.
-TEST(RealEigenDecomposition, EquivalenceWithVnl)
+TEST(BridgeRealEigenDecomposition, EquivalenceWithVnl)
 {
   const double             data[9] = { 0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 2.0 }; // spectrum {i, -i, 2}
   const vnl_matrix<double> A(data, 3, 3);
 
-  const vnl_real_eigensystem                vnlEngine(A);
-  const itk::RealEigenDecomposition<double> itkEngine(A);
+  const vnl_real_eigensystem                        vnlEngine(A);
+  const itk::bridge::RealEigenDecomposition<double> itkEngine(A);
 
   auto sorted = [](std::vector<std::complex<double>> v) {
     std::sort(v.begin(), v.end(), [](const std::complex<double> & a, const std::complex<double> & b) {

--- a/Modules/Core/Common/test/itkBridgeSymmetricEigenDecompositionGTest.cxx
+++ b/Modules/Core/Common/test/itkBridgeSymmetricEigenDecompositionGTest.cxx
@@ -15,7 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 #include "itkConfigure.h"
 #ifndef ITK_FUTURE_LEGACY_REMOVE
 #  define ITK_LEGACY_TEST // exercise the deprecated vnl class for equivalence
@@ -30,7 +30,7 @@ namespace
 
 template <typename T>
 T
-EigenResidual(const vnl_matrix<T> & A, const itk::SymmetricEigenDecomposition<T> & eig)
+EigenResidual(const vnl_matrix<T> & A, const itk::bridge::SymmetricEigenDecomposition<T> & eig)
 {
   vnl_matrix<T> D(A.rows(), A.cols(), T{ 0 });
   for (unsigned int i = 0; i < A.rows(); ++i)
@@ -50,10 +50,10 @@ MakeSymmetric()
 } // namespace
 
 // Scavenged coverage: eigenvalues ascending, A V == V D, V orthonormal.
-TEST(SymmetricEigenDecomposition, DecompositionIdentity)
+TEST(BridgeSymmetricEigenDecomposition, DecompositionIdentity)
 {
-  const vnl_matrix<double>                       A = MakeSymmetric();
-  const itk::SymmetricEigenDecomposition<double> eig(A);
+  const vnl_matrix<double>                               A = MakeSymmetric();
+  const itk::bridge::SymmetricEigenDecomposition<double> eig(A);
 
   for (unsigned int i = 1; i < 3; ++i)
   {
@@ -71,14 +71,14 @@ TEST(SymmetricEigenDecomposition, DecompositionIdentity)
   }
 }
 
-// itk::SymmetricEigenDecomposition and the legacy vnl class agree on eigenvalues
+// itk::bridge::SymmetricEigenDecomposition and the legacy vnl class agree on eigenvalues
 // exactly and on eigenvectors up to per-column sign.
 #ifndef ITK_FUTURE_LEGACY_REMOVE
-TEST(SymmetricEigenDecomposition, EquivalenceWithVnl)
+TEST(BridgeSymmetricEigenDecomposition, EquivalenceWithVnl)
 {
-  const vnl_matrix<double>                       A = MakeSymmetric();
-  const itk::SymmetricEigenDecomposition<double> eigNew(A);
-  const vnl_symmetric_eigensystem<double>        eigVnl(A);
+  const vnl_matrix<double>                               A = MakeSymmetric();
+  const itk::bridge::SymmetricEigenDecomposition<double> eigNew(A);
+  const vnl_symmetric_eigensystem<double>                eigVnl(A);
 
   for (unsigned int i = 0; i < 3; ++i)
   {
@@ -94,10 +94,10 @@ TEST(SymmetricEigenDecomposition, EquivalenceWithVnl)
 // The deterministic sign convention: each eigenvector column's
 // largest-magnitude entry is positive. This makes the decomposition
 // reproducible across solver/SIMD differences.
-TEST(SymmetricEigenDecomposition, CanonicalSignConvention)
+TEST(BridgeSymmetricEigenDecomposition, CanonicalSignConvention)
 {
-  const vnl_matrix<double>                       A = MakeSymmetric();
-  const itk::SymmetricEigenDecomposition<double> eig(A);
+  const vnl_matrix<double>                               A = MakeSymmetric();
+  const itk::bridge::SymmetricEigenDecomposition<double> eig(A);
 
   for (unsigned int j = 0; j < 3; ++j)
   {
@@ -116,11 +116,11 @@ TEST(SymmetricEigenDecomposition, CanonicalSignConvention)
 
 // canonicalizeSigns=false keeps the solver's raw signs but stays a valid
 // decomposition; the default (true) enforces largest-magnitude-positive.
-TEST(SymmetricEigenDecomposition, CanonicalizationIsOptOut)
+TEST(BridgeSymmetricEigenDecomposition, CanonicalizationIsOptOut)
 {
-  const vnl_matrix<double>                       A = MakeSymmetric();
-  const itk::SymmetricEigenDecomposition<double> canon(A); // default true
-  const itk::SymmetricEigenDecomposition<double> raw(A, false);
+  const vnl_matrix<double>                               A = MakeSymmetric();
+  const itk::bridge::SymmetricEigenDecomposition<double> canon(A); // default true
+  const itk::bridge::SymmetricEigenDecomposition<double> raw(A, false);
 
   EXPECT_LT(EigenResidual(A, canon), 1e-12);
   EXPECT_LT(EigenResidual(A, raw), 1e-12);
@@ -131,10 +131,10 @@ TEST(SymmetricEigenDecomposition, CanonicalizationIsOptOut)
   }
 }
 
-TEST(SymmetricEigenDecomposition, NullvectorAndRecompose)
+TEST(BridgeSymmetricEigenDecomposition, NullvectorAndRecompose)
 {
-  const vnl_matrix<double>                       A = MakeSymmetric();
-  const itk::SymmetricEigenDecomposition<double> eig(A);
+  const vnl_matrix<double>                               A = MakeSymmetric();
+  const itk::bridge::SymmetricEigenDecomposition<double> eig(A);
 
   // nullvector is the smallest-eigenvalue eigenvector (column 0).
   EXPECT_NEAR(dot_product(eig.nullvector(), eig.get_eigenvector(0)), 1.0, 1e-12);
@@ -143,17 +143,17 @@ TEST(SymmetricEigenDecomposition, NullvectorAndRecompose)
   EXPECT_LT((eig.recompose() - A).fro_norm(), 1e-12);
 }
 
-TEST(SymmetricEigenDecomposition, FloatInstantiation)
+TEST(BridgeSymmetricEigenDecomposition, FloatInstantiation)
 {
-  float                                         data[4] = { 2.0f, 0.5f, 0.5f, 3.0f };
-  const vnl_matrix<float>                       A(data, 2, 2);
-  const itk::SymmetricEigenDecomposition<float> eig(A);
+  float                                                 data[4] = { 2.0f, 0.5f, 0.5f, 3.0f };
+  const vnl_matrix<float>                               A(data, 2, 2);
+  const itk::bridge::SymmetricEigenDecomposition<float> eig(A);
   EXPECT_LT(EigenResidual(A, eig), 1e-5f);
 }
 
 // Non-finite input leaves the Eigen solver in a non-Success state; the wrapper
 // surfaces that as an exception rather than returning a garbage decomposition.
-TEST(SymmetricEigenDecomposition, NonFiniteInputThrows)
+TEST(BridgeSymmetricEigenDecomposition, NonFiniteInputThrows)
 {
   const double       nan = std::numeric_limits<double>::quiet_NaN();
   vnl_matrix<double> M(2, 2, 0.0);
@@ -162,7 +162,7 @@ TEST(SymmetricEigenDecomposition, NonFiniteInputThrows)
   M(0, 1) = M(1, 0) = nan;
   try
   {
-    const itk::SymmetricEigenDecomposition<double> eig{ M };
+    const itk::bridge::SymmetricEigenDecomposition<double> eig{ M };
     FAIL() << "expected an exception for non-finite input";
   }
   catch (const itk::ExceptionObject & e)

--- a/Modules/Core/Common/test/itkVnlCholeskyEngineGTest.cxx
+++ b/Modules/Core/Common/test/itkVnlCholeskyEngineGTest.cxx
@@ -21,7 +21,7 @@
 // core/vnl/algo/tests/test_cholesky.cxx so the coverage runs in ITK CI and
 // guards any future change of the underlying Cholesky engine.
 
-#include "itkCholeskySolve.h"
+#include "itkBridgeCholeskySolve.h"
 
 // The deprecated VNL engine under test is unavailable under ITK_FUTURE_LEGACY_REMOVE.
 #ifndef ITK_FUTURE_LEGACY_REMOVE
@@ -182,7 +182,7 @@ TEST(VnlCholeskyEngine, EquivalentToItkCholeskySolve)
 
   const vnl_cholesky       chol(A, vnl_cholesky::quiet);
   const vnl_vector<double> xVnl = chol.solve(b);
-  const vnl_vector<double> xItk = itk::Math::SolveSymmetricPositiveDefinite(A, b);
+  const vnl_vector<double> xItk = itk::bridge::Math::SolveSymmetricPositiveDefinite(A, b);
   EXPECT_LT((xItk - xVnl).two_norm() / xVnl.two_norm(), 1e-10);
 }
 

--- a/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
+++ b/Modules/Core/TestKernel/include/itkTestingExtractSliceImageFilter.hxx
@@ -19,7 +19,7 @@
 #define itkTestingExtractSliceImageFilter_hxx
 
 #include "itkImageRegionIterator.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 #include "itkObjectFactory.h"
 #include "itkTotalProgressReporter.h"
 
@@ -201,7 +201,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     break;
     case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOSUBMATRIX:
     {
-      if (Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
+      if (bridge::Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
       {
         itkExceptionStringMacro("Invalid submatrix extracted for collapsed direction.");
       }
@@ -209,7 +209,7 @@ ExtractSliceImageFilter<TInputImage, TOutputImage>::GenerateOutputInformation()
     break;
     case TestExtractSliceImageFilterCollapseStrategyEnum::DIRECTIONCOLLAPSETOGUESS:
     {
-      if (Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
+      if (bridge::Math::Determinant(outputDirection.GetVnlMatrix()) == 0.0)
       {
         outputDirection.SetIdentity();
       }

--- a/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkComposeScaleSkewVersor3DTransform.hxx
@@ -19,7 +19,7 @@
 #define itkComposeScaleSkewVersor3DTransform_hxx
 
 #include "itkMath.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 namespace itk
 {
@@ -279,7 +279,7 @@ ComposeScaleSkewVersor3DTransform<TParametersValueType>::ComputeMatrixParameters
   M(2, 2) /= m_Scale[2];
   m_Skew[1] = ortho0 / m_Scale[0];
   m_Skew[2] = ortho1 / m_Scale[1];
-  if (Math::Determinant(M.GetVnlMatrix()) < 0)
+  if (bridge::Math::Determinant(M.GetVnlMatrix()) < 0)
   {
     m_Scale[0] *= -1;
     M(0, 0) *= -1;

--- a/Modules/Core/Transform/include/itkKernelTransform.hxx
+++ b/Modules/Core/Transform/include/itkKernelTransform.hxx
@@ -18,7 +18,7 @@
 #ifndef itkKernelTransform_hxx
 #define itkKernelTransform_hxx
 
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 
 namespace itk
 {
@@ -142,7 +142,7 @@ KernelTransform<TParametersValueType, VDimension>::ComputeWMatrix()
 {
   this->ComputeL();
   this->ComputeY();
-  const auto svd = itk::Math::SVD(this->m_LMatrix, /*canonicalizeSigns=*/false);
+  const auto svd = itk::bridge::Math::SVD(this->m_LMatrix, /*canonicalizeSigns=*/false);
   // Absolute 1e-8 singular-value tolerance; guard the degenerate all-zero L.
   const auto wmax = svd.W[0];
   const auto rcond =

--- a/Modules/Core/Transform/include/itkRigid2DTransform.hxx
+++ b/Modules/Core/Transform/include/itkRigid2DTransform.hxx
@@ -18,7 +18,7 @@
 #ifndef itkRigid2DTransform_hxx
 #define itkRigid2DTransform_hxx
 
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "itkPrintHelper.h"
 
 namespace itk
@@ -90,7 +90,7 @@ void
 Rigid2DTransform<TParametersValueType>::ComputeMatrixParameters()
 {
   // Extract the orthogonal part of the matrix (U V^T is the closest rotation).
-  const auto                       svd = itk::Math::SVD(this->GetMatrix());
+  const auto                       svd = itk::bridge::Math::SVD(this->GetMatrix());
   vnl_matrix<TParametersValueType> r{ (svd.U * svd.V.transpose()).as_matrix() };
 
   m_Angle = std::acos(r[0][0]);

--- a/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
+++ b/Modules/Core/Transform/include/itkSimilarity3DTransform.hxx
@@ -19,7 +19,7 @@
 #define itkSimilarity3DTransform_hxx
 
 #include "itkMath.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 #include "itkPrintHelper.h"
 
 namespace itk
@@ -85,7 +85,7 @@ Similarity3DTransform<TParametersValueType>::SetMatrix(const MatrixType & matrix
   // multiplied by the scale factor, then its determinant
   // must be equal to the cube of the scale factor.
   //
-  const double det = Math::Determinant(matrix.GetVnlMatrix());
+  const double det = bridge::Math::Determinant(matrix.GetVnlMatrix());
 
   if (det == 0.0)
   {
@@ -290,7 +290,7 @@ Similarity3DTransform<TParametersValueType>::ComputeMatrixParameters()
 {
   MatrixType matrix = this->GetMatrix();
 
-  m_Scale = itk::Math::cbrt(Math::Determinant(matrix.GetVnlMatrix()));
+  m_Scale = itk::Math::cbrt(bridge::Math::Determinant(matrix.GetVnlMatrix()));
 
   matrix /= m_Scale;
 

--- a/Modules/Core/Transform/include/itkTransform.hxx
+++ b/Modules/Core/Transform/include/itkTransform.hxx
@@ -19,7 +19,7 @@
 #define itkTransform_hxx
 
 #include "itkCrossHelper.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  include "vnl/algo/vnl_svd_fixed.h" // transitional transitive include; dropped on ITK legacy removal
 #endif
@@ -543,11 +543,11 @@ Transform<TParametersValueType, VInputDimension, VOutputDimension>::ComputeInver
   if constexpr (VOutputDimension == VInputDimension)
   {
     // Square: fixed-size pseudo-inverse avoids the dynamic as_matrix() round-trip.
-    jacobian = Math::SVD(forward_jacobian).PseudoInverse();
+    jacobian = bridge::Math::SVD(forward_jacobian).PseudoInverse();
   }
   else
   {
-    jacobian.set(Math::SVD(forward_jacobian.as_matrix()).PseudoInverse().data_block());
+    jacobian.set(bridge::Math::SVD(forward_jacobian.as_matrix()).PseudoInverse().data_block());
   }
 }
 

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.h
@@ -24,7 +24,7 @@
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector_fixed.h"
 #include "vnl/vnl_matrix_fixed.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  include "vnl/algo/vnl_svd.h" // transitional transitive include; dropped on ITK legacy removal
 #endif

--- a/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
+++ b/Modules/Filtering/DiffusionTensorImage/include/itkDiffusionTensor3DReconstructionImageFilter.hxx
@@ -25,7 +25,7 @@
 #include "itkImageMaskSpatialObject.h"
 #include "vnl/vnl_vector.h"
 #include "itkTotalProgressReporter.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 
 namespace itk
 {
@@ -435,7 +435,7 @@ DiffusionTensor3DReconstructionImageFilter<TReferenceImagePixelType,
     m_TensorBasis = m_BMatrix;
   }
 
-  m_TensorBasisInverse = itk::Math::SVD(m_TensorBasis.as_matrix()).PseudoInverse();
+  m_TensorBasisInverse = itk::bridge::Math::SVD(m_TensorBasis.as_matrix()).PseudoInverse();
 
   m_BMatrix.inplace_transpose();
 }

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldJacobianDeterminantFilter.hxx
@@ -27,7 +27,7 @@
 
 #include "itkMath.h"
 #include "itkPrintHelper.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 namespace itk
 {
@@ -251,7 +251,7 @@ DisplacementFieldJacobianDeterminantFilter<TInputImage, TRealType, TOutputImage>
   }
 
   // Return determinant of physical Jacobian:
-  return Math::Determinant(physicalGrad);
+  return bridge::Math::Determinant(physicalGrad);
 }
 
 template <typename TInputImage, typename TRealType, typename TOutputImage>

--- a/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
+++ b/Modules/Filtering/DisplacementField/include/itkDisplacementFieldTransform.hxx
@@ -21,7 +21,7 @@
 #include "itkVectorLinearInterpolateImageFunction.h"
 #include "itkImageToImageFilter.h"
 
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "itkCastImageFilter.h"
 #include <algorithm> // For min and max.
 #include "itkPrintHelper.h"
@@ -190,7 +190,7 @@ DisplacementFieldTransform<TParametersValueType, VDimension>::GetInverseJacobian
   {
     this->ComputeJacobianWithRespectToPositionInternal(index, jacobian, false);
     // rcond = 0 keeps every nonzero singular value (no truncation).
-    jacobian = itk::Math::SVD(jacobian, /*canonicalizeSigns=*/false).PseudoInverse(0);
+    jacobian = itk::bridge::Math::SVD(jacobian, /*canonicalizeSigns=*/false).PseudoInverse(0);
   }
   else
   {

--- a/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
+++ b/Modules/Filtering/ImageGradient/include/itkVectorGradientMagnitudeImageFilter.h
@@ -24,7 +24,7 @@
 #include "itkVector.h"
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_vector_fixed.h"
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 #include "itkMath.h"
 
 namespace itk
@@ -468,7 +468,7 @@ protected:
     }
 
     // Find the eigenvalues of g
-    const itk::SymmetricEigenDecomposition<TRealType> E(g);
+    const itk::bridge::SymmetricEigenDecomposition<TRealType> E(g);
 
     // Return the difference in length between the first two principle axes.
     // Note that other edge strength metrics may be appropriate here instead..

--- a/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineControlPointImageFilter.hxx
@@ -20,7 +20,7 @@
 
 
 #include "itkMath.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "itkImageDuplicator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
@@ -135,7 +135,7 @@ BSplineControlPointImageFilter<TInputImage, TOutputImage>::SetSplineOrder(ArrayT
 
       // rcond = 0 keeps every nonzero singular value (no truncation).
       this->m_RefinedLatticeCoefficients[i] =
-        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).PseudoInverse(0) * S).extract(2, S.cols());
+        (itk::bridge::Math::SVD(R, /*canonicalizeSigns=*/false).PseudoInverse(0) * S).extract(2, S.cols());
     }
   }
   this->Modified();

--- a/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
+++ b/Modules/Filtering/ImageGrid/include/itkBSplineScatteredDataPointSetToImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkCastImageFilter.h"
 #include "itkNumericTraits.h"
 #include "itkMath.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "itkPrintHelper.h"
 
 namespace itk
@@ -121,7 +121,7 @@ BSplineScatteredDataPointSetToImageFilter<TInputPointSet, TOutputImage>::SetSpli
 
       // rcond = 0 keeps every nonzero singular value (no truncation).
       this->m_RefinedLatticeCoefficients[i] =
-        (itk::Math::SVD(R, /*canonicalizeSigns=*/false).PseudoInverse(0) * S).extract(2, S.cols());
+        (itk::bridge::Math::SVD(R, /*canonicalizeSigns=*/false).PseudoInverse(0) * S).extract(2, S.cols());
     }
   }
   this->Modified();

--- a/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImageMomentsCalculator.hxx
@@ -18,8 +18,8 @@
 #ifndef itkImageMomentsCalculator_hxx
 #define itkImageMomentsCalculator_hxx
 
-#include "itkRealEigenDecomposition.h"
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeRealEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "vnl/vnl_diag_matrix.h"
 
@@ -147,8 +147,8 @@ ImageMomentsCalculator<TImage>::Compute()
   }
 
   // Compute principal moments and axes
-  const itk::SymmetricEigenDecomposition<double> eigen{ m_Cm.GetVnlMatrix().as_matrix() };
-  vnl_diag_matrix<double>                        pm{ eigen.D };
+  const itk::bridge::SymmetricEigenDecomposition<double> eigen{ m_Cm.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<double>                                pm{ eigen.D };
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     m_Pm[i] = pm(i) * m_M0;
@@ -157,9 +157,9 @@ ImageMomentsCalculator<TImage>::Compute()
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  const itk::RealEigenDecomposition<double> eigenrot{ m_Pa.GetVnlMatrix().as_matrix() };
-  const vnl_vector<std::complex<double>> &  eigenval = eigenrot.GetEigenvalues();
-  std::complex<double>                      det(1.0, 0.0);
+  const itk::bridge::RealEigenDecomposition<double> eigenrot{ m_Pa.GetVnlMatrix().as_matrix() };
+  const vnl_vector<std::complex<double>> &          eigenval = eigenrot.GetEigenvalues();
+  std::complex<double>                              det(1.0, 0.0);
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.h
@@ -35,7 +35,7 @@
 #include "itkImageShapeModelEstimatorBase.h"
 #include "itkConceptChecking.h"
 #include "itkImage.h"
-#include "itkGeneralizedEigenDecomposition.h"
+#include "itkBridgeGeneralizedEigenDecomposition.h"
 
 namespace itk
 {

--- a/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
+++ b/Modules/Filtering/ImageStatistics/include/itkImagePCAShapeModelEstimator.hxx
@@ -340,7 +340,7 @@ ImagePCAShapeModelEstimator<TInputImage, TOutputImage>::EstimatePCAShapeModelPar
 
   identityMatrix.set_identity();
 
-  const itk::GeneralizedEigenDecomposition<double> eigenVectors_eigenValues(m_InnerProduct, identityMatrix);
+  const itk::bridge::GeneralizedEigenDecomposition<double> eigenVectors_eigenValues(m_InnerProduct, identityMatrix);
 
   MatrixOfDoubleType eigenVectorsOfInnerProductMatrix = eigenVectors_eigenValues.GetEigenvectors();
 

--- a/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkShapeLabelMapFilter.hxx
@@ -25,8 +25,8 @@
 #include "itkConstantBoundaryCondition.h"
 #include "itkGeometryUtilities.h"
 #include "itkConnectedComponentAlgorithm.h"
-#include "itkRealEigenDecomposition.h"
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeRealEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 #include "itkMath.h"
 #include "itkLexicographicCompare.h"
 #include <deque>
@@ -307,9 +307,9 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
   }
 
   // Compute principal moments and axes
-  VectorType                                     principalMoments;
-  const itk::SymmetricEigenDecomposition<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
-  vnl_diag_matrix<double>                        pm = eigen.D;
+  VectorType                                             principalMoments;
+  const itk::bridge::SymmetricEigenDecomposition<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
+  vnl_diag_matrix<double>                                pm = eigen.D;
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     // Clamp to zero: near-zero negative eigenvalues from numerical precision cause FPE in std::pow(edet, ...)
@@ -319,9 +319,9 @@ ShapeLabelMapFilter<TImage, TLabelImage>::ThreadedProcessLabelObject(LabelObject
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  const itk::RealEigenDecomposition<double> eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
-  const vnl_vector<std::complex<double>> &  eigenval = eigenrot.GetEigenvalues();
-  std::complex<double>                      det(1.0, 0.0);
+  const itk::bridge::RealEigenDecomposition<double> eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
+  const vnl_vector<std::complex<double>> &          eigenval = eigenrot.GetEigenvalues();
+  std::complex<double>                              det(1.0, 0.0);
 
   for (unsigned int i = 0; i < ImageDimension; ++i)
   {

--- a/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
+++ b/Modules/Filtering/LabelMap/include/itkStatisticsLabelMapFilter.hxx
@@ -21,8 +21,8 @@
 #include "itkMath.h"
 #include "itkMinimumMaximumImageCalculator.h"
 #include "itkProgressReporter.h"
-#include "itkRealEigenDecomposition.h"
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeRealEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 #include "vnl/vnl_diag_matrix.h"
 
 namespace itk
@@ -229,8 +229,8 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
     }
 
     // Compute principal moments and axes
-    const itk::SymmetricEigenDecomposition<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
-    vnl_diag_matrix<double>                        pm{ eigen.D };
+    const itk::bridge::SymmetricEigenDecomposition<double> eigen{ centralMoments.GetVnlMatrix().as_matrix() };
+    vnl_diag_matrix<double>                                pm{ eigen.D };
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {
       //    principalMoments[i] = 4 * std::sqrt( pm(i,i) );
@@ -240,9 +240,9 @@ StatisticsLabelMapFilter<TImage, TFeatureImage>::ThreadedProcessLabelObject(Labe
 
     // Add a final reflection if needed for a proper rotation,
     // by multiplying the last row by the determinant
-    const itk::RealEigenDecomposition<double> eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
-    const vnl_vector<std::complex<double>> &  eigenval = eigenrot.GetEigenvalues();
-    std::complex<double>                      det(1.0, 0.0);
+    const itk::bridge::RealEigenDecomposition<double> eigenrot{ principalAxes.GetVnlMatrix().as_matrix() };
+    const vnl_vector<std::complex<double>> &          eigenval = eigenrot.GetEigenvalues();
+    std::complex<double>                              det(1.0, 0.0);
 
     for (unsigned int i = 0; i < ImageDimension; ++i)
     {

--- a/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
+++ b/Modules/Filtering/QuadEdgeMeshFiltering/include/itkQuadEdgeMeshDecimationQuadricElementHelper.h
@@ -19,7 +19,7 @@
 #define itkQuadEdgeMeshDecimationQuadricElementHelper_h
 
 #include "itkPoint.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "vnl/vnl_vector_fixed.h"
 #include "vnl/vnl_matrix.h"
 #include <algorithm>
@@ -100,7 +100,7 @@ public:
   ComputeError(const PointType & iP) const
   {
     //     ComputeAMatrixAndBVector();
-    const auto      svd = itk::Math::SVD(m_A, /*canonicalizeSigns=*/false);
+    const auto      svd = itk::bridge::Math::SVD(m_A, /*canonicalizeSigns=*/false);
     const CoordType wmax = svd.W[0];
     // Fold the absolute and relative singular-value tolerances into one rcond.
     const CoordType rcond =
@@ -149,7 +149,7 @@ public:
   {
     ComputeAMatrixAndBVector();
 
-    const auto      svd = itk::Math::SVD(m_A, /*canonicalizeSigns=*/false);
+    const auto      svd = itk::bridge::Math::SVD(m_A, /*canonicalizeSigns=*/false);
     const CoordType wmax = svd.W[0];
     const CoordType rcond =
       (wmax > CoordType{}) ? std::max(m_SVDAbsoluteThreshold / wmax, m_SVDRelativeThreshold) : m_SVDRelativeThreshold;

--- a/Modules/IO/IOFDF/src/itkFDFImageIO.cxx
+++ b/Modules/IO/IOFDF/src/itkFDFImageIO.cxx
@@ -17,7 +17,7 @@
  *=========================================================================*/
 #include "itkFDFImageIO.h"
 #include "itkFDFCommonImageIO.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 #include "itkByteSwapper.h"
 #include "itkRGBPixel.h"
@@ -176,7 +176,7 @@ FDFImageIO::ReadImageInformation()
         // direction matrix in the file is 3x3.
         // if direction matrix is degenerate, punt and set
         // directions to identity
-        if (itk::Math::Determinant(testDirections) == 0)
+        if (itk::bridge::Math::Determinant(testDirections) == 0)
         {
           for (unsigned int i = 0; i < numDim; i++)
           {

--- a/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
+++ b/Modules/IO/ImageBase/include/itkImageSeriesWriter.hxx
@@ -25,7 +25,7 @@
 #include "itkImageAlgorithm.h"
 #include "itkMetaDataObject.h"
 #include "itkArray.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 #include <cstdio>
 
 namespace itk
@@ -214,7 +214,7 @@ ImageSeriesWriter<TInputImage, TOutputImage>::WriteFiles()
   // therefore, replacing the orientation with an identity
   // is as arbitrary as any other choice.
   //
-  if (Math::Determinant(direction.GetVnlMatrix()) == 0.0)
+  if (bridge::Math::Determinant(direction.GetVnlMatrix()) == 0.0)
   {
     direction.SetIdentity();
   }

--- a/Modules/IO/MINC/src/itkMINCImageIO.cxx
+++ b/Modules/IO/MINC/src/itkMINCImageIO.cxx
@@ -22,7 +22,7 @@
 #include "vnl/vnl_vector.h"
 #include "itkMetaDataObject.h"
 #include "itkArray.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include "itkPrintHelper.h"
 #include "itkMakeUniqueForOverwrite.h"
 
@@ -983,7 +983,7 @@ MINCImageIO::WriteImageInformation()
     origin[i] = this->GetOrigin(i);
   }
 
-  const vnl_matrix<double> inverseDirectionCosines{ itk::Math::SVD(directionCosineMatrix).PseudoInverse() };
+  const vnl_matrix<double> inverseDirectionCosines{ itk::bridge::Math::SVD(directionCosineMatrix).PseudoInverse() };
   origin *= inverseDirectionCosines; // transform to minc convention
 
 

--- a/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
+++ b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx
@@ -21,7 +21,7 @@
 #include "itkMetaDataObject.h"
 #include "itkNumberToString.h"
 #include "itkAnatomicalOrientation.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #include <nifti1_io.h>
 #include "itkNiftiImageIOConfigurePrivate.h"
 #include "itkMakeUniqueForOverwrite.h"
@@ -1597,7 +1597,7 @@ IsAffine(const mat44 & nifti_mat)
     }
   }
 
-  const double condition = itk::Math::SVD(mat.as_matrix()).WellCondition();
+  const double condition = itk::bridge::Math::SVD(mat.as_matrix()).WellCondition();
   // Check matrix is invertible by testing condition number of inverse
   if (!(condition > std::numeric_limits<double>::epsilon()))
   {
@@ -1606,14 +1606,15 @@ IsAffine(const mat44 & nifti_mat)
 
   // Calculate the inverse and separate the inverse translation component
   // and the top 3x3 part of the inverse matrix
-  const vnl_matrix_fixed<double, 4, 4> inv4x4Matrix = itk::Math::SVD(mat.as_matrix()).PseudoInverse();
+  const vnl_matrix_fixed<double, 4, 4> inv4x4Matrix = itk::bridge::Math::SVD(mat.as_matrix()).PseudoInverse();
   const vnl_vector_fixed<double, 3>    inv4x4Translation(inv4x4Matrix[0][3], inv4x4Matrix[1][3], inv4x4Matrix[2][3]);
   const vnl_matrix_fixed<double, 3, 3> inv4x4Top3x3 = inv4x4Matrix.extract(3, 3, 0, 0);
 
   // Grab just the top 3x3 matrix
   const vnl_matrix_fixed<double, 3, 3> top3x3Matrix = mat.extract(3, 3, 0, 0);
-  const vnl_matrix_fixed<double, 3, 3> invTop3x3Matrix = itk::Math::SVD(top3x3Matrix.as_matrix()).PseudoInverse();
-  const vnl_vector_fixed<double, 3>    inv3x3Translation = -(invTop3x3Matrix * mat.get_column(3).extract(3));
+  const vnl_matrix_fixed<double, 3, 3> invTop3x3Matrix =
+    itk::bridge::Math::SVD(top3x3Matrix.as_matrix()).PseudoInverse();
+  const vnl_vector_fixed<double, 3> inv3x3Translation = -(invTop3x3Matrix * mat.get_column(3).extract(3));
 
   // Make sure we adhere to the conditions of a 4x4 invertible affine transform matrix
   const double     diff_matrix_array_one_norm = (inv4x4Top3x3 - invTop3x3Matrix).array_one_norm();
@@ -1809,8 +1810,8 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short dims, double spacing
             // extract rotation matrix
             const vnl_matrix_fixed<float, 3, 3> sform_3x3 = sform_as_matrix.extract(3, 3, 0, 0);
             const vnl_matrix_fixed<float, 3, 3> qform_3x3 = qform_as_matrix.extract(3, 3, 0, 0);
-            const auto                          sform_svd = itk::Math::SVD(sform_3x3);
-            const auto                          qform_svd = itk::Math::SVD(qform_3x3);
+            const auto                          sform_svd = itk::bridge::Math::SVD(sform_3x3);
+            const auto                          qform_svd = itk::bridge::Math::SVD(qform_3x3);
 
             // extract offset
             const vnl_vector<float> sform_offset{ sform_as_matrix.get_column(3).extract(3, 0) };
@@ -1848,7 +1849,7 @@ NiftiImageIO::SetImageIOOrientationFromNIfTI(unsigned short dims, double spacing
             mat[i][j] = double{ m_Holder->ptr->sto_xyz.m[i][j] };
           }
 
-        const auto svd = itk::Math::SVD(mat);
+        const auto svd = itk::bridge::Math::SVD(mat);
 
         if (svd.W.min_value() > 1e-8)
         {

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.h
@@ -24,8 +24,8 @@
 #include "itkSimpleDataObjectDecorator.h"
 #include <map>
 #include <vector>
-#include "itkSymmetricEigenDecomposition.h"
-#include "itkMathDeterminant.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
+#include "itkBridgeMathDeterminant.h"
 #include "itkMath.h"
 
 namespace itk
@@ -500,7 +500,8 @@ protected:
 
 private:
   bool
-  CalculateOrientedBoundingBoxVertices(itk::SymmetricEigenDecomposition<double> eig, LabelGeometry & m_LabelGeometry);
+  CalculateOrientedBoundingBoxVertices(itk::bridge::SymmetricEigenDecomposition<double> eig,
+                                       LabelGeometry &                                  m_LabelGeometry);
 
   bool m_CalculatePixelIndices{};
   bool m_CalculateOrientedBoundingBox{};

--- a/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
+++ b/Modules/Nonunit/Review/include/itkLabelGeometryImageFilter.hxx
@@ -43,7 +43,7 @@ namespace
 //
 template <unsigned int VDimension>
 inline vnl_matrix<double>
-CalculateRotationMatrix(const itk::SymmetricEigenDecomposition<double> & eig)
+CalculateRotationMatrix(const itk::bridge::SymmetricEigenDecomposition<double> & eig)
 {
   vnl_matrix<double> rotationMatrix(VDimension, VDimension, 0);
   for (unsigned int i = 0; i < VDimension; ++i)
@@ -62,7 +62,7 @@ CalculateRotationMatrix(const itk::SymmetricEigenDecomposition<double> & eig)
   float matrixDet = NAN;
   if constexpr (VDimension == 2 || VDimension == 3)
   {
-    matrixDet = static_cast<float>(itk::Math::Determinant(rotationMatrix));
+    matrixDet = static_cast<float>(itk::bridge::Math::Determinant(rotationMatrix));
   }
   else
   {
@@ -83,7 +83,7 @@ CalculateRotationMatrix(const itk::SymmetricEigenDecomposition<double> & eig)
 
 template <typename TLabelImage, typename TIntensityImage, typename TInputImage>
 inline bool
-CalculateOrientedImage(const itk::SymmetricEigenDecomposition<double> &                                 eig,
+CalculateOrientedImage(const itk::bridge::SymmetricEigenDecomposition<double> &                         eig,
                        typename LabelGeometryImageFilter<TLabelImage, TIntensityImage>::LabelGeometry & labelGeometry,
                        bool                                                                             useLabelImage,
                        const TInputImage *                                                              inputImage)
@@ -360,7 +360,7 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
     // Compute the eigenvalues/eigenvectors of the covariance matrix.
     // The result is stored in increasing eigenvalues with
     // corresponding eigenvectors.
-    itk::SymmetricEigenDecomposition<double> eig(normalizedSecondOrderCentralMoments);
+    itk::bridge::SymmetricEigenDecomposition<double> eig(normalizedSecondOrderCentralMoments);
 
     // Calculate the eigenvalues/eigenvectors
     VectorType eigenvalues(ImageDimension, 0);
@@ -416,8 +416,8 @@ LabelGeometryImageFilter<TLabelImage, TIntensityImage>::GenerateData()
 template <typename TLabelImage, typename TIntensityImage>
 bool
 LabelGeometryImageFilter<TLabelImage, TIntensityImage>::CalculateOrientedBoundingBoxVertices(
-  itk::SymmetricEigenDecomposition<double> eig,
-  LabelGeometry &                          labelGeometry)
+  itk::bridge::SymmetricEigenDecomposition<double> eig,
+  LabelGeometry &                                  labelGeometry)
 {
   // Calculate the oriented bounding box using the eigenvectors.
   // For each label, the pixels are rotated to the new coordinate

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.h
@@ -22,11 +22,11 @@
 #include "itkBooleanStdVector.h"
 #include "itkGradientDescentOptimizerv4.h"
 
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
 #endif
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 namespace itk
 {

--- a/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
+++ b/Modules/Numerics/Optimizersv4/include/itkQuasiNewtonOptimizerv4.hxx
@@ -386,7 +386,7 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::ComputeHessianAnd
 
   TInternalComputationValueType threshold = NumericTraits<TInternalComputationValueType>::epsilon();
 
-  if (itk::Math::Absolute(Math::Determinant(newHessian)) <= threshold)
+  if (itk::Math::Absolute(bridge::Math::Determinant(newHessian)) <= threshold)
   {
     return false;
   }
@@ -398,7 +398,9 @@ QuasiNewtonOptimizerv4Template<TInternalComputationValueType>::ComputeHessianAnd
       gradient[p] = this->m_Gradient[offset + p];
     }
 
-    const vnl_matrix<TInternalComputationValueType> hessianInverse{ itk::Math::SVD(newHessian).PseudoInverse() };
+    const vnl_matrix<TInternalComputationValueType> hessianInverse{
+      itk::bridge::Math::SVD(newHessian).PseudoInverse()
+    };
     // gradient is already negated
     const DerivativeType newtonStep{ hessianInverse * gradient };
     for (SizeValueType p = 0; p < numLocalPara; ++p)

--- a/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.hxx
+++ b/Modules/Numerics/PrincipalComponentsAnalysis/include/itkVectorFieldPCA.hxx
@@ -19,7 +19,7 @@
 #ifndef itkVectorFieldPCA_hxx
 #define itkVectorFieldPCA_hxx
 
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 #include "vnl/vnl_c_vector.h"
 #include "itkMath.h"
 
@@ -253,7 +253,7 @@ VectorFieldPCA<TVectorFieldElementType,
     }
   }
 
-  itk::SymmetricEigenDecomposition<TPCType> eigs(K0);
+  itk::bridge::SymmetricEigenDecomposition<TPCType> eigs(K0);
 
   m_PCAEigenValues = eigs.D.diagonal();
 

--- a/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkGaussianMembershipFunction.hxx
@@ -18,7 +18,7 @@
 #ifndef itkGaussianMembershipFunction_hxx
 #define itkGaussianMembershipFunction_hxx
 
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 namespace itk::Statistics
 {
@@ -102,11 +102,11 @@ GaussianMembershipFunction<TMeasurementVector>::SetCovariance(const CovarianceMa
   }
 
   // the inverse of the covariance matrix is first computed by SVD
-  const auto inv_cov = itk::Math::SVD(cov.GetVnlMatrix());
+  const auto inv_cov = itk::bridge::Math::SVD(cov.GetVnlMatrix());
 
   // Signed determinant of the covariance: a magnitude-only determinant is
   // always non-negative and cannot detect a non-positive-definite matrix.
-  const double det = itk::Math::Determinant(cov.GetVnlMatrix());
+  const double det = itk::bridge::Math::Determinant(cov.GetVnlMatrix());
 
   if (det <= 0.0)
   {

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMembershipFunction.hxx
@@ -21,7 +21,7 @@
 
 #include "vnl/vnl_vector.h"
 #include "vnl/vnl_matrix.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
 #endif
@@ -95,7 +95,7 @@ MahalanobisDistanceMembershipFunction<TVector>::SetCovariance(const CovarianceMa
   m_Covariance = cov;
 
   // the inverse of the covariance matrix is first computed by SVD
-  const auto inv_cov = itk::Math::SVD(m_Covariance.GetVnlMatrix());
+  const auto inv_cov = itk::bridge::Math::SVD(m_Covariance.GetVnlMatrix());
 
   // the determinant is then costless this way
   const double det = inv_cov.DeterminantMagnitude();

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.h
@@ -22,7 +22,7 @@
 #include "vnl/vnl_vector_ref.h"
 #include "vnl/vnl_transpose.h"
 #include "vnl/vnl_matrix.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 #if !defined(ITK_LEGACY_REMOVE) && !defined(ITK_FUTURE_LEGACY_REMOVE)
 #  include "vnl/algo/vnl_matrix_inverse.h" // transitional transitive include; dropped on ITK legacy removal
 #endif

--- a/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
+++ b/Modules/Numerics/Statistics/include/itkMahalanobisDistanceMetric.hxx
@@ -127,7 +127,7 @@ MahalanobisDistanceMetric<TVector>::CalculateInverseCovariance()
     }
     else
     {
-      m_InverseCovariance = itk::Math::SVD(m_Covariance).PseudoInverse();
+      m_InverseCovariance = itk::bridge::Math::SVD(m_Covariance).PseudoInverse();
     }
   } // end inverse calculations
 }

--- a/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
+++ b/Modules/Registration/Common/include/itkLandmarkBasedTransformInitializer.hxx
@@ -23,7 +23,7 @@
 #include "itkPrintHelper.h"
 
 #include <cmath>
-#include "itkQRDecomposition.h"
+#include "itkBridgeQRDecomposition.h"
 
 namespace itk
 {
@@ -314,7 +314,7 @@ LandmarkBasedTransformInitializer<TTransform, TFixedImage, TMovingImage>::Intern
   // [Solve Qa=C]
   // :: Solving code is from
   // https://www.itk.org/pipermail/insight-users/2008-December/028207.html
-  const vnl_matrix<ParametersValueType> transposeAffine = QRDecomposition<ParametersValueType>(Q).Solve(C);
+  const vnl_matrix<ParametersValueType> transposeAffine = bridge::QRDecomposition<ParametersValueType>(Q).Solve(C);
   vnl_matrix<ParametersValueType>       Affine = transposeAffine.transpose();
 
   const vnl_matrix<ParametersValueType> AffineRotation(Affine.get_n_columns(0, ImageDimension));

--- a/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration9.cxx
+++ b/Modules/Registration/Common/test/RegistrationITKv3/ImageRegistration9.cxx
@@ -65,7 +65,7 @@
 //  that will monitor the evolution of the registration process.
 //
 #include "itkCommand.h"
-#include "itkMathSVD.h"
+#include "itkBridgeMathSVD.h"
 class CommandIterationUpdate : public itk::Command
 {
 public:
@@ -105,7 +105,7 @@ public:
     p[0][1] = static_cast<double>(optimizer->GetCurrentPosition()[1]);
     p[1][0] = static_cast<double>(optimizer->GetCurrentPosition()[2]);
     p[1][1] = static_cast<double>(optimizer->GetCurrentPosition()[3]);
-    const auto         svd = itk::Math::SVD(p);
+    const auto         svd = itk::bridge::Math::SVD(p);
     vnl_matrix<double> r(2, 2);
     r = svd.U * svd.V.transpose();
     const double angle = std::asin(r[1][0]);
@@ -360,7 +360,7 @@ main(int argc, char * argv[])
   p[0][1] = static_cast<double>(finalParameters[1]);
   p[1][0] = static_cast<double>(finalParameters[2]);
   p[1][1] = static_cast<double>(finalParameters[3]);
-  const auto         svd = itk::Math::SVD(p);
+  const auto         svd = itk::bridge::Math::SVD(p);
   vnl_matrix<double> r(2, 2);
   r = svd.U * svd.V.transpose();
   const double angle = std::asin(r[1][0]);

--- a/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
+++ b/Modules/Segmentation/LevelSets/include/itkLevelSetFunction.hxx
@@ -18,7 +18,7 @@
 #ifndef itkLevelSetFunction_hxx
 #define itkLevelSetFunction_hxx
 
-#include "itkSymmetricEigenDecomposition.h"
+#include "itkBridgeSymmetricEigenDecomposition.h"
 
 namespace itk
 {
@@ -95,7 +95,7 @@ LevelSetFunction<TImageType>::ComputeMinimalCurvature(const NeighborhoodType & i
   }
 
   // Eigensystem
-  const itk::SymmetricEigenDecomposition<ScalarValueType> eig{ Curve.as_matrix() };
+  const itk::bridge::SymmetricEigenDecomposition<ScalarValueType> eig{ Curve.as_matrix() };
 
   constexpr ScalarValueType MIN_EIG{ NumericTraits<ScalarValueType>::min() };
   ScalarValueType           mincurve = itk::Math::Absolute(eig.get_eigenvalue(ImageDimension - 1));

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT ITK_FUTURE_LEGACY_REMOVE)
   )
 endif()
 
-# vnl_matrix_inverse is a thin vnl_svd wrapper deprecated for itk::Math::SVD;
+# vnl_matrix_inverse is a thin vnl_svd wrapper deprecated for itk::bridge::Math::SVD;
 # drop it and its template instantiations under ITK_FUTURE_LEGACY_REMOVE.
 if(NOT ITK_FUTURE_LEGACY_REMOVE)
   list(APPEND vnl_algo_sources
@@ -64,7 +64,7 @@ endif()
 
 # LINPACK-svdc-backed legacy: vnl_svd{,_economy,_fixed} and vnl_solve_qp (its
 # only client outside the deprecated eigensystem/matrix_inverse wrappers) are
-# the consumers of the netlib svdc engine. They are deprecated for itk::Math::SVD;
+# the consumers of the netlib svdc engine. They are deprecated for itk::bridge::Math::SVD;
 # drop them and their template instantiations once the APIs are removed, leaving
 # no svdc dependency to build.
 if(NOT ITK_FUTURE_LEGACY_REMOVE)

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_cholesky.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_cholesky.h
@@ -3,7 +3,7 @@
 #define vnl_cholesky_h_
 
 // ITK deprecation shim: the netlib LINPACK engine behind vnl_cholesky was
-// retired in favor of a native factor; itk::Math::SolveSymmetricPositiveDefinite
+// retired in favor of a native factor; itk::bridge::Math::SolveSymmetricPositiveDefinite
 // / CholeskyLowerTriangle (Eigen-backed) are the supported replacements. The
 // guard is active only when itkConfigure.h is reachable (an ITK consumer), so
 // ITK's own VXL build is unaffected.
@@ -11,14 +11,14 @@
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
 #    error \
-      "vnl/algo/vnl_cholesky.h is deprecated; migrate to itk::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkCholeskySolve.h, Eigen-backed)."
+      "vnl/algo/vnl_cholesky.h is deprecated; migrate to itk::bridge::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkBridgeCholeskySolve.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
 #      pragma message( \
-        "vnl/algo/vnl_cholesky.h is deprecated; migrate to itk::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkCholeskySolve.h, Eigen-backed).")
+        "vnl/algo/vnl_cholesky.h is deprecated; migrate to itk::bridge::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkBridgeCholeskySolve.h, Eigen-backed).")
 #    else
 #      warning \
-        "vnl/algo/vnl_cholesky.h is deprecated; migrate to itk::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkCholeskySolve.h, Eigen-backed)."
+        "vnl/algo/vnl_cholesky.h is deprecated; migrate to itk::bridge::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkBridgeCholeskySolve.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_determinant.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_determinant.h
@@ -5,12 +5,12 @@
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl_determinant was removed; migrate to itk::Math::Determinant (itkMathDeterminant.h, Eigen-backed)."
+#    error "vnl_determinant was removed; migrate to itk::bridge::Math::Determinant (itkBridgeMathDeterminant.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl_determinant is deprecated; migrate to itk::Math::Determinant.")
+#      pragma message("vnl_determinant is deprecated; migrate to itk::bridge::Math::Determinant.")
 #    else
-#      warning "vnl_determinant is deprecated; migrate to itk::Math::Determinant."
+#      warning "vnl_determinant is deprecated; migrate to itk::bridge::Math::Determinant."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_generalized_eigensystem.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_generalized_eigensystem.h
@@ -3,19 +3,19 @@
 #define vnl_generalized_eigensystem_h_
 
 // ITK deprecation shim: the netlib EISPACK engine (rsg) behind
-// vnl_generalized_eigensystem is being retired; itk::GeneralizedEigenDecomposition
+// vnl_generalized_eigensystem is being retired; itk::bridge::GeneralizedEigenDecomposition
 // (Eigen-backed) is the supported replacement. The guard is active only when
 // itkConfigure.h is reachable (an ITK consumer), so ITK's own VXL build is
 // unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::GeneralizedEigenDecomposition (itkGeneralizedEigenDecomposition.h, Eigen-backed)."
+#    error "vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::bridge::GeneralizedEigenDecomposition (itkBridgeGeneralizedEigenDecomposition.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::GeneralizedEigenDecomposition (itkGeneralizedEigenDecomposition.h, Eigen-backed).")
+#      pragma message("vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::bridge::GeneralizedEigenDecomposition (itkBridgeGeneralizedEigenDecomposition.h, Eigen-backed).")
 #    else
-#      warning "vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::GeneralizedEigenDecomposition (itkGeneralizedEigenDecomposition.h, Eigen-backed)."
+#      warning "vnl/algo/vnl_generalized_eigensystem.h is deprecated; migrate to itk::bridge::GeneralizedEigenDecomposition (itkBridgeGeneralizedEigenDecomposition.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_ldl_cholesky.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_ldl_cholesky.h
@@ -3,7 +3,7 @@
 #define vnl_ldl_cholesky_h_
 
 // ITK deprecation shim: the netlib LINPACK engine behind vnl_ldl_cholesky was
-// retired in favor of a native factor; itk::Math::SolveSymmetricPositiveDefinite
+// retired in favor of a native factor; itk::bridge::Math::SolveSymmetricPositiveDefinite
 // / CholeskyLowerTriangle (Eigen-backed) are the supported replacements. The
 // guard is active only when itkConfigure.h is reachable (an ITK consumer), so
 // ITK's own VXL build is unaffected.
@@ -11,14 +11,14 @@
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
 #    error \
-      "vnl/algo/vnl_ldl_cholesky.h is deprecated; migrate to itk::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkCholeskySolve.h, Eigen-backed)."
+      "vnl/algo/vnl_ldl_cholesky.h is deprecated; migrate to itk::bridge::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkBridgeCholeskySolve.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
 #      pragma message( \
-        "vnl/algo/vnl_ldl_cholesky.h is deprecated; migrate to itk::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkCholeskySolve.h, Eigen-backed).")
+        "vnl/algo/vnl_ldl_cholesky.h is deprecated; migrate to itk::bridge::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkBridgeCholeskySolve.h, Eigen-backed).")
 #    else
 #      warning \
-        "vnl/algo/vnl_ldl_cholesky.h is deprecated; migrate to itk::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkCholeskySolve.h, Eigen-backed)."
+        "vnl/algo/vnl_ldl_cholesky.h is deprecated; migrate to itk::bridge::Math::SolveSymmetricPositiveDefinite / CholeskyLowerTriangle (itkBridgeCholeskySolve.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_matrix_inverse.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_matrix_inverse.h
@@ -3,18 +3,18 @@
 #define vnl_matrix_inverse_h_
 
 // ITK deprecation shim: vnl_matrix_inverse is a thin vnl_svd wrapper being
-// retired; itk::Math::SVD (PseudoInverse/Solve, Eigen-backed) is the supported
+// retired; itk::bridge::Math::SVD (PseudoInverse/Solve, Eigen-backed) is the supported
 // replacement. The guard is active only when itkConfigure.h is reachable (an
 // ITK consumer), so ITK's own VXL build is unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl/algo/vnl_matrix_inverse.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+#    error "vnl/algo/vnl_matrix_inverse.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl/algo/vnl_matrix_inverse.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed).")
+#      pragma message("vnl/algo/vnl_matrix_inverse.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed).")
 #    else
-#      warning "vnl/algo/vnl_matrix_inverse.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+#      warning "vnl/algo/vnl_matrix_inverse.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_qr.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_qr.h
@@ -3,18 +3,18 @@
 #define vnl_qr_h_
 
 // ITK deprecation shim: the netlib LINPACK engine behind vnl_qr was retired in
-// favor of a native (BLAS-backed) factor; itk::QRDecomposition (Eigen-backed)
+// favor of a native (BLAS-backed) factor; itk::bridge::QRDecomposition (Eigen-backed)
 // is the supported replacement. The guard is active only when itkConfigure.h is
 // reachable (an ITK consumer), so ITK's own VXL build is unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl/algo/vnl_qr.h is deprecated; migrate to itk::QRDecomposition (itkQRDecomposition.h, Eigen-backed)."
+#    error "vnl/algo/vnl_qr.h is deprecated; migrate to itk::bridge::QRDecomposition (itkBridgeQRDecomposition.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl/algo/vnl_qr.h is deprecated; migrate to itk::QRDecomposition (itkQRDecomposition.h, Eigen-backed).")
+#      pragma message("vnl/algo/vnl_qr.h is deprecated; migrate to itk::bridge::QRDecomposition (itkBridgeQRDecomposition.h, Eigen-backed).")
 #    else
-#      warning "vnl/algo/vnl_qr.h is deprecated; migrate to itk::QRDecomposition (itkQRDecomposition.h, Eigen-backed)."
+#      warning "vnl/algo/vnl_qr.h is deprecated; migrate to itk::bridge::QRDecomposition (itkBridgeQRDecomposition.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_real_eigensystem.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_real_eigensystem.h
@@ -3,18 +3,18 @@
 #define vnl_real_eigensystem_h_
 
 // ITK deprecation shim: the netlib EISPACK engine (rg) behind vnl_real_eigensystem
-// is being retired; itk::RealEigenDecomposition (Eigen-backed) is the supported
+// is being retired; itk::bridge::RealEigenDecomposition (Eigen-backed) is the supported
 // replacement. The guard is active only when itkConfigure.h is reachable (an ITK
 // consumer), so ITK's own VXL build is unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::RealEigenDecomposition (itkRealEigenDecomposition.h, Eigen-backed)."
+#    error "vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::bridge::RealEigenDecomposition (itkBridgeRealEigenDecomposition.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::RealEigenDecomposition (itkRealEigenDecomposition.h, Eigen-backed).")
+#      pragma message("vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::bridge::RealEigenDecomposition (itkBridgeRealEigenDecomposition.h, Eigen-backed).")
 #    else
-#      warning "vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::RealEigenDecomposition (itkRealEigenDecomposition.h, Eigen-backed)."
+#      warning "vnl/algo/vnl_real_eigensystem.h is deprecated; migrate to itk::bridge::RealEigenDecomposition (itkBridgeRealEigenDecomposition.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_scatter_3x3.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_scatter_3x3.h
@@ -5,18 +5,18 @@
 // ITK deprecation shim: vnl_scatter_3x3 is the only non-deprecated client of the
 // netlib EISPACK symmetric eigensolver; it is deprecated alongside the
 // vnl_*_eigensystem classes so the dead engine can be retired. Build a 3x3
-// scatter matrix directly and use itk::SymmetricEigenDecomposition for its
+// scatter matrix directly and use itk::bridge::SymmetricEigenDecomposition for its
 // eigensystem. The guard is active only when itkConfigure.h is reachable (an ITK
 // consumer), so ITK's own VXL build is unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl/algo/vnl_scatter_3x3.h is deprecated; build a 3x3 scatter matrix directly and use itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed) for its eigensystem."
+#    error "vnl/algo/vnl_scatter_3x3.h is deprecated; build a 3x3 scatter matrix directly and use itk::bridge::SymmetricEigenDecomposition (itkBridgeSymmetricEigenDecomposition.h, Eigen-backed) for its eigensystem."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl/algo/vnl_scatter_3x3.h is deprecated; use itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h) for the eigensystem.")
+#      pragma message("vnl/algo/vnl_scatter_3x3.h is deprecated; use itk::bridge::SymmetricEigenDecomposition (itkBridgeSymmetricEigenDecomposition.h) for the eigensystem.")
 #    else
-#      warning "vnl/algo/vnl_scatter_3x3.h is deprecated; use itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h) for the eigensystem."
+#      warning "vnl/algo/vnl_scatter_3x3.h is deprecated; use itk::bridge::SymmetricEigenDecomposition (itkBridgeSymmetricEigenDecomposition.h) for the eigensystem."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_svd.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_svd.h
@@ -2,7 +2,7 @@
 #ifndef vnl_svd_h_
 #define vnl_svd_h_
 
-// ITK deprecation shim: the Eigen-backed itk::Math::SVD (itkMathSVD.h) is the
+// ITK deprecation shim: the Eigen-backed itk::bridge::Math::SVD (itkBridgeMathSVD.h) is the
 // supported replacement for vnl_svd, offering PseudoInverse()/Solve()/Rank()/
 // Recompose() with fixed- and runtime-sized overloads. The guard is active only
 // when itkConfigure.h is reachable (an ITK consumer), so ITK's own VXL build is
@@ -11,14 +11,14 @@
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
 #    error \
-      "vnl/algo/vnl_svd.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+      "vnl/algo/vnl_svd.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
 #      pragma message( \
-        "vnl/algo/vnl_svd.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed).")
+        "vnl/algo/vnl_svd.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed).")
 #    else
 #      warning \
-        "vnl/algo/vnl_svd.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+        "vnl/algo/vnl_svd.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_svd_economy.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_svd_economy.h
@@ -2,21 +2,21 @@
 #ifndef vnl_svd_economy_h_
 #define vnl_svd_economy_h_
 
-// ITK deprecation shim: the Eigen-backed itk::Math::SVD (itkMathSVD.h) is the
+// ITK deprecation shim: the Eigen-backed itk::bridge::Math::SVD (itkBridgeMathSVD.h) is the
 // supported replacement. The guard is active only when itkConfigure.h is
 // reachable (an ITK consumer); ITK's own VXL build is unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
 #    error \
-      "vnl/algo/vnl_svd_economy.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+      "vnl/algo/vnl_svd_economy.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
 #      pragma message( \
-        "vnl/algo/vnl_svd_economy.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed).")
+        "vnl/algo/vnl_svd_economy.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed).")
 #    else
 #      warning \
-        "vnl/algo/vnl_svd_economy.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+        "vnl/algo/vnl_svd_economy.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_svd_fixed.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_svd_fixed.h
@@ -2,7 +2,7 @@
 #ifndef vnl_svd_fixed_h_
 #define vnl_svd_fixed_h_
 
-// ITK deprecation shim: the Eigen-backed itk::Math::SVD (itkMathSVD.h) is the
+// ITK deprecation shim: the Eigen-backed itk::bridge::Math::SVD (itkBridgeMathSVD.h) is the
 // supported replacement (fixed-size square overload). The guard is active only
 // when itkConfigure.h is reachable (an ITK consumer); ITK's own VXL build is
 // unaffected.
@@ -10,14 +10,14 @@
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
 #    error \
-      "vnl/algo/vnl_svd_fixed.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+      "vnl/algo/vnl_svd_fixed.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
 #      pragma message( \
-        "vnl/algo/vnl_svd_fixed.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed).")
+        "vnl/algo/vnl_svd_fixed.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed).")
 #    else
 #      warning \
-        "vnl/algo/vnl_svd_fixed.h is deprecated; migrate to itk::Math::SVD (itkMathSVD.h, Eigen-backed)."
+        "vnl/algo/vnl_svd_fixed.h is deprecated; migrate to itk::bridge::Math::SVD (itkBridgeMathSVD.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_symmetric_eigensystem.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/algo/vnl_symmetric_eigensystem.h
@@ -3,19 +3,19 @@
 #define vnl_symmetric_eigensystem_h_
 
 // ITK deprecation shim: the netlib EISPACK engine (rs) behind
-// vnl_symmetric_eigensystem is being retired; itk::SymmetricEigenDecomposition
+// vnl_symmetric_eigensystem is being retired; itk::bridge::SymmetricEigenDecomposition
 // (Eigen-backed) is the supported replacement. The guard is active only when
 // itkConfigure.h is reachable (an ITK consumer), so ITK's own VXL build is
 // unaffected.
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed)."
+#    error "vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::bridge::SymmetricEigenDecomposition (itkBridgeSymmetricEigenDecomposition.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed).")
+#      pragma message("vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::bridge::SymmetricEigenDecomposition (itkBridgeSymmetricEigenDecomposition.h, Eigen-backed).")
 #    else
-#      warning "vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::SymmetricEigenDecomposition (itkSymmetricEigenDecomposition.h, Eigen-backed)."
+#      warning "vnl/algo/vnl_symmetric_eigensystem.h is deprecated; migrate to itk::bridge::SymmetricEigenDecomposition (itkBridgeSymmetricEigenDecomposition.h, Eigen-backed)."
 #    endif
 #  endif
 #endif

--- a/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_det.h
+++ b/Modules/ThirdParty/VNL/src/vxl/core/vnl/vnl_det.h
@@ -5,12 +5,12 @@
 #if __has_include(<itkConfigure.h>)
 #  include <itkConfigure.h>
 #  if defined(ITK_FUTURE_LEGACY_REMOVE) && !defined(ITK_LEGACY_TEST)
-#    error "vnl_det was removed; migrate to itk::Math::Determinant (itkMathDeterminant.h, Eigen-backed)."
+#    error "vnl_det was removed; migrate to itk::bridge::Math::Determinant (itkBridgeMathDeterminant.h, Eigen-backed)."
 #  elif defined(ITK_LEGACY_REMOVE) && !defined(ITK_LEGACY_SILENT) && !defined(ITK_LEGACY_TEST)
 #    if defined(_MSC_VER)
-#      pragma message("vnl_det is deprecated; migrate to itk::Math::Determinant.")
+#      pragma message("vnl_det is deprecated; migrate to itk::bridge::Math::Determinant.")
 #    else
-#      warning "vnl_det is deprecated; migrate to itk::Math::Determinant."
+#      warning "vnl_det is deprecated; migrate to itk::bridge::Math::Determinant."
 #    endif
 #  endif
 #endif

--- a/Modules/Video/Core/include/itkVideoStream.hxx
+++ b/Modules/Video/Core/include/itkVideoStream.hxx
@@ -18,7 +18,7 @@
 #ifndef itkVideoStream_hxx
 #define itkVideoStream_hxx
 
-#include "itkMathDeterminant.h"
+#include "itkBridgeMathDeterminant.h"
 
 
 namespace itk
@@ -176,7 +176,7 @@ void
 VideoStream<TFrameType>::SetFrameDirection(SizeValueType frameNumber, typename TFrameType::DirectionType direction)
 {
   // Determinant is non-zero
-  if (itk::Math::Absolute(Math::Determinant(direction.GetVnlMatrix())) <= itk::Math::eps)
+  if (itk::Math::Absolute(bridge::Math::Determinant(direction.GetVnlMatrix())) <= itk::Math::eps)
   {
     itkExceptionMacro("Bad direction, determinant is 0. Direction is " << direction);
   }


### PR DESCRIPTION
Moves the Eigen-backed convenience numerics from `itk::Math` / `itk::` into
`itk::bridge`, and renames their headers to `itkBridge*.h`, so the support tier
is visible in the spelling. Implements #6620.

**ITK 6 is not released, so no deprecation window is owed** — this is the last
point at which the move is free.

The namespace names what the layer is *for*: **bridging call sites off the
deprecated VNL algorithms** without the caller first having to learn Eigen's
API. It is a migration aid, not a numerics library ITK undertakes to maintain
or validate — **downstream code should prefer depending on Eigen directly**.
That contract is now written down in three places (see below).

<details>
<summary>The support contract, and where it is documented</summary>

`itk::bridge` holds convenience wrappers over third-party numerical backends,
provided to ease the *initial* burden of migrating away from VNL. A `vnl_svd`
call site becomes `itk::bridge::Math::SVD` as a mechanical, low-risk edit.

They are **not part of the core ITK mission to maintain or validate**:

- API and ABI may change, or be removed, without the deprecation cycle core
  ITK API changes receive.
- Numerical behavior is the backend's. ITK does not independently validate
  accuracy, conditioning, or convergence, and does not guarantee bit-for-bit
  stability across backend versions.
- Coverage extends only to what ITK's own migration required; missing
  functionality will not necessarily be added.

**Downstream users should prefer Eigen (or another numerical library)
directly** rather than depending on the API/ABI of these wrappers. Using
`itk::bridge` as a transitional step while retiring VNL is reasonable;
treating it as a permanent dependency is not.

Documented at three levels, so the warning is reachable from wherever a reader
starts:

| Where | What |
|---|---|
| `Documentation/Doxygen/BridgeNumerics.dox` | Canonical statement — a `\page` plus a `\namespace itk::bridge` block |
| Each of the 10 headers | 5-line `\file` block pointing at that page |
| ITK 6 migration guide | Prose section, for downstream readers who never open a header |

</details>

<details>
<summary>Why — the concern this addresses</summary>

VNL was vendored as an implementation detail, but its symbols reached ITK's
public surface. ITK thereby became the de-facto maintainer and compatibility
guarantor of general linear algebra for two decades, and could not change its
numerics backend without a deprecation campaign.

Every `itk::Math::*` wrapper added by the VNL→Eigen migration is currently
indistinguishable — in namespace, header location, and implied support level —
from core contract API like `itk::Image`. Downstream adopts them as freely as
it adopted `vnl_svd`. Naming the tier, and stating its contract in the
documentation, is what prevents the same trap closing a second time.

</details>

<details>
<summary>Scope — 10 headers</summary>

`itkMathSVD.h`, `itkMathLDLT.h`, `itkMathDeterminant.h`, `itkCholeskySolve.h`,
`itkQRDecomposition.h`, `itkSymmetricEigenDecomposition.h`,
`itkRealEigenDecomposition.h`, `itkGeneralizedEigenDecomposition.h`, and the
two `itk::detail` helpers — each gaining an `itkBridge` prefix.

`itkCholeskySolve.h` is included beyond the list in #6620: it is Eigen-backed,
lives in `itk::Math`, and is one of "the LU decomposition and the other matrix
solving methods" @blowekamp scoped. Two test consumers.

Out of scope, per @dzenanz: `itk::Math::abs`, the `itkMath.h` constants, and
other long-standing utilities — core contract already.

The capability macro becomes `ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC`.
GoogleTest suite names gain the same prefix.

</details>

<details>
<summary>Fixes the VNL deprecation diagnostics (@greptileai P1)</summary>

Greptile found that the VNL deprecation messages still named the pre-move
`itk::Math::SVD` / `itkMathSVD.h`, so a consumer following the emitted
guidance could not compile — it verified this by building an external
consumer. Correct, and it was a live defect on the previous head rather than
one introduced here.

The actual extent was larger than the four files reported. **13 VNL headers
plus 2 `CMakeLists.txt` comments** carried stale spellings across the whole
family, not just SVD:

`vnl_svd.h`, `vnl_svd_fixed.h`, `vnl_svd_economy.h`, `vnl_matrix_inverse.h`,
`vnl_cholesky.h`, `vnl_ldl_cholesky.h`, `vnl_determinant.h`, `vnl_det.h`,
`vnl_qr.h`, `vnl_real_eigensystem.h`, `vnl_symmetric_eigensystem.h`,
`vnl_generalized_eigensystem.h`, `vnl_scatter_3x3.h`, plus
`algo/CMakeLists.txt`.

All now name the `itk::bridge` spellings.

</details>

<details>
<summary>Why no separate CommonMath module</summary>

A `Modules/Core/CommonMath` module was evaluated and rejected: it cannot be
built without a dependency cycle.

- `itkMatrix.h` includes `itkBridgeMathSVD.h` and `itkBridgeMathDeterminant.h`
  for `GetInverse()`; `itkImageBase.hxx` and `itkVersor.hxx` call
  `Math::Determinant`. So those headers must sit at-or-below ITKCommon.
- `itkBridgeMathLDLT.h` includes `itkMatrix.h`, `itkArray.h`, `itkArray2D.h`
  and `itkVector.h`. So it must sit at-or-above ITKCommon.

The surface straddles ITKCommon in both directions.

Worth noting for the tiering discussion: **ITK core depends on these APIs.**
`itk::Matrix::GetInverse()` needs them. The tier can describe the public
spelling; it cannot describe the dependency.

</details>

<details>
<summary>Why the headers are renamed, not just the namespace</summary>

Downstream feature-detects with `__has_include(<itkMathSVD.h>)`. If only the
namespace moved, that probe would still succeed while the symbol inside had
changed — the guard would report the wrong answer and the build would fail at
the call site instead. Renaming makes the probe truthful: the old path
genuinely disappears, so `#elif` fallbacks work as written.

</details>

<details>
<summary>Test plan — forest build</summary>

Validated in the ITK forest testbed (ITK + downstream consumers built against
one locally built ITK):

| Repo | Build | Tests | Guard path |
|---|---|---|---|
| ITK | all 1633 targets, 0 errors | 75/75 tier GTests | n/a |
| ANTs | 0 errors | — | objects reference the tiered namespace; 0 reference the old symbol |
| BRAINSTools | 0 errors | — | same |

The guard column is the one that matters: a rename like this can compile
cleanly while silently dropping downstream back to `vnl_svd`. Symbol
inspection confirms both consumers kept the Eigen path.

`pre-commit run --all-files` clean, re-run after the rebase onto current main.

</details>

<details>
<summary>⚠ ccache can serve stale objects across this rename</summary>

If you build a downstream project incrementally with a warm ccache, you may
see link errors naming the **old** `itk::Math::detail::RectangularSVDEigen`.

ccache direct mode keys an object on a manifest of the files it included. When
a header is *renamed* rather than edited, a compile can hash-hit an entry
recorded against the vanished include set and return an object compiled
against headers that no longer exist. `ninja -t clean` does not help — it
deletes the object and ccache immediately re-serves the stale one.

`CCACHE_RECACHE=1` for the downstream build fixes it. CI does cold builds, so
this never appears there — it only affects local evaluation.

</details>

<!--
provenance: claude-code session 2026-08-19, renamed unsupported -> bridge 2026-08-20
issue: 6620
naming: settled on itk::bridge (was itk::unsupported); names the layer's purpose
  - bridging off VNL - rather than only its support status
scope: 10 headers + capability macro + GTest suite names; 19 renames
docs_added: Documentation/Doxygen/BridgeNumerics.dox (page + \namespace block),
  \file block in each of the 10 headers, migration-guide prose section
greptile_p1_fixed: VNL deprecation diagnostics named pre-move spellings; extent was
  13 VNL headers + 2 CMakeLists comments, not the 4 files reported
rejected_alternative: Modules/Core/CommonMath module - ITKCommon dependency cycle
scope_extension: itkCholeskySolve.h added beyond the #6620 list
forest: build_forest-itk-main; ITK 1633 targets green, 75/75 tier GTests,
  ANTs + BRAINSTools green with guard-path symbol verification
downstream_prs: ANTs #2019 and BRAINSTools #623 WIP drafts, must not merge until
  this lands; both still reference the itk::unsupported spelling and need updating
branch_name: still enh-tier-unsupported-math-6620 - renaming would close the PR
unrelated_defect_found: ITKTargets.cmake exports ITK::ITKNrrdIO with
  $<LINK_ONLY:Threads::Threads> but ITKConfig.cmake never find_package(Threads);
  breaks ANTs configure. Not fixed here - needs its own issue.
-->
