### PR TITLE
COMP: fixed build compatibility with < VTK 9.7 and VTK_FUTURE_CONST

### DIFF
--- a/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkImageToVTKImageFilter.hxx
@@ -40,11 +40,15 @@ ImageToVTKImageFilter<TInputImage>::ImageToVTKImageFilter()
   m_Importer->SetScalarTypeCallback(m_Exporter->GetScalarTypeCallback());
   m_Importer->SetNumberOfComponentsCallback(m_Exporter->GetNumberOfComponentsCallback());
   // Adapt the exporter callback to vtkImageImport's VTK_FUTURE_CONST extent
-  // signature; the const_cast is safe because the callback only reads the extent.
+  // signature starting with VTK 9.7; the const_cast is safe because the callback only reads the extent.
+#if VTK_MAJOR_VERSION > 9 || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
   m_Importer->SetPropagateUpdateExtentCallback([](void * userData, VTK_FUTURE_CONST int * extent) {
     static_cast<VTKImageExportBase *>(userData)->GetPropagateUpdateExtentCallback()(userData,
                                                                                     const_cast<int *>(extent));
   });
+#else
+  m_Importer->SetPropagateUpdateExtentCallback(m_Exporter->GetPropagateUpdateExtentCallback());
+#endif
   m_Importer->SetUpdateDataCallback(m_Exporter->GetUpdateDataCallback());
   m_Importer->SetDataExtentCallback(m_Exporter->GetDataExtentCallback());
   m_Importer->SetBufferPointerCallback(m_Exporter->GetBufferPointerCallback());

--- a/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
+++ b/Modules/Bridge/VtkGlue/include/itkVTKImageToImageFilter.hxx
@@ -42,10 +42,14 @@ VTKImageToImageFilter<TOutputImage>::VTKImageToImageFilter()
   this->SetScalarTypeCallback(m_Exporter->GetScalarTypeCallback());
   this->SetNumberOfComponentsCallback(m_Exporter->GetNumberOfComponentsCallback());
   // Adapt vtkImageExport's VTK_FUTURE_CONST extent callback to the importer's
-  // int* signature; the int* argument binds to the VTK_FUTURE_CONST parameter.
+  // int* signature starting with VTK 9.7; the int* argument binds to the VTK_FUTURE_CONST parameter.
+#if VTK_MAJOR_VERSION > 9 || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
   this->SetPropagateUpdateExtentCallback([](void * userData, int * extent) {
     static_cast<vtkImageExport *>(userData)->GetPropagateUpdateExtentCallback()(userData, extent);
   });
+#else
+  this->SetPropagateUpdateExtentCallback(m_Exporter->GetPropagateUpdateExtentCallback());
+#endif
   this->SetUpdateDataCallback(m_Exporter->GetUpdateDataCallback());
   this->SetDataExtentCallback(m_Exporter->GetDataExtentCallback());
   this->SetBufferPointerCallback(m_Exporter->GetBufferPointerCallback());


### PR DESCRIPTION
A VTK signature changed in 9.7 to include `VTK_FUTURE_CONST`, which resolves to either `const` or nothing depending on a VTK build option.
