### PR TITLE
STYLE: Replace uint64_t with IT as index type in "*SerializationTest.py"

### DIFF
--- a/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
+++ b/Modules/Core/Common/wrapping/test/itkPointSetSerializationTest.py
@@ -48,7 +48,7 @@ def test_point_set_serialization(use_unsafe_SetPoints_overload: bool = False):
 
     # Set Points in the PointSet
     PointType = itk.Point[itk.F, 3]
-    v_point = itk.VectorContainer[itk.uint64_t, PointType].New()
+    v_point = itk.VectorContainer[itk.IT, PointType].New()
     v_point.Reserve(NumberOfPoints)
 
     point = PointType()

--- a/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
+++ b/Modules/Core/Mesh/wrapping/test/itkMeshSerializationTest.py
@@ -45,7 +45,7 @@ def test_mesh_serialization(use_unsafe_SetPoints_overload: bool = False):
 
     # Set Points in the Mesh
     PointType = itk.Point[itk.F, 3]
-    v_point = itk.VectorContainer[itk.uint64_t, PointType].New()
+    v_point = itk.VectorContainer[itk.IT, PointType].New()
     v_point.Reserve(NumberOfPoints)
 
     point = PointType()


### PR DESCRIPTION
- `itk.IT` ("IdentifierType") is the most commonly supported index type for VectorContainer. `itk.uint64_t` may or may not be identical to `itk.IT`, depending on `ITK_USE_64BITS_IDS`, as discussed at issue #6774.

- Follow-up to pull request #6800