### PR TITLE
COMP: Use an absolute path in the vxl core tests EXISTS guard

### DIFF
--- a/Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt
+++ b/Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt
@@ -29,6 +29,6 @@ add_subdirectory(testlib)
 
 # Tests that check and output the vxl configuration
 # NOTE: some external projects remove the tests directory (aka ITK)
-if( BUILD_TESTING AND EXISTS "tests")
+if( BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests")
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
`if(EXISTS)` is well defined only for absolute paths, so vxl's `tests` guard resolved against the **cmake process working directory**. Configuring ITK with `BUILD_TESTING=ON` from any directory that happens to contain a `tests/` subdirectory failed. One line; no behavior change otherwise.

```
CMake Error at Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt:33 (add_subdirectory):
  add_subdirectory given source "tests" which is not an existing directory.
```

**Note for the next VXL update:** this file is vendored from vxl upstream, so the fix needs to reach the ISC vxl fork overlay (`for/itk-vxl-master-*`) and ideally vxl itself, or the next `update-third-party.bash` run will drop it.

<details>
<summary>Why CI never caught it</summary>

CI invokes cmake from a build directory, which has no `tests/` subdirectory, so the guard evaluated false and the broken branch was never taken. It reproduces immediately from any working directory containing `tests/`.

Demonstrated on a minimal project, same CMake 3.26.6:

```
cmake run from a directory containing ./tests  ->  EXISTS tests -> TRUE
cmake run from a directory without   ./tests  ->  EXISTS tests -> FALSE
```

The guard was added specifically because ITK strips vxl's `tests` directory (`# NOTE: some external projects remove the tests directory (aka ITK)`), so it has never worked for the case it was written for.

</details>

<details>
<summary>Verification</summary>

Same working directory (containing `./tests`), same flags, same source apart from the one line. macOS 15 arm64, CMake 3.26.6, Ninja.

```
cmake -S <ITK> -B <build> -GNinja -DBUILD_TESTING=ON \
      -DITK_BUILD_DEFAULT_MODULES=OFF -DBUILD_EXAMPLES=OFF
```

| source | result |
|---|---|
| `upstream/main` (5ffbf44f729) | **RC=1** — `add_subdirectory given source "tests" which is not an existing directory` |
| this branch | **RC=0** — Configuring done, Generating done |

For a CMake-config-only change the reconfigure is the test.

`pre-commit run --all-files` passes on the branch tip.

</details>

<details>
<summary>Scope</summary>

A tree-wide search for quoted relative paths in `if(EXISTS ...)` across every `CMakeLists.txt` and `*.cmake` found exactly one occurrence — this one. Nothing else to fix.

</details>

<!--
provenance: claude-code session 2026-08-27, author hjmjohnson
branch: comp-vxl-tests-guard-abspath, base upstream/main 5ffbf44f729
file: Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt:32
found_by: bootstrap script building ITK from a package directory that contains ./tests
root_cause: if(EXISTS "tests") relative path resolves against cmake process cwd, not
            CMAKE_CURRENT_SOURCE_DIR; verified empirically with a minimal project
guard_origin: 844dc7d2736 "ENH: Manual copy from vxl/master" -- upstream vxl code
followup: carry to ISC vxl fork overlay for/itk-vxl-master-* and upstream vxl,
          else the next update-third-party.bash run reverts it
verification: configure RC=1 before / RC=0 after, same cwd and flags
-->
