### PR TITLE
Fix off64_t portability on musl-based systems

### DIFF
--- a/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
+++ b/Modules/ThirdParty/GDCM/src/gdcm/Source/MediaStorageAndFileFormat/gdcmFileStreamer.cxx
@@ -35,7 +35,7 @@
 #include <io.h>
 typedef int64_t off64_t;
 #else
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__EMSCRIPTEN__) || !defined(__GLIBC__)
 #  define off64_t off_t
 #endif
 #include <unistd.h> // ftruncate


### PR DESCRIPTION
## Problem
Builds on musl-based Linux distributions (like Alpine Linux) were failing with:
```
error: 'off64_t' has not been declared
```

The issue occurs in `gdcmFileStreamer.cxx` where the code defines `off64_t` for Windows and BSD systems, but doesn't handle musl-based systems which don't define `off64_t` by default.

## Solution
Modified the platform detection condition to check for non-glibc systems. This covers musl and other libc implementations by defining `off64_t` as `off_t`, which is the standard portability approach.

The specific change checks for `!defined(__GLIBC__)` to detect non-glibc systems, complementing existing checks for specific BSD and Apple platforms.

## Testing
This fix should allow musl-based builds to compile without the `off64_t` error while maintaining compatibility with existing platforms (Windows, glibc-based Linux, BSD variants, etc.).

Fixes SimpleITK build failures on Alpine Linux and other musl-based distributions.
