### PR TITLE
ENH: Add regression test for NIfTI scl_slope precision (#6750)

### DIFF
--- a/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
+++ b/Modules/IO/NIFTI/test/itkNiftiImageIOGTest.cxx
@@ -22,6 +22,7 @@
 #include "itkNiftiImageIO.h"
 #include "itkVectorImage.h"
 #include "itkImageRegionIterator.h"
+#include "itkImageRegionConstIterator.h"
 
 #include <array>
 #include <cmath>
@@ -141,6 +142,68 @@ TEST(NiftiImageIO, RescaleAppliesToEveryComponentOfEveryVoxel)
       EXPECT_FLOAT_EQ(rescaled.Get()[c], original.Get()[c] * slope + intercept);
     }
   }
+}
+
+// Issue #6750: Ensure that scl_slope can make a read/write round trip and
+// be recovered with full precision. Regression test for Issue #6003.
+TEST(NiftiImageIO, SclSlopeInterceptRoundTripsAtFullPrecision)
+{
+  using WriteImageType = itk::Image<unsigned char, 3>;
+  constexpr float slope = 1.0 / 3.0;
+  constexpr float intercept = 5.333333;
+
+  const std::string path = OutputPath("nifti_scl_slope_precision.nii");
+
+  auto                     writeImage = WriteImageType::New();
+  WriteImageType::SizeType size;
+  size.Fill(10);
+  WriteImageType::IndexType index;
+  index.Fill(0);
+
+  WriteImageType::RegionType region;
+  region.SetIndex(index);
+  region.SetSize(size);
+
+  writeImage->SetRegions(region);
+  writeImage->Allocate();
+
+  writeImage->FillBuffer(231);
+
+  auto writer = itk::ImageFileWriter<WriteImageType>::New();
+  auto writerIo = itk::NiftiImageIO::New();
+  writerIo->SetRescaleSlope(slope);
+  writerIo->SetRescaleIntercept(intercept);
+  writer->SetImageIO(writerIo);
+  writer->SetInput(writeImage);
+  writer->SetFileName(path);
+  ASSERT_NO_THROW(writer->Update());
+
+  using ReadImageType = itk::Image<float, 3>;
+  auto reader = itk::ImageFileReader<ReadImageType>::New();
+  auto readerIo = itk::NiftiImageIO::New();
+  reader->SetImageIO(readerIo);
+  reader->SetFileName(path);
+  ASSERT_NO_THROW(reader->Update());
+
+  ReadImageType::Pointer readImage = reader->GetOutput();
+
+  using IteratorType = itk::ImageRegionConstIterator<ReadImageType>;
+  IteratorType it(readImage, readImage->GetLargestPossibleRegion());
+
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it)
+  {
+    ASSERT_EQ(it.Get(), static_cast<float>(231) * slope + intercept);
+  }
+
+  const auto & metadata = reader->GetOutput()->GetMetaDataDictionary();
+
+  std::string slopeString;
+  ASSERT_TRUE(itk::ExposeMetaData<std::string>(metadata, "scl_slope", slopeString));
+  EXPECT_EQ(std::stof(slopeString), slope);
+
+  std::string interceptString;
+  ASSERT_TRUE(itk::ExposeMetaData<std::string>(metadata, "scl_inter", interceptString));
+  EXPECT_EQ(std::stof(interceptString), intercept);
 }
 
 TEST(NiftiImageIO, RASConversionRejectsNonThreeComponentVector)


### PR DESCRIPTION
<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->


<!-- See the CONTRIBUTING (CONTRIBUTING.md) guide. Specifically:

Start ITK commit messages with a standard prefix (and a space):

 * BUG: fix for runtime crash or incorrect result
 * COMP: compiler error or warning fix
 * DOC: documentation change
 * ENH: new functionality
 * PERF: performance improvement
 * STYLE: no logic impact (indentation, comments)
 * WIP: Work In Progress not ready for merge

Provide a short, meaningful message that describes the change you made.

When the PR is based on a single commit, the commit message is usually left as
the PR message.

A reference to a related issue or pull request (https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests)
in your repository. You can automatically
close a related issues using keywords (https://help.github.com/articles/closing-issues-using-keywords/)

@mentions (https://help.github.com/articles/basic-writing-and-formatting-syntax/#mentioning-people-and-teams)
of the person or team responsible for reviewing proposed changes. -->

Issue #6750 requested a regression test for `scl_slope` survival through a NIfTI write/read round trip. This guards the precision fix introduced by PR #6003. Followed @hjmjohnson's proposed test by setting `scl_slope` to the `float` value `1.0 / 3.0` and verifying exact equivalence after the write/read round trip.

Used `float` instead of `double` as NIfTI1 stores `scl_slope` as `float`.

## PR Checklist
- [X] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [X] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [X] Added test (or behavior not changed)
- [X] Updated API documentation (or API not changed)
- [X] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [X] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [X] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)

Refer to the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) for
further development details if necessary.

<!-- **Thanks for contributing to ITK!** -->
