### PR TITLE
COMP: Restore SimpleITKFilters pin removed on release-5.4

### DIFF
--- a/Modules/Remote/SimpleITKFilters.remote.cmake
+++ b/Modules/Remote/SimpleITKFilters.remote.cmake
@@ -50,5 +50,5 @@ itk_fetch_module(
   contains a discrete hessian, and a composite filter to compute objectness."
   MODULE_COMPLIANCE_LEVEL 3
   GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITKSimpleITKFilters.git
-  GIT_TAG 372ab10343df104063ca6a55eb72f7d5fe830d7b
+  GIT_TAG bb896868fc6480835495d0da4356d5db009592a6
   )


### PR DESCRIPTION
## Summary

`34853cf1ca` ("COMP: Update remote-module pins toward buildable convergence with main") advanced the `ITKSimpleITKFilters` remote-module pin on `release-5.4` to `372ab10343d`. That commit removes `MaskedAssignImageFilter` from the remote module now that it has graduated to `ITKImageIntensity` core (`ITKSimpleITKFilters#35`, companion to #6542).

#6542 ("Add MaskedAssignImageFilter to ITKImageIntensity") was merged only to `main` and has not been backported to `release-5.4`. As a result, on current `release-5.4`, `itkMaskedAssignImageFilter.h` doesn't exist anywhere: removed from the remote module, not yet added to core.

This reverts just that one pin to the last `ITKSimpleITKFilters` commit that still contains the filter, restoring buildability of `release-5.4` until #6542 is backported. The other 55 pin updates from `34853cf1ca` are left untouched.

Found while investigating a CI failure in SimpleITK/SimpleITK#2674, which pins `ITK_GIT_TAG` to `release-5.4` in one CI matrix job specifically to catch this kind of drift, and fails to compile `sitkMaskedAssignImageFilter.cxx` with a missing-header error.

## Test plan

- [ ] Confirm a build with this pin restored successfully compiles `MaskedAssignImageFilter` from the `SimpleITKFilters` remote module on `release-5.4`
- [ ] Alternatively, consider backporting #6542 directly instead of reverting the pin, as the more complete long-term fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)