### PR TITLE
STYLE: Replace ULL with IT as index type in itkPyVectorContainerTest.py

### DIFF
--- a/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
+++ b/Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py
@@ -32,19 +32,7 @@ class TestNumpyVectorContainerMemoryviewInterface(unittest.TestCase):
     def test_NumPyBridge_VectorContainer(self):
         "Try to convert a itk.VectorContainer into a Numpy array and back."
 
-        if not (
-            hasattr(itk.VectorContainer, "ULLF")
-            and hasattr(itk.PyVectorContainer, "ULLF")
-            and hasattr(itk.Point, "F3")
-            and hasattr(itk.VectorContainer, "ULLPF3")
-            and hasattr(itk.Point, "F2")
-            and hasattr(itk.VectorContainer, "ULLPF2")
-        ):
-            # There is insufficient wrapping to perform this test; skip it.
-            print("Insufficient wrapping to perform itkPyVectorContainerTest")
-            return
-
-        v1 = itk.VectorContainer[itk.ULL, itk.F].New()
+        v1 = itk.VectorContainer[itk.IT, itk.F].New()
         v1.Reserve(4)
         v1.SetElement(0, 1.2)
         v1.SetElement(1, 2)
@@ -78,7 +66,7 @@ class TestNumpyVectorContainerMemoryviewInterface(unittest.TestCase):
         self.assertNotEqual(v2_cp.GetElement(0), arr_cp[0])
 
         PointType = itk.Point[itk.F, 3]
-        v_point = itk.VectorContainer[itk.ULL, PointType].New()
+        v_point = itk.VectorContainer[itk.IT, PointType].New()
         v_point.Reserve(2)
         point = PointType()
         point[0] = 1.0
@@ -95,7 +83,7 @@ class TestNumpyVectorContainerMemoryviewInterface(unittest.TestCase):
         )
 
         PointType = itk.Point[itk.F, 2]
-        v_point = itk.VectorContainer[itk.ULL, PointType].New()
+        v_point = itk.VectorContainer[itk.IT, PointType].New()
         v_point.Reserve(2)
         point = PointType()
         point[0] = 1.0


### PR DESCRIPTION
Removed the check for sufficient wrapping from "Modules/Bridge/NumPy/wrapping/test/itkPyVectorContainerTest.py". `itk.VectorContainer` is always sufficiently wrapped for `itk.IT`.

- Follow-up to pull request #6800 (which was about the other "itkPyVectorContainerTest.py" file, in "Filtering/MeshToPolyData/wrapping/test").