### PR TITLE
COMP: Pass /Zc:__cplusplus when compiling SWIG wrappers with MSVC

### DIFF
--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -529,11 +529,12 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
       if(MSVC)
         # /wd4244: Disables 'conversion from 'type1' to 'type2', possible loss of data warnings
         # /wd4996: Disables deprecated declaration warnings in generated wrapper code
+        # /Zc:__cplusplus: Make MSVC correctly report __cplusplus version
         set_target_properties(
           ${lib}
           PROPERTIES
             COMPILE_FLAGS
-              "/wd4244 /wd4996"
+              "/wd4244 /wd4996 /Zc:__cplusplus"
         )
       endif()
       target_link_directories(${lib} PUBLIC ${Python3_LIBRARY_DIRS})


### PR DESCRIPTION
## Problem

The Windows Python wrapping build fails with five `C2280` errors, all from one root cause:

```
itkGradientImageFilterPython.cpp: error C2280:
  'std::unique_ptr<itk::ImageBoundaryCondition<TInputImage,TInputImage>,...>::unique_ptr(const unique_ptr &)':
  attempting to reference a deleted function
```

## Root cause

Not the wrapping declarations. SWIG generates correct code:

```cpp
std::unique_ptr< itkImageBoundaryConditionIF2 > arg2 ;
...
(&arg2)->reset((itkImageBoundaryConditionIF2 *)argp2);
(arg1)->SetBoundaryCondition(SWIG_STD_MOVE(arg2));
```

The `%unique_ptr(...)` typemap applies as intended and the one-argument mangled name resolves against
`ImageBoundaryCondition<TInputImage, TInputImage>` without trouble, since the default template argument
collapses for SWIG just as it does for C++.

The failure is in SWIG's move guard:

```cpp
#if __cplusplus >= 201103L
# define SWIG_STD_MOVE(OBJ) std::move(OBJ)
#else
# define SWIG_STD_MOVE(OBJ) OBJ
#endif
```

**MSVC reports `__cplusplus` as `199711L` regardless of `/std:c++NN` unless `/Zc:__cplusplus` is given.**
ITK passes `/std:c++17` but never `/Zc:__cplusplus`. On MSVC the `#else` branch therefore wins,
`SWIG_STD_MOVE(arg2)` degrades from `std::move(arg2)` to plain `arg2`, and the by-value `std::unique_ptr`
parameter is copied.

Measured on the CI toolchain (MSVC 19.38.33145):

| Flags | `__cplusplus` | SWIG emits |
|---|---|---|
| `/std:c++17` | `199711L` | a copy → C2280 |
| `/std:c++17 /Zc:__cplusplus` | `201703L` | `std::move` |

GCC and Clang report `__cplusplus` truthfully and emit `std::move`, which is why only the MSVC Python
wrapping build is affected. It is not that other platforms wrap a different instantiation set.

`GradientImageFilter::SetBoundaryCondition` (added in 62033711d5f) is simply the first wrapped method to take
a `std::unique_ptr` by value, so it is the first to trip a pre-existing gap in the MSVC wrapper flags rather
than the cause of it.

## Fix

Add `/Zc:__cplusplus` to the MSVC wrapper compile flags, alongside the `/wd4244 /wd4996` already there. This
is scoped to the SWIG-generated wrapper sources, so it does not change how ITK itself is compiled, and it
covers any other SWIG feature gated on `__cplusplus` rather than only this call site.

No `.wrap` file or header change is required; the generated `.cpp` is unchanged by this fix.

## Verification

Reproduced and fixed on Windows, MSVC 19.38.33145 (VS 2022, toolset 14.38), Ninja, Release x64, against
`main` at 2bdb783c82.

Before:

```
itkGradientImageFilterPython.cpp(4512): error C2280: ... attempting to reference a deleted function
```

After: `ITKImageGradientPython` builds and links clean — 0 errors, 0 `C2280`, producing
`_ITKImageGradientPython.pyd`. SWIG did not regenerate the `.cpp`; only the compile flags changed, confirming
this is purely a flag defect.

**Scope of verification:** the reproduction used a reduced wrapping configuration
(`Module_ITKImageGradient` only, `ITK_WRAP_float=ON`, `ITK_WRAP_IMAGE_DIMS=2;3`) to keep the turnaround short.
The flag applies to every wrapper target, so a full `ITK_WRAP_PYTHON` build is the appropriate regression
check before merging; that has not been run here.


<details>
<summary>AI assistance</summary>

- Tool: Claude Code (claude-opus-5)
- Role: root-cause analysis, hypothesis testing
- Contribution: traced the `C2280` past the wrapping declarations to
  SWIG's `SWIG_STD_MOVE` guard, and measured `__cplusplus` with and
  without `/Zc:__cplusplus` on the CI toolchain to confirm
- Reproduced and verified locally on Windows/MSVC before committing

</details>
