### PR TITLE
COMP: Declare ITKGoogleTest where GTest drivers are built

### DIFF
--- a/CMake/ITKModuleTest.cmake
+++ b/CMake/ITKModuleTest.cmake
@@ -315,6 +315,13 @@ function(itk_python_expression_add_test)
 endfunction()
 
 function(CreateGoogleTestDriver KIT KIT_LIBS KitTests)
+  # KIT names the driver, not necessarily the module, so key the check on itk-module.
+  if(NOT "ITKGoogleTest" IN_LIST ITK_MODULE_${itk-module}-Test_DEPENDS)
+    message(
+      FATAL_ERROR
+      "${itk-module} builds a GoogleTest driver: add ITKGoogleTest to its TEST_DEPENDS"
+    )
+  endif()
   set(exe "${KIT}GTestDriver")
   add_executable(${exe} ${KitTests})
   target_link_libraries(

--- a/Modules/Filtering/CurvatureFlow/itk-module.cmake
+++ b/Modules/Filtering/CurvatureFlow/itk-module.cmake
@@ -16,5 +16,6 @@ itk_module(
   TEST_DEPENDS
     ITKTestKernel
     ITKIOVTK
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/DisplacementField/itk-module.cmake
+++ b/Modules/Filtering/DisplacementField/itk-module.cmake
@@ -17,5 +17,6 @@ itk_module(
     ITKImageGrid
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/Filtering/ImageCompare/itk-module.cmake
+++ b/Modules/Filtering/ImageCompare/itk-module.cmake
@@ -15,5 +15,6 @@ itk_module(
     ITKImageFilterBase
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )

--- a/Modules/IO/IOTransformDCMTK/itk-module.cmake
+++ b/Modules/IO/IOTransformDCMTK/itk-module.cmake
@@ -19,6 +19,7 @@ itk_module(
     ITKIODCMTK
     ITKIOGDCM
     ITKImageGrid
+    ITKGoogleTest
   FACTORY_NAMES
     TransformIO::DCMTK
   EXCLUDE_FROM_DEFAULT

--- a/Modules/IO/NRRD/itk-module.cmake
+++ b/Modules/IO/NRRD/itk-module.cmake
@@ -16,6 +16,7 @@ itk_module(
     ITKImageCompose
     ITKImageGrid
     ITKTestKernel
+    ITKGoogleTest
   FACTORY_NAMES
     ImageIO::Nrrd
   DESCRIPTION "${DOCUMENTATION}"

--- a/Modules/Nonunit/Review/itk-module.cmake
+++ b/Modules/Nonunit/Review/itk-module.cmake
@@ -95,6 +95,7 @@ itk_module(
     ITKIOCSV
     ITKIOLSM
     ITKRegistrationCommon
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
   EXCLUDE_FROM_DEFAULT
 )

--- a/Modules/Segmentation/RegionGrowing/itk-module.cmake
+++ b/Modules/Segmentation/RegionGrowing/itk-module.cmake
@@ -13,5 +13,6 @@ itk_module(
     ITKThresholding
   TEST_DEPENDS
     ITKTestKernel
+    ITKGoogleTest
   DESCRIPTION "${DOCUMENTATION}"
 )


### PR DESCRIPTION
Seven modules call `CreateGoogleTestDriver` without declaring `ITKGoogleTest` in `TEST_DEPENDS`, so enabling one of them alone with `BUILD_TESTING=ON` fails on an unresolved `GTest::gtest`. Second commit adds a guard in `CreateGoogleTestDriver` that names the missing declaration.

<details>
<summary>Why the guard is second, and evidence it detects the defect</summary>

The guard was written first and the declarations second. That order is a red/green pair but leaves commit 1 unbuildable — with the guard applied to unpatched `main`, both a default and a minimal configure fail:

```
CMake Error at CMake/ITKModuleTest.cmake:320 (message):
  ITKCurvatureFlow builds a GoogleTest driver: add ITKGoogleTest to its
  TEST_DEPENDS
```

```
CMake Error at CMake/ITKModuleTest.cmake:320 (message):
  ITKIONRRD builds a GoogleTest driver: add ITKGoogleTest to its TEST_DEPENDS
```

Reordered so every commit configures; the tree at the tip is byte-identical to the tree that produced those runs. The guard therefore detects exactly the seven declarations that the first commit adds.

</details>

<details>
<summary>Symptom without the guard</summary>

```
$ cmake -DITK_BUILD_DEFAULT_MODULES=OFF -DModule_ITKIONRRD=ON -DBUILD_TESTING=ON ...
CMake Error at CMake/ITKModuleTest.cmake:320 (target_link_libraries):
  Target "ITKIONRRDGTestDriver" links to:
    GTest::gtest
  but the target was not found.
Call Stack (most recent call first):
  Modules/IO/NRRD/test/CMakeLists.txt:425 (creategoogletestdriver)
```

`TEST_DEPENDS` carries two effects here: `ITK_MODULE_<mod>-Test_DEPENDS` enables `ITKGoogleTest`, and `itk_module_test()` puts `ITK::ITKGoogleTestModule` on the test kit's interface.

The guard keys on `${itk-module}`, not the `KIT` argument: five call sites pass a KIT that differs from the module name (`Registration/Common`, `ImageFrequency`, `BoneEnhancement`, `SuperPixel`, `IO/GDCM`), and a KIT-keyed check reports `ITKIOGDCM` as an offender when it is not one.

</details>

<details>
<summary>Local validation</summary>

macOS arm64, `-DBUILD_TESTING=ON`:

| tree | default modules | `-DModule_ITKIONRRD=ON` only |
|---|---|---|
| `main` | configures | **fails** on `GTest::gtest` |
| guard applied to `main` | **fails**, names ITKCurvatureFlow | **fails**, names ITKIONRRD |
| first commit | configures | configures |
| both commits | configures | configures |

Minimal tree at the tip: build ok, `ctest` 100% tests passed out of 230. `pre-commit run --all-files` clean.

</details>

<details>
<summary>AI assistance</summary>

- Role: detection sweep across the 72 modules that build GTest drivers, guard implementation, red/green runs
- Evidence of local testing: table above

</details>

<!--
found_by: vetting PR #6776, where a minimal IONRRD build with testing on could not configure
guard: CMake/ITKModuleTest.cmake, CreateGoogleTestDriver
kit_vs_module_mismatches: Registration/Common, ImageFrequency, BoneEnhancement, SuperPixel, IO/GDCM
rejected_alternatives: #6778 blanket enablement under BUILD_TESTING; a pre-commit hook scanning itk-module.cmake (misses remote modules, cannot see the KIT argument)
maintainer_ruling: blowekamp on #6778 - TEST_DEPENDS is what keeps the cmake interface correct
-->
