### PR TITLE
COMP: Declare NrrdIO's Threads dependency in ITK's exported config

### DIFF
--- a/Modules/ThirdParty/NrrdIO/CMakeLists.txt
+++ b/Modules/ThirdParty/NrrdIO/CMakeLists.txt
@@ -12,4 +12,23 @@ set(
   WINDOWS_EXPORT_ALL_SYMBOLS
   FALSE
 )
+
+if(UNIX)
+  # ITKNrrdIO's exported link interface names Threads::Threads.
+  set(
+    ITKNrrdIO_EXPORT_CODE_INSTALL
+    "
+find_package(Threads REQUIRED)
+"
+  )
+  set(
+    ITKNrrdIO_EXPORT_CODE_BUILD
+    "
+if(NOT ITK_BINARY_DIR)
+  find_package(Threads REQUIRED)
+endif()
+"
+  )
+endif()
+
 itk_module_impl()


### PR DESCRIPTION
`ITK::ITKNrrdIO`'s exported interface names `Threads::Threads`, which nothing resolves for consumers, so `find_package(ITK)` fails at generate time for UNIX consumers linking an ITK target. `ITKIONRRD` is a default module, so `main` is affected.

<details>
<summary>Root cause</summary>

#6695 added to `Modules/ThirdParty/NrrdIO/src/CMakeLists.txt`:

```cmake
find_package(Threads REQUIRED)
list(APPEND NRRDIO_COMPRESSION_LIBRARIES Threads::Threads)
```

which reaches `ITKTargets.cmake` as `$<LINK_ONLY:Threads::Threads>` with no consumer-side declaration. `main` only; `release-5.4` is unaffected.

`ITKNrrdIO_EXPORT_CODE_{BUILD,INSTALL}` re-runs `find_package(Threads)` on the consumer side, as `ITKTBB` does for the same dependency. The variables must be set before `itk_module_impl()` in the module's top-level `CMakeLists.txt`; `add_subdirectory(src)` opens a new scope.

</details>

<details>
<summary>Local validation</summary>

Isolated consumer project (posted in a comment, two directories: `UseITK` + `ITK_LIBRARIES`, and `ITK_INTERFACE_LIBRARIES` without `UseITK`):

| ITK under test | legacy | modern |
|---|---|---|
| `main` | FAIL | FAIL |
| this branch | PASS | PASS |

Both styles fail identically without the change: `INTERFACE_LINK_LIBRARIES` on an imported target resolves at generate time once anything links `ITK::ITKNrrdIO` transitively. A consumer that calls `find_package(ITK)` without linking a target passes either way, which matters for any regression test added for this.

Build tree and install tree, macOS arm64, `-DITK_BUILD_DEFAULT_MODULES=OFF -DModule_ITKIONRRD=ON -DBUILD_TESTING=ON`:

```
configure  ok
build      ok
ctest      100% tests passed out of 230
install    ok

install-tree consumer probe   PASS legacy  PASS modern
build-tree   consumer probe   PASS legacy  PASS modern
```

</details>

<details>
<summary>Audit of other externally-namespaced targets in ITKTargets.cmake</summary>

An earlier revision of this description listed `DCMTK::*`, `GTest::gtest` and `MPI::MPI_C` as latent leaks of the same class. Each was checked against a real build tree; that was wrong.

| target | finding |
|---|---|
| `Threads::Threads` (via `ITKNrrdIO`) | Live breakage, fixed here |
| `DCMTK::*` (19) | `ITKDCMTK` sets export code on both paths |
| `GTest::*` | Vendored path exports them as imported targets; GoogleTest is build-tree-only by design |
| `VTK::*` (10, via `ITKVtkGlue`) | Export code present, both variants |
| `MPI::MPI_C`, vendored-HDF5 `Threads::Threads` | Unreachable: inside genexes vendored HDF5 cannot make true in an ITK build |

</details>

<details>
<summary>AI assistance</summary>

- Role: root-cause analysis, consumer-probe construction, audit of the other exported targets
- Evidence of local testing: the table above; `pre-commit run --all-files` clean on the pushed HEAD

</details>

<!--
found_by: forest sweep, ITK main 9f127d9231 + ANTs main d92f933e (macOS arm64)
introducer: PR #6695, Modules/ThirdParty/NrrdIO/src/CMakeLists.txt:20
pattern_source: Modules/ThirdParty/TBB/CMakeLists.txt
superseded_approach: find_dependency(Threads) in CMake/ITKConfig.cmake.in (rev 452cf941b23)
export_code_census_on_main: 17 modules set _EXPORT_CODE_BUILD, 16 set both
closed_followups: #6777 (GoogleTest install export - build-tree-only by design), #6778 (blanket enablement - TEST_DEPENDS is the correct mechanism)
open_followup: 7 modules call CreateGoogleTestDriver without TEST_DEPENDS ITKGoogleTest
-->
