### PR TITLE
ENH: Update actions to fix Node.js warning

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -142,7 +142,7 @@ jobs:
             pixi run -e cxx ccache --show-config
 
         - name: Cache ccache
-          uses: actions/cache@v4
+          uses: actions/cache@v5
           with:
             path: ${{ github.workspace }}/.ccache
             key: ccache-rel54-${{ matrix.os }}-${{ github.run_id }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,14 +7,14 @@ jobs:
   pre-commit:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Check install of Python, pre-commit
       run: |
         ./Utilities/GitSetup/setup-precommit
         git config hooks.SetupForDevelopment 99
         git config user.email "you@example.com"
         git config user.name "Your Name"
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
The warning was:

Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4, actions/setup-python@v5. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<!-- The text within this markup is a comment, and is intended to provide
guidelines to open a Pull Request for the ITK repository. This text will not
be part of the Pull Request. -->

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
