### PR TITLE
STYLE: Consolidate C++ type alias IdentifierType = SizeValueType

### DIFF
--- a/Modules/Core/Common/include/itkIntTypes.h
+++ b/Modules/Core/Common/include/itkIntTypes.h
@@ -68,10 +68,6 @@ using std::ptrdiff_t;
  *  points) (it is unsigned) */
 using SizeValueType = uint64_t;
 
-/** Same type as SizeValueType but when used as an Id (pointId, cellId,
- *  labelObjectId..)(it is unsigned) */
-using IdentifierType = SizeValueType;
-
 /** The components of the Index array (they are signed) */
 using IndexValueType = int64_t;
 
@@ -85,10 +81,6 @@ using OffsetValueType = int64_t;
  *  points) (it is unsigned) */
 using SizeValueType = unsigned long;
 
-/** Same type as SizeValueType but when used as an Id (pointId, cellId,
- *  labelObjectId..)(it is unsigned) */
-using IdentifierType = SizeValueType;
-
 /** The components of the Index array (they are signed) */
 using IndexValueType = long;
 
@@ -97,6 +89,10 @@ using IndexValueType = long;
 using OffsetValueType = long;
 
 #endif
+
+/** Same type as SizeValueType but when used as an Id (pointId, cellId,
+ *  labelObjectId..)(it is unsigned) */
+using IdentifierType = SizeValueType;
 
 /** Type to count and reference number of threads */
 using ThreadIdType = unsigned int;

--- a/Modules/Core/Common/test/itkIntTypesGTest.cxx
+++ b/Modules/Core/Common/test/itkIntTypesGTest.cxx
@@ -21,6 +21,10 @@
 #include "itkGTest.h"
 
 #include <iostream>
+#include <type_traits> // For is_same_v.
+
+
+static_assert(std::is_same_v<itk::IdentifierType, itk::SizeValueType>);
 
 namespace
 {


### PR DESCRIPTION
Replaced the two equivalent `itk::IdentifierType` definitions from the `#if` and the `#else` section of "itkIntTypes.h" with one outside the `#if`...`#endif` that is exactly the same.

Added compile-time test to ensure that `itk::IdentifierType` is always the same as `itk::SizeValueType`.