### PR TITLE
ENH: Configure the ObjectFactory autoload symbol name

### DIFF
--- a/CMake/ITKFactoryRegistration.cmake
+++ b/CMake/ITKFactoryRegistration.cmake
@@ -7,7 +7,8 @@
 # "statically" : This is the mechanism described below and supported by UseITK.
 #
 # "dynamically": This corresponds to the runtime loading of shared libraries
-#                exporting the "itkLoad" symbol and available in directory
+#                exporting the ITK_LOAD_FUNCTION_NAME symbol ("itkLoad" by
+#                default) and available in directory
 #                associated with the `ITK_AUTOLOAD_PATH` environment variable.
 #
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,21 @@ if(NOT DEFINED ITK_LIBRARY_NAMESPACE)
   set(ITK_LIBRARY_NAMESPACE "ITK")
 endif()
 
+# extern "C" names carry no C++ namespace, so a renamed build must set this explicitly.
+set(
+  ITK_LOAD_FUNCTION_NAME
+  "itkLoad"
+  CACHE STRING
+  "Name of the C entry point ObjectFactoryBase looks up in each autoloaded library."
+)
+mark_as_advanced(ITK_LOAD_FUNCTION_NAME)
+if(NOT ITK_LOAD_FUNCTION_NAME MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+  message(
+    FATAL_ERROR
+    "ITK_LOAD_FUNCTION_NAME must be a valid C identifier, got '${ITK_LOAD_FUNCTION_NAME}'"
+  )
+endif()
+
 if(NOT CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR lib)
 endif()

--- a/Modules/Core/Common/include/itkFactoryTestLib.h
+++ b/Modules/Core/Common/include/itkFactoryTestLib.h
@@ -24,12 +24,12 @@
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * This entry point is a C (not C++) function.
  */
 extern "C"
 {
   ITK_ABI_EXPORT itk::ObjectFactoryBase *
-                 itkLoad();
+                 ITK_LOAD_FUNCTION_NAME();
 }
 
 #endif

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -53,6 +53,10 @@
 #include <sstream>
 #include <type_traits> // For is_same, remove_const, and remove_reference.
 
+// Two levels: # does not expand its operand, so the inner macro receives the expanded token.
+#define ITK_STRINGIFY_HELPER(x) #x
+#define ITK_STRINGIFY(x) ITK_STRINGIFY_HELPER(x)
+
 /** \namespace itk
  * \brief The "itk" namespace contains all Insight Segmentation and
  * Registration Toolkit (ITK) classes. There are several nested namespaces

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -45,9 +45,10 @@ namespace itk
  * used to create itk objects from the list of registered ObjectFactoryBase
  * sub-classes.  The first time CreateInstance() is called, all dll's or
  * shared libraries in the environment variable ITK_AUTOLOAD_PATH are loaded
- * into the current process.  The C function itkLoad is called on each dll.
- * itkLoad should return an instance of the factory sub-class implemented in
- * the shared library. ITK_AUTOLOAD_PATH is an environment variable
+ * into the current process.  The C function named by ITK_LOAD_FUNCTION_NAME
+ * (itkLoad by default) is called on each dll.  It should return an instance of
+ * the factory sub-class implemented in the shared library.  ITK_AUTOLOAD_PATH
+ * is an environment variable
  * containing a colon separated (semi-colon on win32) list of paths.
  *
  * This can be use to override the creation of any object in ITK.

--- a/Modules/Core/Common/src/itkConfigure.h.in
+++ b/Modules/Core/Common/src/itkConfigure.h.in
@@ -190,4 +190,7 @@
 
 #cmakedefine ITK_HAS_SCHED_GETAFFINITY
 
+// Name of the C entry point ObjectFactoryBase looks up in each autoloaded library.
+#define ITK_LOAD_FUNCTION_NAME @ITK_LOAD_FUNCTION_NAME@
+
 #endif //itkConfigure_h

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -339,7 +339,7 @@ CreateFullPath(const char * path, const char * file)
  * A file scope type alias to make the cast code to the load
  * function cleaner to read.
  */
-using ITK_LOAD_FUNCTION = ObjectFactoryBase * (*)();
+using AutoloadFunctionType = ObjectFactoryBase * (*)();
 
 /**
  * A file scoped function to determine if a file has
@@ -404,9 +404,10 @@ ObjectFactoryBase::LoadLibrariesInPath(const char * path)
       if (lib)
       {
         /**
-         * Look for the symbol itkLoad in the library
+         * Look for the autoload symbol in the library
          */
-        auto loadfunction = (ITK_LOAD_FUNCTION)DynamicLoader::GetSymbolAddress(lib, "itkLoad");
+        auto loadfunction =
+          (AutoloadFunctionType)DynamicLoader::GetSymbolAddress(lib, ITK_STRINGIFY(ITK_LOAD_FUNCTION_NAME));
         /**
          * if the symbol is found call it to create the factory
          * from the library

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -174,11 +174,11 @@ private:
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * This entry point is a C (not C++) function.
  */
 static ImportImageContainerFactory::Pointer staticImportImageContainerFactory;
 itk::ObjectFactoryBase *
-itkLoad()
+ITK_LOAD_FUNCTION_NAME()
 {
   staticImportImageContainerFactory = ImportImageContainerFactory::New();
   return staticImportImageContainerFactory;

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
@@ -26,17 +26,17 @@
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * This entry point is a C (not C++) function.
  */
 extern "C"
 {
   ITKIOImageBase_EXPORT itk::ObjectFactoryBase *
-                        itkLoad();
+                        ITK_LOAD_FUNCTION_NAME();
 }
 
 
 itk::ObjectFactoryBase *
-itkLoad()
+ITK_LOAD_FUNCTION_NAME()
 {
   static itk::FileFreeImageIOFactory::Pointer f = itk::FileFreeImageIOFactory::New();
   return f;


### PR DESCRIPTION
`ObjectFactoryBase` looked up the autoload entry point by string literal while plugins define it by name, so the two agreed only by convention. Both now derive from `ITK_LOAD_FUNCTION_NAME`, configured once into `itkConfigure.h`. **No behavior change — the default is `itkLoad`.**

**This is enabling work with no improvement today.** It makes one of four names configurable so that independently-distributed ITK builds can eventually coexist in one process — PyPI `itk` wheels as `py_itk`, SimpleITK as `simple_itk`, Slicer as `slicer_itk`, possibly built from the same source. `extern "C"` names carry no C++ namespace, so the autoload entry point needs its own configurable name whichever namespace mechanism ITK adopts. That mechanism question is [![#6786](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6786?label=%236786&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/issues/6786) and is **not decided here**.

| Related work | Status |
|---|---|
| Namespace mechanism decision | [![#6786](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6786?label=%236786&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/issues/6786) |
| `release-5.4` backport of this PR | [![#6795](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6795?label=%236795&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/pull/6795) |
| Slicer plugin uses the macro | [![Slicer#9374](https://img.shields.io/github/issues/detail/state/Slicer/Slicer/9374?label=Slicer%239374&style=flat-square)](https://github.com/Slicer/Slicer/pull/9374) |
| Slicer's fork-side patch this supersedes | [![Slicer/ITK#14](https://img.shields.io/github/issues/detail/state/Slicer/ITK/14?label=Slicer%2FITK%2314&style=flat-square)](https://github.com/Slicer/ITK/pull/14) |
| Stringify-macro consolidation (blocked on this) | [![#6788](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6788?label=%236788&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/issues/6788) |

**Reviewers:** the plugin-facing code is only reachable with `BUILD_SHARED_LIBS=ON`. ITK guards both factory plugin targets behind `if(ITK_BUILD_SHARED_LIBS)` (`Modules/Core/Common/test/CMakeLists.txt:151`, `Modules/IO/ImageBase/test/CMakeLists.txt:933`), so **3 of the 9 changed files are compiled only in a shared build** (`itkFactoryTestLib.h`, `itkFactoryTestLib.cxx`, `itkFileFreeImageIOFactory.cxx`) and a static build does not register `itkIOPluginTest`. Of the remainder, 2 are CMake and 4 compile in both configurations.

<details>
<summary>The four naming axes, and why this is one of them</summary>

Coexisting builds need all four aligned. Two are already configurable on `main`:

| Axis | Variable | On `main` |
|---|---|---|
| C++ symbols | `ITK_NAMESPACE` or an ABI inline namespace | no — [#6786](https://github.com/InsightSoftwareConsortium/ITK/issues/6786) |
| autoload C symbol | `ITK_LOAD_FUNCTION_NAME` | **no — this PR** |
| CMake target prefix | `ITK_LIBRARY_NAMESPACE` (`CMakeLists.txt:205`) | yes |
| library filename | `ITK_CUSTOM_LIBRARY_SUFFIX` (`ITKModuleMacros.cmake:731`) | yes |

`ITK_LOAD_FUNCTION_NAME` is defined at the top level beside `ITK_LIBRARY_NAMESPACE`, so all four are settable before any module is configured.

The filename axis is not cosmetic: three shared libraries all named `libITKCommon-6.0.so` in one process means the dynamic loader keys on SONAME and the first one loaded wins, so the C++ symbols can be perfectly distinct and it still will not work.

</details>

<details>
<summary>Why the name is build-configured rather than a header <code>#ifndef</code></summary>

An earlier revision put an overridable `#ifndef ITK_LOAD_FUNCTION_NAME` in `itkObjectFactoryBase.h`. That was unsound and has been replaced.

The lookup side is compiled into `libITKCommon` when ITK is built. A downstream consumer defining the macro before including the installed header would change only *its own* plugin's exported symbol, while the prebuilt loader still searched for `itkLoad` — the plugin would silently never load. Confirmed against the built library:

```console
$ strings libITKCommon-6.0.1.dylib | grep -x itkLoad
itkLoad
```

Routing the value through the generated `itkConfigure.h` makes disagreement structurally impossible: there is one generated header, and the loader and every plugin include it.

```c
// itkConfigure.h.in
#define ITK_LOAD_FUNCTION_NAME @ITK_LOAD_FUNCTION_NAME@
```

```cmake
# CMakeLists.txt, beside ITK_LIBRARY_NAMESPACE
set(ITK_LOAD_FUNCTION_NAME "itkLoad" CACHE STRING "...")
mark_as_advanced(ITK_LOAD_FUNCTION_NAME)
if(NOT ITK_LOAD_FUNCTION_NAME MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
  message(FATAL_ERROR "... must be a valid C identifier, got '${ITK_LOAD_FUNCTION_NAME}'")
endif()
```

</details>

<details>
<summary>Why <code>extern "C"</code> needs its own mechanism</summary>

`extern "C"` names carry no C++ namespace, so no namespace scheme reaches this entry point. Demonstrated on one library containing both kinds of symbol:

```console
$ nm -gU libexternc.so
__ZN3itk2v67cppFuncEv     # C++ inside `inline namespace v6` -> mangled, namespaced
_itkLoad                  # extern "C"                       -> untouched
```

VTK hit the same thing and ships `VTK_ABI_NAMESPACE_MANGLE(x)` for `GetVTKVersion`, `signal_handler`, and its serialization registrars.

</details>

<details>
<summary>Also included: <code>ITK_STRINGIFY</code> in <code>itkMacro.h</code></summary>

The loader needs the configured token as a string, which requires the two-level stringify idiom — `#` does not expand its operand, so a single level yields `"ITK_LOAD_FUNCTION_NAME"`.

Rather than adding another local copy, this PR puts `ITK_STRINGIFY` / `ITK_STRINGIFY_HELPER` in `itkMacro.h`. ITK already contains **34 hand-rolled copies of this idiom** across 17 files — 32 named `_STRING`/`TOSTRING`, and `_STRING` is a reserved identifier ([lex.name]/3.1), so those are undefined behavior as well as duplicates.

Migrating the existing 34 is deliberately **not** in this PR; it is tracked as #6788. This PR adds only the shared definition its own single call site needs.

</details>

<details>
<summary>Verification</summary>

macOS 15 arm64, Apple clang via the pixi `cxx` environment, Release.

**1. `BUILD_SHARED_LIBS=ON`, default** — build clean, `itkIOPluginTest` **PASS**.

```console
plugin export:  000000000000717c T _itkLoad
libITKCommon:   itkLoad
```

**2. `BUILD_SHARED_LIBS=ON`, `-DITK_LOAD_FUNCTION_NAME=slicer_itkLoad`** — build clean, `itkIOPluginTest` **PASS**.

```console
generated:      #define ITK_LOAD_FUNCTION_NAME slicer_itkLoad
plugin export:  000000000000717c T _slicer_itkLoad
libITKCommon:   slicer_itkLoad
```

Loader and plugin move together; the factory still loads.

**3. Validation** — a value that is not a valid C identifier fails configure:

```
ITK_LOAD_FUNCTION_NAME must be a valid C identifier, got 'not a valid name'
```

**4. `BUILD_SHARED_LIBS=OFF`** — build clean, 4/4 `ObjectFactory` tests **PASS**. `ctest -N -R itkIOPluginTest` reports `Total Tests: 0`, confirming the plugin test is absent by ITK's own guard rather than by anything in this change.

`pre-commit run --all-files` passes on the branch tip.

</details>

<!--
provenance: claude-code session 2026-08-25, author hjmjohnson
branch: comp-itkload-symbol-macro, base upstream/main
derived_from: Slicer/ITK#14 (blowekamp:itk_namespace_itkLoad)
design_issue: #6786 (open, undecided) — three-channel coexistence target
followon: #6788 (34 stringify duplicates), #6789 (44 installed-header macro leaks), #6790 (test-helper dups)
backport: #6795 (release-5.4)
slicer_side: Slicer/Slicer#9374 (merged 2026-08-25) — itkMRMLIDIOPlugin spells the entry point via the macro
revision_history:
  v1 overridable #ifndef in itkObjectFactoryBase.h - unsound, loader compiled into libITKCommon
     cannot see a downstream -D; replaced by itkConfigure.h.in + CMake cache variable
  ITKConfig.cmake.in export added then removed on review - no CMake logic consumes the load symbol name
  cache variable moved to top-level CMakeLists.txt beside ITK_LIBRARY_NAMESPACE (dzenanz review)
key_evidence:
  extern "C" immune to inline namespace (nm: _itkLoad vs __ZN3itk2v67cppFuncEv)
  override verified end-to-end: slicer_itkLoad in both plugin and libITKCommon, test passes
badges: shields.io github/issues/detail/state - dynamic, reflects live open/closed/merged
-->
