### PR TITLE
Fix GetCTypeForDType(itk_ctype.dtype) round-trip

### DIFF
--- a/Wrapping/Generators/Python/Tests/test_ctype.py
+++ b/Wrapping/Generators/Python/Tests/test_ctype.py
@@ -70,6 +70,23 @@ class CTypeTestCase(unittest.TestCase):
                 itk.UL,
             )
 
+    def test_itk_ctype_numpy_dtype_roundtrip(self) -> None:
+        """Tests round-trip from itkCType to NumPy dtype and back, for the itkCType aliases with a specified size"""
+
+        for itk_ctype in (
+            itk.float32_t,
+            itk.float64_t,
+            itk.uint8_t,
+            itk.uint16_t,
+            itk.uint32_t,
+            itk.uint64_t,
+            itk.int8_t,
+            itk.int16_t,
+            itk.int32_t,
+            itk.int64_t,
+        ):
+            self.assertEqual(itk.itkCType.GetCTypeForDType(itk_ctype.dtype), itk_ctype)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -104,13 +104,13 @@ class itkCType:
         _D: itkCType = cls("double", "D", np.dtype(np.float64))
         _UC: itkCType = cls("unsigned char", "UC", np.dtype(np.uint8))
         _US: itkCType = cls("unsigned short", "US", np.dtype(np.uint16))
-        _UI: itkCType = cls("unsigned int", "UI", np.dtype(np.uint32))
         if os.name == "nt":
             _UL: itkCType = cls("unsigned long", "UL", np.dtype(np.uint32))
             _SL: itkCType = cls("signed long", "SL", np.dtype(np.int32))
         else:
             _UL: itkCType = cls("unsigned long", "UL", np.dtype(np.uint64))
             _SL: itkCType = cls("signed long", "SL", np.dtype(np.int64))
+        _UI: itkCType = cls("unsigned int", "UI", np.dtype(np.uint32))
         _ULL: itkCType = cls("unsigned long long", "ULL", np.dtype(np.uint64))
         _SC: itkCType = cls("signed char", "SC", np.dtype(np.int8))
         _SS: itkCType = cls("signed short", "SS", np.dtype(np.int16))

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -96,6 +96,10 @@ class itkCType:
         """
         import numpy as np
 
+        # Note: The order in which the following itkCType objects are created
+        # is relevant! For each NumPy `dtype`, only the last created itkCType
+        # object for that particular `dtype` is stored in the mapping from
+        # `dtype` to itkCType (using the Python dict `__c_types_for_dtype__`).
         _F: itkCType = cls("float", "F", np.dtype(np.float32))
         _D: itkCType = cls("double", "D", np.dtype(np.float64))
         _UC: itkCType = cls("unsigned char", "UC", np.dtype(np.uint8))

--- a/Wrapping/Generators/Python/itk/support/types.py
+++ b/Wrapping/Generators/Python/itk/support/types.py
@@ -104,6 +104,8 @@ class itkCType:
         _D: itkCType = cls("double", "D", np.dtype(np.float64))
         _UC: itkCType = cls("unsigned char", "UC", np.dtype(np.uint8))
         _US: itkCType = cls("unsigned short", "US", np.dtype(np.uint16))
+        _ULL: itkCType = cls("unsigned long long", "ULL", np.dtype(np.uint64))
+        _SLL: itkCType = cls("signed long long", "SLL", np.dtype(np.int64))
         if os.name == "nt":
             _UL: itkCType = cls("unsigned long", "UL", np.dtype(np.uint32))
             _SL: itkCType = cls("signed long", "SL", np.dtype(np.int32))
@@ -111,11 +113,9 @@ class itkCType:
             _UL: itkCType = cls("unsigned long", "UL", np.dtype(np.uint64))
             _SL: itkCType = cls("signed long", "SL", np.dtype(np.int64))
         _UI: itkCType = cls("unsigned int", "UI", np.dtype(np.uint32))
-        _ULL: itkCType = cls("unsigned long long", "ULL", np.dtype(np.uint64))
         _SC: itkCType = cls("signed char", "SC", np.dtype(np.int8))
         _SS: itkCType = cls("signed short", "SS", np.dtype(np.int16))
         _SI: itkCType = cls("signed int", "SI", np.dtype(np.int32))
-        _SLL: itkCType = cls("signed long long", "SLL", np.dtype(np.int64))
         _B: itkCType = cls("bool", "B", np.dtype(np.bool_))
         return _F, _D, _UC, _US, _UI, _UL, _SL, _ULL, _SC, _SS, _SI, _SLL, _B
 


### PR DESCRIPTION
Reordered the creation of  itkCType objects in initialize_c_types_once, in order to fix the following two issues:
- #6782
- #6785

Documented that the order in which these itkCType objects are created is relevant for the mapping from NumPy `dtype` to itkCType.

Added a Python unit test to check the round-trip itkCType ==> dtype ==> itkCType, for numeric C types with specified sizes ("fixed width types"): int8_t, uint8_t, int16_t, uint16_t, etc.