### PR TITLE
BUG: AzimuthElevationToCartesianTransform::IsLinear() returns false backpoint to release-5.4

### DIFF
--- a/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
+++ b/Modules/Core/Transform/include/itkAzimuthElevationToCartesianTransform.h
@@ -178,6 +178,14 @@ public:
     return Self::TransformCategoryEnum::UnknownTransformCategory;
   }
 
+  /** The spherical to cartesian mapping is not linear: T(a*P) != a*T(P).
+   *  MatrixOffsetTransformBase::IsLinear() would return true for this class. */
+  bool
+  IsLinear() const override
+  {
+    return false;
+  }
+
   /** Defines that the forward transform goes from azimuth,elevation to
    *  cartesian. */
   void

--- a/Modules/Core/Transform/test/itkAzimuthElevationToCartesianTransformTest.cxx
+++ b/Modules/Core/Transform/test/itkAzimuthElevationToCartesianTransformTest.cxx
@@ -185,6 +185,47 @@ itkAzimuthElevationToCartesianTransformTest(int argc, char * argv[])
     return EXIT_FAILURE;
   }
 
+  // The transform derives from AffineTransform but is not linear.
+  ITK_TEST_EXPECT_TRUE(!transform->IsLinear());
+
+  // Neither direction of the mapping scales linearly, so the IsLinear() override stays justified.
+  // The loop above left the transform in the cartesian to azimuth-elevation direction.
+  for (const bool forwardAzimuthElevationToCartesian : { true, false })
+  {
+    if (forwardAzimuthElevationToCartesian)
+    {
+      transform->SetForwardAzimuthElevationToCartesian();
+    }
+    else
+    {
+      transform->SetForwardCartesianToAzimuthElevation();
+    }
+
+    AzimuthElevationToCartesianTransformType::InputPointType point;
+    point[0] = 1.0;
+    point[1] = 2.0;
+    point[2] = 3.0;
+    AzimuthElevationToCartesianTransformType::InputPointType doubledPoint;
+    doubledPoint[0] = 2.0;
+    doubledPoint[1] = 4.0;
+    doubledPoint[2] = 6.0;
+    const AzimuthElevationToCartesianTransformType::OutputPointType transformedPoint = transform->TransformPoint(point);
+    const AzimuthElevationToCartesianTransformType::OutputPointType transformedDoubledPoint =
+      transform->TransformPoint(doubledPoint);
+
+    bool scalesLinearly = true;
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      scalesLinearly &= (itk::Math::abs(transformedDoubledPoint[i] - 2.0 * transformedPoint[i]) < ACCEPTABLE_ERROR);
+    }
+    if (scalesLinearly)
+    {
+      std::cout << "Test failed: TransformPoint scales linearly with ForwardAzimuthElevationToCartesian = "
+                << forwardAzimuthElevationToCartesian << ", IsLinear() should not be overridden" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
   std::cout << "itkAzimuthElevationToCartesianTransformTest passed" << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The class derives from AffineTransform and overrides TransformPoint with a spherical to cartesian mapping, but inherited
MatrixOffsetTransformBase::IsLinear(), which returns true unconditionally. Code that reduces a transform to a matrix and an offset when IsLinear() is true silently produced a wrong matrix for this class.

Override IsLinear() to return false, consistent with the existing GetTransformCategory() override, and check both in the test, along with the mapping itself not scaling linearly.

Closes #6791