### PR TITLE
BUG: dict_from_transform flattens nested CompositeTransform children release-5.4 backport

### DIFF
--- a/Wrapping/Generators/Python/Tests/extras.py
+++ b/Wrapping/Generators/Python/Tests/extras.py
@@ -382,6 +382,21 @@ transform_back = itk.transform_from_dict(transform_dict)
 transform_dict = itk.dict_from_transform(transforms)
 transform_back = itk.transform_from_dict(transform_dict)
 
+# A nested CompositeTransform is flattened, one entry per leaf transform
+inner_composite = itk.CompositeTransform[itk.D, 3].New()
+inner_composite.AddTransform(itk.TranslationTransform[itk.D, 3].New())
+outer_composite = itk.CompositeTransform[itk.D, 3].New()
+outer_composite.AddTransform(inner_composite)
+outer_composite.AddTransform(itk.AffineTransform[itk.D, 3].New())
+nested_dict = itk.dict_from_transform(outer_composite)
+assert [d["transformType"]["transformParameterization"] for d in nested_dict] == [
+    "Translation",
+    "Affine",
+]
+assert all("parameters" in d for d in nested_dict)
+nested_back = itk.transform_from_dict(nested_dict)
+assert nested_back.GetNumberOfTransforms() == 2
+
 # Write single transform
 itk.transformwrite(transforms[0], sys.argv[7], compression=True)
 

--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -1082,11 +1082,15 @@ def dict_from_transform(
     def add_transform_dict(transform):
         transform_type = transform.GetTransformTypeAsString()
         if "CompositeTransform" in transform_type:
-            # Add the transforms inside the composite transform
+            # Add the transforms inside the composite transform, recursing
+            # into nested composite transforms so that they are flattened.
+            # GetNthTransform returns the TransformBase interface, so the
+            # child is down-cast to reach GetNumberOfTransforms when it is
+            # itself a composite transform.
             # range is over-ridden so using this hack to create a list
             for i, _ in enumerate([0] * transform.GetNumberOfTransforms()):
-                current_transform = transform.GetNthTransform(i)
-                dict_array.append(update_transform_dict(current_transform))
+                current_transform = itk.down_cast(transform.GetNthTransform(i))
+                add_transform_dict(current_transform)
             return True
         else:
             dict_array.append(update_transform_dict(transform))


### PR DESCRIPTION
add_transform_dict looped over the direct children of a CompositeTransform and serialized each with update_transform_dict, which skips the parameters of a composite. A child that was itself a CompositeTransform was therefore emitted as a bare header and its own transforms were lost, and transform_from_dict raised KeyError on the entry. The docstring already described nested composites as flattened.

Recurse into composite children instead. GetNthTransform returns the TransformBase interface, so the child is down-cast first to reach GetNumberOfTransforms.

Closes #6792
