### PR TITLE
BUG: dict_from_transform flattens nested CompositeTransform children

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -386,6 +386,21 @@ transform_back = itk.transform_from_dict(transform_dict)
 transform_dict = itk.dict_from_transform(transforms)
 transform_back = itk.transform_from_dict(transform_dict)
 
+# A nested CompositeTransform is flattened, one entry per leaf transform
+inner_composite = itk.CompositeTransform[itk.D, 3].New()
+inner_composite.AddTransform(itk.TranslationTransform[itk.D, 3].New())
+outer_composite = itk.CompositeTransform[itk.D, 3].New()
+outer_composite.AddTransform(inner_composite)
+outer_composite.AddTransform(itk.AffineTransform[itk.D, 3].New())
+nested_dict = itk.dict_from_transform(outer_composite)
+assert [d["transformType"]["transformParameterization"] for d in nested_dict] == [
+    "Translation",
+    "Affine",
+]
+assert all("parameters" in d for d in nested_dict)
+nested_back = itk.transform_from_dict(nested_dict)
+assert nested_back.GetNumberOfTransforms() == 2
+
 # Write single transform
 itk.transformwrite(transforms[0], sys.argv[7], compression=True)
 

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1074,11 +1074,15 @@ def dict_from_transform(
     def add_transform_dict(transform):
         transform_type = transform.GetTransformTypeAsString()
         if "CompositeTransform" in transform_type:
-            # Add the transforms inside the composite transform
+            # Add the transforms inside the composite transform, recursing
+            # into nested composite transforms so that they are flattened.
+            # GetNthTransform returns the TransformBase interface, so the
+            # child is down-cast to reach GetNumberOfTransforms when it is
+            # itself a composite transform.
             # range is over-ridden so using this hack to create a list
             for i, _ in enumerate([0] * transform.GetNumberOfTransforms()):
-                current_transform = transform.GetNthTransform(i)
-                dict_array.append(update_transform_dict(current_transform))
+                current_transform = itk.down_cast(transform.GetNthTransform(i))
+                add_transform_dict(current_transform)
             return True
         else:
             dict_array.append(update_transform_dict(transform))


### PR DESCRIPTION
`itk.dict_from_transform` looped over the direct children of a `CompositeTransform` and serialized each one with `update_transform_dict`, which skips the parameters of a composite. A child that was itself a `CompositeTransform` was emitted as a bare header (`transformType`, `name`, `inputSpaceName`, `outputSpaceName`) and its own transforms were lost; `itk.transform_from_dict` then raised `KeyError: 'parameters'` on that entry. The docstring already described nested composites as flattened.

`add_transform_dict` now recurses into composite children. `GetNthTransform` returns the `TransformBase` interface, so the child is passed through `itk.down_cast` first to reach `GetNumberOfTransforms`.

The repro case from the issue is added to `Wrapping/Generators/Python/Tests/extras.py`: a composite containing a composite (translation) and an affine serializes to `["Translation", "Affine"]`, every entry carries `parameters`, and `transform_from_dict` returns a composite with two transforms. Verified against the ITK 5.4.6 wheel with the patched function: before, `['Composite', 'Affine']` and `KeyError`; after, `['Translation', 'Affine']` and a successful round trip.

Closes #6792

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Updated API documentation (or API not changed)
- [x] Added [license](https://github.com/InsightSoftwareConsortium/ITK/blob/main/Utilities/KWStyle/ITKHeader.h) to new files (if any)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5
- [x] Added [ITK examples](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples) for all new major features (if any)