### PR TITLE
COMP: Enable ITKGoogleTest whenever BUILD_TESTING is on

### DIFF
--- a/CMake/ITKModuleEnablement.cmake
+++ b/CMake/ITKModuleEnablement.cmake
@@ -213,6 +213,12 @@ macro(itk_module_enable itk-module _needed_by)
   endif()
 endmacro()
 
+# Any module's test kit may create a GoogleTest driver, so testing needs
+# ITKGoogleTest whatever the module selection is.
+if(BUILD_TESTING AND NOT DISABLE_MODULE_TESTS)
+  itk_module_enable(ITKGoogleTest "")
+endif()
+
 foreach(itk-module ${ITK_MODULES_ALL})
   if(Module_${itk-module} OR ITK_MODULE_${itk-module}_IN_DEFAULT)
     itk_module_enable("${itk-module}" "")


### PR DESCRIPTION
`BUILD_TESTING=ON` now mandates `ITKGoogleTest`, instead of relying on each module to list it in `TEST_DEPENDS`. Any module's test kit may call `CreateGoogleTestDriver`, and the set of modules with no GoogleTest tests keeps shrinking, so tracking the dependency per module is the wrong lever.

Fixes a configure failure on current `main`:

```
$ cmake -DITK_BUILD_DEFAULT_MODULES=OFF -DModule_ITKIONRRD=ON -DBUILD_TESTING=ON ...
CMake Error at CMake/ITKModuleTest.cmake:320 (target_link_libraries):
  Target "ITKIONRRDGTestDriver" links to:
    GTest::gtest
  but the target was not found.
Call Stack (most recent call first):
  Modules/IO/NRRD/test/CMakeLists.txt:425 (creategoogletestdriver)
```

Found while auditing #6776 / #6777; independent of both.

<details>
<summary>Scope: seven modules have the same latent omission</summary>

72 modules call `CreateGoogleTestDriver`; these seven do not name `ITKGoogleTest` in their `itk-module.cmake`, so any selection that enables one of them without separately pulling in `ITKGoogleTest` hits the error above:

```
Modules/Filtering/CurvatureFlow
Modules/Filtering/ImageCompare
Modules/Filtering/DisplacementField
Modules/Segmentation/RegionGrowing
Modules/Nonunit/Review
Modules/IO/NRRD
Modules/IO/IOTransformDCMTK
```

Adding seven `TEST_DEPENDS` entries would fix today's instances and leave the next one to be discovered the same way. This PR removes the class instead. The seven entries are left alone; they are harmless where present.

</details>

<details>
<summary>Verification</summary>

| configuration | before | after | `ITKGoogleTest` enabled after |
|---|---|---|---|
| minimal + `Module_ITKIONRRD=ON` + `BUILD_TESTING=ON` | configure fails | configures | yes |
| minimal + `Module_ITKIONRRD=ON` + `BUILD_TESTING=OFF` | configures | configures | no |
| default modules + `BUILD_TESTING=ON` | configures | configures | yes |

Enablement checked by the presence of `lib/cmake/ITK-6.0/Modules/ITKGoogleTest.cmake` in each build tree. The guard is `BUILD_TESTING AND NOT DISABLE_MODULE_TESTS`, so a testing build that adds no module test directories does not pull the module in.

</details>

<!--
provenance: claude-code session 2026-08-21
file: CMake/ITKModuleEnablement.cmake, after the itk_module_enable macro
related: #6776 (NrrdIO Threads export), #6777 (GoogleTest install-tree export code)
verified: configure-only, macOS arm64, build dirs itk-gt5/6/7
rationale: user directive 2026-08-21 - "if BUILD_TESTING=ON then ITKGoogleTest=ON should be mandated"
omitting_modules: CurvatureFlow, ImageCompare, DisplacementField, RegionGrowing, Review, IONRRD, IOTransformDCMTK
-->
