### PR TITLE
COMP: Emit GoogleTest export code for install-tree consumers

### DIFF
--- a/Modules/ThirdParty/GoogleTest/CMakeLists.txt
+++ b/Modules/ThirdParty/GoogleTest/CMakeLists.txt
@@ -13,6 +13,13 @@ if(NOT ITK_BINARY_DIR)
 endif()
 "
     )
+    set(
+      ITKGoogleTest_EXPORT_CODE_INSTALL
+      "
+set(GTEST_ROOT \"${GTEST_ROOT}\")
+find_package(GTest REQUIRED)
+"
+    )
   endif()
 endif()
 


### PR DESCRIPTION
Follow-on to #6776, same class of defect: a module whose consumer-side dependency is not declared in what ITK exports. `ITKGoogleTest` set only `ITKGoogleTest_EXPORT_CODE_BUILD`, so the module file installed with ITK carried no GTest resolution, and a project built against an *installed* ITK configured with `ITK_USE_SYSTEM_GOOGLETEST=ON` failed at `CreateGoogleTestDriver` with `GTest::gtest ... but the target was not found`.

It is the only asymmetric module: on `main`, seventeen modules declare export code and the other sixteen set both `_BUILD` and `_INSTALL`.

<details>
<summary>Red/green, verified at configure time</summary>

`-DITK_BUILD_DEFAULT_MODULES=ON -DBUILD_TESTING=ON -DITK_USE_SYSTEM_GOOGLETEST=ON`, comparing the generated install-tree module file `Modules/ThirdParty/GoogleTest/CMakeFiles/ITKGoogleTest.cmake`:

| | tail of the install-tree `ITKGoogleTest.cmake` |
|---|---|
| before | *(nothing after the `set(ITKGoogleTest_FACTORY_NAMES "")` block)* |
| after | `set(GTEST_ROOT "")` then `find_package(GTest REQUIRED)` |

The build-tree variant already carried the equivalent block and is unchanged. Both variants are written at configure time, so this needs no build or install to check.

</details>

<details>
<summary>Audit of the other targets named in #6776 — no change needed</summary>

#6776's description claimed `DCMTK::*`, `GTest::gtest` and `MPI::MPI_C` were latent leaks of the same kind. Each was checked against real build trees; that claim was wrong, and #6776's body has been corrected.

| target | finding |
|---|---|
| `DCMTK::*` (19) | Already handled. `ITKDCMTK` sets export code on both the system and FetchContent paths. An external project linking `ITK::ITKIODCMTK` against a `Module_ITKIODCMTK=ON` build configures cleanly. |
| `GTest::gtest`, `GTest::gtest_main` | Self-contained on the vendored path — ITK exports them as real imported targets in `ITKTargets.cmake`. The install-tree gap this PR fixes is on the *system*-GTest path, where they are absent from the export instead. |
| `VTK::*` (10, via `ITKVtkGlue`) | Already handled, both variants. |
| `MPI::MPI_C`, and `Threads::Threads` from the vendored HDF5 | Unreachable. Both sit inside `$<$<BOOL:${HDF5_ENABLE_PARALLEL}>:...>`-style genexes, and vendored HDF5 refuses to configure with `HDF5_ENABLE_PARALLEL=ON` ("Parallel and C++ options are mutually exclusive"), which ITK requires. `HDF5_ENABLE_THREADS` is referenced by the vendored snapshot but never defined. |

</details>

<details>
<summary>Unrelated defect found while testing, not fixed here</summary>

`-DITK_BUILD_DEFAULT_MODULES=OFF -DModule_ITKIONRRD=ON -DBUILD_TESTING=ON` fails to configure: `ITKGoogleTest` is not enabled, but `Modules/IO/NRRD/test/CMakeLists.txt` still calls `CreateGoogleTestDriver`, so `GTest::gtest` is undefined. That is a module-enablement problem rather than an export problem, and can be filed separately.

</details>

<!--
provenance: claude-code session 2026-08-21
parent: PR #6776 (NrrdIO Threads::Threads export)
file: Modules/ThirdParty/GoogleTest/CMakeLists.txt
verified: configure-time diff of Modules/ThirdParty/GoogleTest/CMakeFiles/ITKGoogleTest.cmake, macOS arm64, homebrew googletest
audit_build_trees: minimal+IONRRD, Module_ITKIODCMTK=ON (FetchContent), default+system-gtest, HDF5_ENABLE_PARALLEL=ON (configure refused)
followup: minimal-modules + BUILD_TESTING=ON does not enable ITKGoogleTest -> CreateGoogleTestDriver fails
-->
