### PR TITLE
COMP: Resolve Python ST/IT/OT from the wrapped C types

### DIFF
--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -22,6 +22,8 @@ import importlib.util
 from typing import Self, TypeAlias, Union, TYPE_CHECKING
 import os
 
+from itkConfig import ITK_GLOBAL_WRAPPING_TYPE_ALIASES
+
 try:
     from numpy.typing import ArrayLike
 except ImportError:
@@ -157,10 +159,19 @@ int16_t = SS
 int32_t = SI
 int64_t = SL if SL.dtype.itemsize == 8 else SLL
 
-# Aliases for SizeValueType, IdentifierType, OffsetType
-ST = uint64_t
-IT = uint64_t
-OT = int64_t
+# Aliases for SizeValueType, IdentifierType, OffsetType, resolved from the
+# C types the wrapping actually instantiated rather than re-derived here.
+_c_type_by_mangled_name: dict[str, itkCType] = {
+    "UL": UL,
+    "ULL": ULL,
+    "SL": SL,
+    "SLL": SLL,
+}
+ST = _c_type_by_mangled_name[ITK_GLOBAL_WRAPPING_TYPE_ALIASES["ST"]]
+IT = _c_type_by_mangled_name[ITK_GLOBAL_WRAPPING_TYPE_ALIASES["IT"]]
+OT = _c_type_by_mangled_name[ITK_GLOBAL_WRAPPING_TYPE_ALIASES["OT"]]
+del _c_type_by_mangled_name
+del ITK_GLOBAL_WRAPPING_TYPE_ALIASES
 
 # Type aliases to avoid expensive import, circular references. Use with forward references.
 if TYPE_CHECKING:

--- a/Wrapping/Generators/Python/itkConfig.template.in.py
+++ b/Wrapping/Generators/Python/itkConfig.template.in.py
@@ -194,6 +194,14 @@ ITK_GLOBAL_WRAPPING_BUILD_OPTIONS: dict[str, list[str]] = {
     "ITK_WRAP_PYTHON_COMPLEX_REAL": "@ITK_WRAP_PYTHON_COMPLEX_REAL@".split(";"),
 }
 
+# Mangled names of the C types the wrapping instantiated for itk::SizeValueType,
+# itk::IdentifierType and itk::OffsetValueType, from Wrapping/WrapBasicTypes.cmake.
+ITK_GLOBAL_WRAPPING_TYPE_ALIASES: dict[str, str] = {
+    "ST": "@ITKM_ST@",
+    "IT": "@ITKM_IT@",
+    "OT": "@ITKM_OT@",
+}
+
 (swig_lib, swig_py, config_py, doxygen_root, path) = _initialize()
 del _initialize
 del warnings


### PR DESCRIPTION
`itk.IT` did not agree with the identifier type the wrapping actually instantiated: `Wrapping/WrapBasicTypes.cmake` selects `unsigned long long` only when **both** `WIN32` and `ITK_USE_64BITS_IDS` hold, while `itk/support/types.py` derived the alias independently. On Windows with `ITK_USE_64BITS_IDS=OFF` the two disagreed, so `itk.VectorContainer[itk.IT, ...]` named an instantiation that does not exist.

Export `ITKM_ST` / `ITKM_IT` / `ITKM_OT` through `itkConfig` and resolve the Python aliases from there, so both sides come from one definition.

Surfaced while answering https://github.com/InsightSoftwareConsortium/ITK/pull/6769#issuecomment-5354359248 — that PR wants to use `itk.IT` as `IdentifierType`, which needs this first.

<details>
<summary>The disagreement</summary>

`Wrapping/WrapBasicTypes.cmake:221`:

```cmake
if(WIN32 AND ITK_USE_64BITS_IDS)
  set(ITKM_IT ${ITKM_ULL})
else()
  set(ITKM_IT ${ITKM_UL})
endif()
```

`Wrapping/Generators/Python/itk/support/types.py`, after #6767:

```python
ST = uint64_t
IT = uint64_t
OT = int64_t
```

On Windows with `ITK_USE_64BITS_IDS=OFF`, CMake instantiates `unsigned long` (32-bit there) while Python reports a 64-bit type. Elsewhere the two happen to coincide, which is why this has gone unnoticed.

`ITKM_IT` expands to the literal `"UL"` / `"ULL"`, which is exactly the `itkCType` short name, so the CMake value maps to the Python object by direct lookup with no translation table to drift.

</details>

<details>
<summary>Local verification</summary>

macOS, `ITK_WRAP_PYTHON=ON`, `Module_ITKVtkGlue=OFF` (incompatible with `ITK_USE_PYTHON_LIMITED_API`). Build exit 0, 4610/4610 targets, zero errors.

```
aliases from CMake: {'ST': 'UL', 'IT': 'UL', 'OT': 'SL'}
ST unsigned long | IT unsigned long | OT signed long
IT == Mesh PointDataContainer identifier: unsigned long
VectorContainer[itk.IT, itk.Array.D] instantiation exists: True
```

`ctest -R "[Pp]ython"` -> **176/176 passed**, including `PythonTypeTest`, `PythonVerifyTTypeAPIConsistency` and `PythonTemplateTest`.

**Not verifiable locally:** the defect case is `WIN32 + ITK_USE_64BITS_IDS=OFF`. Every build available to me resolves `ITKM_IT=UL`, so what is shown above is that the new path reproduces the correct answer where the old path was also right. Windows CI is the first real executor for the case this targets.

</details>

<!--
provenance: claude-code session 2026-08-20
branch: comp-itk-identifier-type-from-cmake off upstream/main da04f0bf32c
files: Wrapping/Generators/Python/itkConfig.template.in.py (+ITK_GLOBAL_WRAPPING_TYPE_ALIASES),
       Wrapping/Generators/Python/itk/support/types.py (ST/IT/OT resolved via that dict)
import_safety: itk/__init__.py:27 imports itkConfig before itk.support.types; itkConfig imports nothing from itk -> no cycle
related: PR #6769 (wants itk.IT as IdentifierType), PR #6767 (changed types.py to IT = uint64_t)
-->
