### PR TITLE
ENH: Configure the ObjectFactory autoload symbol name (backport of #6787)

### DIFF
--- a/CMake/ITKFactoryRegistration.cmake
+++ b/CMake/ITKFactoryRegistration.cmake
@@ -7,7 +7,8 @@
 # "statically" : This is the mechanism described below and supported by UseITK.
 #
 # "dynamically": This corresponds to the runtime loading of shared libraries
-#                exporting the "itkLoad" symbol and available in directory
+#                exporting the ITK_LOAD_FUNCTION_NAME symbol ("itkLoad" by
+#                default) and available in directory
 #                associated with the `ITK_AUTOLOAD_PATH` environment variable.
 #
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,21 @@ set(main_project_name ${_ITKModuleMacros_DEFAULT_LABEL})
 #-----------------------------------------------------------------------------
 configure_file(CMake/ITKConfigVersion.cmake.in ITKConfigVersion.cmake @ONLY)
 
+# extern "C" names carry no C++ namespace, so a renamed build must set this explicitly.
+set(
+  ITK_LOAD_FUNCTION_NAME
+  "itkLoad"
+  CACHE STRING
+  "Name of the C entry point ObjectFactoryBase looks up in each autoloaded library."
+)
+mark_as_advanced(ITK_LOAD_FUNCTION_NAME)
+if(NOT ITK_LOAD_FUNCTION_NAME MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+  message(
+    FATAL_ERROR
+    "ITK_LOAD_FUNCTION_NAME must be a valid C identifier, got '${ITK_LOAD_FUNCTION_NAME}'"
+  )
+endif()
+
 if(NOT CMAKE_INSTALL_LIBDIR)
   set(CMAKE_INSTALL_LIBDIR lib)
 endif()

--- a/Modules/Core/Common/include/itkFactoryTestLib.h
+++ b/Modules/Core/Common/include/itkFactoryTestLib.h
@@ -24,12 +24,12 @@
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * This entry point is a C (not C++) function.
  */
 extern "C"
 {
   ITK_ABI_EXPORT itk::ObjectFactoryBase *
-                 itkLoad();
+                 ITK_LOAD_FUNCTION_NAME();
 }
 
 #endif

--- a/Modules/Core/Common/include/itkMacro.h
+++ b/Modules/Core/Common/include/itkMacro.h
@@ -54,6 +54,10 @@
 #include <sstream>
 #include <type_traits> // For is_same, remove_const, and remove_reference.
 
+// Two levels: # does not expand its operand, so the inner macro receives the expanded token.
+#define ITK_STRINGIFY_HELPER(x) #x
+#define ITK_STRINGIFY(x) ITK_STRINGIFY_HELPER(x)
+
 /** \namespace itk
  * \brief The "itk" namespace contains all Insight Segmentation and
  * Registration Toolkit (ITK) classes. There are several nested namespaces

--- a/Modules/Core/Common/include/itkObjectFactoryBase.h
+++ b/Modules/Core/Common/include/itkObjectFactoryBase.h
@@ -45,9 +45,10 @@ namespace itk
  * used to create itk objects from the list of registered ObjectFactoryBase
  * sub-classes.  The first time CreateInstance() is called, all dll's or
  * shared libraries in the environment variable ITK_AUTOLOAD_PATH are loaded
- * into the current process.  The C function itkLoad is called on each dll.
- * itkLoad should return an instance of the factory sub-class implemented in
- * the shared library. ITK_AUTOLOAD_PATH is an environment variable
+ * into the current process.  The C function named by ITK_LOAD_FUNCTION_NAME
+ * (itkLoad by default) is called on each dll.  It should return an instance of
+ * the factory sub-class implemented in the shared library.  ITK_AUTOLOAD_PATH
+ * is an environment variable
  * containing a colon separated (semi-colon on win32) list of paths.
  *
  * This can be use to override the creation of any object in ITK.

--- a/Modules/Core/Common/src/itkConfigure.h.in
+++ b/Modules/Core/Common/src/itkConfigure.h.in
@@ -193,4 +193,7 @@
 
 #cmakedefine ITK_HAS_SCHED_GETAFFINITY
 
+// Name of the C entry point ObjectFactoryBase looks up in each autoloaded library.
+#define ITK_LOAD_FUNCTION_NAME @ITK_LOAD_FUNCTION_NAME@
+
 #endif //itkConfigure_h

--- a/Modules/Core/Common/src/itkObjectFactoryBase.cxx
+++ b/Modules/Core/Common/src/itkObjectFactoryBase.cxx
@@ -339,7 +339,7 @@ CreateFullPath(const char * path, const char * file)
  * A file scope type alias to make the cast code to the load
  * function cleaner to read.
  */
-using ITK_LOAD_FUNCTION = ObjectFactoryBase * (*)();
+using AutoloadFunctionType = ObjectFactoryBase * (*)();
 
 /**
  * A file scoped function to determine if a file has
@@ -405,9 +405,10 @@ ObjectFactoryBase::LoadLibrariesInPath(const char * path)
       if (lib)
       {
         /**
-         * Look for the symbol itkLoad in the library
+         * Look for the autoload symbol in the library
          */
-        auto loadfunction = (ITK_LOAD_FUNCTION)DynamicLoader::GetSymbolAddress(lib, "itkLoad");
+        auto loadfunction =
+          (AutoloadFunctionType)DynamicLoader::GetSymbolAddress(lib, ITK_STRINGIFY(ITK_LOAD_FUNCTION_NAME));
         /**
          * if the symbol is found call it to create the factory
          * from the library

--- a/Modules/Core/Common/test/itkFactoryTestLib.cxx
+++ b/Modules/Core/Common/test/itkFactoryTestLib.cxx
@@ -174,11 +174,11 @@ private:
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * This entry point is a C (not C++) function.
  */
 static ImportImageContainerFactory::Pointer staticImportImageContainerFactory;
 itk::ObjectFactoryBase *
-itkLoad()
+ITK_LOAD_FUNCTION_NAME()
 {
   staticImportImageContainerFactory = ImportImageContainerFactory::New();
   return staticImportImageContainerFactory;

--- a/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/test/itkFileFreeImageIOFactory.cxx
@@ -26,17 +26,17 @@
  * Routine that is called when the shared library is loaded by
  * itk::ObjectFactoryBase::LoadDynamicFactories().
  *
- * itkLoad() is C (not C++) function.
+ * This entry point is a C (not C++) function.
  */
 extern "C"
 {
   ITKIOImageBase_EXPORT itk::ObjectFactoryBase *
-                        itkLoad();
+                        ITK_LOAD_FUNCTION_NAME();
 }
 
 
 itk::ObjectFactoryBase *
-itkLoad()
+ITK_LOAD_FUNCTION_NAME()
 {
   static itk::FileFreeImageIOFactory::Pointer f = itk::FileFreeImageIOFactory::New();
   return f;


### PR DESCRIPTION
Backport of [![#6787](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6787?label=%236787&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/pull/6787) to `release-5.4`. `ObjectFactoryBase` looked up the autoload entry point by string literal while plugins define it by name; both now derive from `ITK_LOAD_FUNCTION_NAME`, configured once into `itkConfigure.h`. **No behavior change — the default is `itkLoad`.**

**Byte-identical change set.** Every added and removed line matches #6787 exactly — verified by comparing the two patches with context stripped: 53 changed lines on each side, zero differences. Both are 9 files, +39/−14. The only variation in the raw diffs is two *context* lines at the top-level `CMakeLists.txt` insertion point, because the surrounding text differs between branches (details below).

**Merge after #6787.** This should not land before its `main` counterpart.

| Related work | Status |
|---|---|
| `main` counterpart | [![#6787](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6787?label=%236787&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/pull/6787) |
| Namespace mechanism decision | [![#6786](https://img.shields.io/github/issues/detail/state/InsightSoftwareConsortium/ITK/6786?label=%236786&style=flat-square)](https://github.com/InsightSoftwareConsortium/ITK/issues/6786) |
| Slicer plugin uses the macro | [![Slicer#9374](https://img.shields.io/github/issues/detail/state/Slicer/Slicer/9374?label=Slicer%239374&style=flat-square)](https://github.com/Slicer/Slicer/pull/9374) |
| Slicer's fork-side patch this supersedes | [![Slicer/ITK#14](https://img.shields.io/github/issues/detail/state/Slicer/ITK/14?label=Slicer%2FITK%2314&style=flat-square)](https://github.com/Slicer/ITK/pull/14) |

**Why `release-5.4` matters:** it is the branch 3D Slicer builds against. This is enabling work with no improvement today — it makes one of four names configurable so independently-distributed ITK builds can eventually coexist in one process, as PyPI `itk` wheels (`py_itk`), SimpleITK (`simple_itk`) and Slicer (`slicer_itk`). The namespace mechanism question is #6786 and is **not** decided here.

<details>
<summary>Equivalence with #6787, and the one legitimate difference</summary>

Comparing only added/removed lines, ignoring context and hunk headers:

```
main-side changed lines: 53
5.4-side  changed lines: 53
==> ACTUAL CHANGES IDENTICAL
```

The two raw patches differ in exactly two *context* lines, in the top-level `CMakeLists.txt` hunk:

| | context above the inserted block |
|---|---|
| `main` | `set(ITK_LIBRARY_NAMESPACE "ITK")` / `endif()` |
| `release-5.4` | `configure_file(CMake/ITKConfigVersion.cmake.in ...)` |

`ITK_LIBRARY_NAMESPACE` does not exist on `release-5.4` — it is a `main`-only feature — so the cache variable lands at the structurally equivalent slot (after `ITKConfigVersion`, before `CMAKE_INSTALL_LIBDIR`) rather than beside a sibling that is not there. Context lines describe the base, not the change.

An earlier revision of this PR also carried an `ITKConfig.cmake.in` export; it was removed from #6787 on review (no CMake logic consumes the load symbol name) and removed here in the same pass, so `ITKConfig.cmake.in` is untouched by both PRs.

</details>

<details>
<summary>Reviewer note: which files a static build exercises</summary>

The plugin-facing code is only reachable with `BUILD_SHARED_LIBS=ON`. ITK guards both factory plugin targets behind `if(ITK_BUILD_SHARED_LIBS)`, so 3 of the 9 changed files are compiled only in a shared build (`itkFactoryTestLib.h`, `itkFactoryTestLib.cxx`, `itkFileFreeImageIOFactory.cxx`), and a static build does not register `itkIOPluginTest`. Of the remainder, 2 are CMake and 4 compile in both configurations.

</details>

<details>
<summary>Why <code>extern "C"</code> needs its own mechanism</summary>

`extern "C"` names carry no C++ namespace, so no namespace scheme reaches this entry point:

```console
$ nm -gU libexternc.so
__ZN3itk2v67cppFuncEv     # C++ inside `inline namespace v6` -> mangled, namespaced
_itkLoad                  # extern "C"                       -> untouched
```

VTK hit the same thing and ships `VTK_ABI_NAMESPACE_MANGLE(x)` for it.

</details>

<details>
<summary>Verification on this branch</summary>

macOS 15 arm64, Apple clang via the pixi `cxx` environment, Release. All four phases run against `release-5.4`, not inherited from #6787.

**1. `BUILD_SHARED_LIBS=ON`, default** — build clean, `itkIOPluginTest` **PASS**.

```console
plugin export:  000000000000717c T _itkLoad
```

**2. `BUILD_SHARED_LIBS=ON`, `-DITK_LOAD_FUNCTION_NAME=slicer_itkLoad`** — build clean, `itkIOPluginTest` **PASS**.

```console
generated:      #define ITK_LOAD_FUNCTION_NAME slicer_itkLoad
plugin export:  000000000000717c T _slicer_itkLoad
```

**3. Validation** — a value that is not a valid C identifier fails configure:

```
ITK_LOAD_FUNCTION_NAME must be a valid C identifier, got 'bad name'
```

**4. `BUILD_SHARED_LIBS=OFF`** — build clean, **5/5** `ObjectFactory` + `itkIOPluginTest` tests **PASS**.

`release-5.4` predates `.pre-commit-config.yaml`, so the `pre-commit run --all-files` gate does not apply on this branch.

</details>

<!--
provenance: claude-code session 2026-08-25/26, author hjmjohnson
branch: backport-itkload-symbol-54, base upstream/release-5.4 (ITK 5.4.7)
equivalence: changed lines byte-identical to #6787; only context differs (ITK_LIBRARY_NAMESPACE
             absent on release-5.4, so the top-level block lands at the equivalent slot)
gate: merge after #6787
sequencing: #6787 -> main; this -> release-5.4; Slicer repins onto 5.4.7, Slicer/ITK#14 unnecessary
slicer_side: Slicer/Slicer#9374 merged 2026-08-25
precommit: release-5.4 has no .pre-commit-config.yaml (documented gate exception)
verification: shared default + overridden + bad-name reject + static 5/5, all on this branch
-->
