### PR TITLE
STYLE: Remove int from VectorContainer in comments IsotropicWavelets

### DIFF
--- a/Modules/Filtering/IsotropicWavelets/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkRieszFrequencyFilterBankGenerator.h
@@ -68,7 +68,7 @@ public:
   using FunctionValueType = typename RieszFunctionType::FunctionValueType;
 
   using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  // using OutputsType = typename itk::VectorContainer<OutputImagePointer>;
 
   /** Dimension */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Modules/Filtering/IsotropicWavelets/include/itkStructureTensorImageFilter.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkStructureTensorImageFilter.h
@@ -132,7 +132,7 @@ public:
   using GaussianSourceType = GaussianImageSource<FloatImageType>;
 
   using InputsType = typename std::vector<InputImagePointer>;
-  // using InputsType = typename itk::VectorContainer<int, InputImagePointer>;
+  // using InputsType = typename itk::VectorContainer<InputImagePointer>;
   //
   void
   SetInputs(const InputsType & inputs);

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -79,7 +79,7 @@ public:
   using FunctionValueType = typename WaveletFunctionType::FunctionValueType;
 
   using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  // using OutputsType = typename itk::VectorContainer<OutputImagePointer>;
 
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForward.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForward.h
@@ -67,7 +67,7 @@ public:
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
   using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  // using OutputsType = typename itk::VectorContainer<OutputImagePointer>;
 
   using OutputRegionIterator = typename itk::ImageRegionIterator<OutputImageType>;
   using InputRegionConstIterator = typename itk::ImageRegionConstIterator<InputImageType>;

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyForwardUndecimated.h
@@ -61,7 +61,7 @@ public:
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
   using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  // using OutputsType = typename itk::VectorContainer<OutputImagePointer>;
 
   using OutputRegionIterator = typename itk::ImageRegionIterator<OutputImageType>;
   using InputRegionConstIterator = typename itk::ImageRegionConstIterator<InputImageType>;

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverse.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverse.h
@@ -59,7 +59,7 @@ public:
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
   using InputsType = typename std::vector<InputImagePointer>;
-  // using InputsType = typename itk::VectorContainer<int, InputImagePointer>;
+  // using InputsType = typename itk::VectorContainer<InputImagePointer>;
 
   using WaveletFilterBankType = TWaveletFilterBank;
   using WaveletFilterBankPointer = typename WaveletFilterBankType::Pointer;

--- a/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverseUndecimated.h
+++ b/Modules/Filtering/IsotropicWavelets/include/itkWaveletFrequencyInverseUndecimated.h
@@ -53,7 +53,7 @@ public:
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
   using InputsType = typename std::vector<InputImagePointer>;
-  // using InputsType = typename itk::VectorContainer<int, InputImagePointer>;
+  // using InputsType = typename itk::VectorContainer<InputImagePointer>;
 
   using WaveletFilterBankType = TWaveletFilterBank;
   using WaveletFilterBankPointer = typename WaveletFilterBankType::Pointer;


### PR DESCRIPTION
Removed the `int` template argument from the VectorContainer type aliases in comments in "IsotropicWavelets". The default index type (Identifier Type) is usually preferable for VectorContainer. The default index type does not need to be specified, when using VectorContainer in C++.

- Following pull request #4879 commit c103044a99b70b25dcdd18087e46fe0197b3946f "STYLE: Remove VectorContainer Identifier template argument from comments"