### PR TITLE
STYLE: Remove any access specifier that is followed by another one

### DIFF
--- a/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkAutoPointerDataObjectDecorator.h
@@ -102,7 +102,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-protected:
 private:
   ComponentPointer m_Component{};
 };

--- a/Modules/Core/Common/include/itkDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkDataObjectDecorator.h
@@ -140,7 +140,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-protected:
 private:
   ComponentPointer m_Component{};
 };

--- a/Modules/Core/Common/include/itkOctreeNode.h
+++ b/Modules/Core/Common/include/itkOctreeNode.h
@@ -125,7 +125,6 @@ public:
     m_Parent = parent;
   }
 
-protected:
 private:
   /**
    * Removes all children from this node down, and sets the value

--- a/Modules/Core/Common/include/itkSimpleDataObjectDecorator.h
+++ b/Modules/Core/Common/include/itkSimpleDataObjectDecorator.h
@@ -106,7 +106,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-protected:
 private:
   ComponentType m_Component{};
   bool          m_Initialized{};

--- a/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
+++ b/Modules/Core/QuadEdgeMesh/include/itkQuadEdgeMeshFunctionBase.h
@@ -93,7 +93,6 @@ protected:
 
   ~QuadEdgeMeshFunctionBase() override = default;
 
-private:
 protected:
   /** Mesh on which to apply the modification */
   MeshType * m_Mesh{};

--- a/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
+++ b/Modules/Filtering/Colormap/include/itkScalarToRGBColormapImageFilter.h
@@ -241,7 +241,6 @@ protected:
   BeforeThreadedGenerateData() override;
 
 private:
-private:
   typename ColormapType::Pointer m_Colormap{};
 
   bool m_UseInputImageExtremaForScaling{};

--- a/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
+++ b/Modules/Filtering/CurvatureFlow/include/itkBinaryMinMaxCurvatureFlowImageFilter.h
@@ -112,7 +112,6 @@ public:
                   (Concept::Convertible<typename TInputImage::PixelType, typename TOutputImage::PixelType>));
 
 protected:
-protected:
   BinaryMinMaxCurvatureFlowImageFilter();
   ~BinaryMinMaxCurvatureFlowImageFilter() override = default;
   void

--- a/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
+++ b/Modules/Filtering/ImageFusion/include/itkLabelOverlayFunctor.h
@@ -129,7 +129,6 @@ public:
     m_RGBFunctor.AddColor(r, g, b);
   }
 
-protected:
 private:
   double m_Opacity{ 1.0 };
   TLabel m_BackgroundValue;

--- a/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
+++ b/Modules/Numerics/Optimizers/include/itkRegularStepGradientDescentBaseOptimizer.h
@@ -172,7 +172,6 @@ protected:
     throw ex;
   }
 
-private:
 protected:
   DerivativeType m_Gradient{};
   DerivativeType m_PreviousGradient{};


### PR DESCRIPTION
When an access specifiers is directly followed by another one, the first one has no effect at all.

Using Notepad++ Replace in Files, doing:

  Find what: `^\w+:\r\n(\w+:)`
  Replace with: `$`
  Filters: `itk*.*`
  (*) Regular expression