### PR TITLE
ENH: Fix buffer ownership and a redundant copy in SimpleITK interop

### DIFF
--- a/Wrapping/Generators/Python/itk/support/extras.py
+++ b/Wrapping/Generators/Python/itk/support/extras.py
@@ -815,9 +815,11 @@ def image_from_simpleitk(sitk_image) -> itkt.ImageBase:
     Geometry is read in ITK (x, y, z) order, via the order-explicit
     ``spacing_xyz``/``origin_xyz``/``direction_xyz`` keys when the object
     provides them and otherwise via ``GetSpacing()``/``GetOrigin()``/
-    ``GetDirection()``. Pixels are copied through SimpleITK's array API.
-    Multi-component images become an itk.VectorImage. Entries reported by
-    ``GetMetaDataKeys()`` are copied into the MetaDataDictionary.
+    ``GetDirection()``. Pixels are deep-copied into a buffer the returned
+    image owns, so it is independent of ``sitk_image`` and safe for
+    grafting or in-place filters. Multi-component images become an
+    itk.VectorImage. Entries reported by ``GetMetaDataKeys()`` are copied
+    into the MetaDataDictionary.
 
     Parameters
     ----------
@@ -836,9 +838,9 @@ def image_from_simpleitk(sitk_image) -> itkt.ImageBase:
     number_of_components = sitk_image.GetNumberOfComponentsPerPixel()
     is_vector = number_of_components != 1
 
-    array = sitk.GetArrayFromImage(sitk_image)
+    array = sitk.GetArrayViewFromImage(sitk_image)
 
-    l_image = itk.image_view_from_array(array, is_vector=is_vector)
+    l_image = itk.image_from_array(array, is_vector=is_vector)
 
     spacing = _spatial_from_order_explicit(sitk_image, "spacing")
     if spacing is not None:
@@ -879,8 +881,8 @@ def simpleitk_from_image(image: itkt.ImageOrImageSource):
 
     image = itk.output(image)
 
-    # Updates the image, so the regions compared below are the ones just read.
-    array = itk.array_from_image(image)
+    # Updates the image; a view is safe since GetImageFromArray deep-copies.
+    array = itk.array_view_from_image(image)
 
     buffered_region = image.GetBufferedRegion()
     largest_region = image.GetLargestPossibleRegion()


### PR DESCRIPTION
Follow-up to #6811. Fixes buffer-ownership in `image_from_simpleitk` and removes a redundant copy in `simpleitk_from_image`.

`image_from_simpleitk` wrapped a numpy buffer via `image_view_from_array`, giving the itk::Image a pixel container that does not own its memory, which is unsafe for `Graft()` and in-place filters. It now reads pixels with `sitk.GetArrayViewFromImage` (no copy) and builds the ITK image with `itk.image_from_array` (deep copy into an ITK-owned buffer) — same one copy overall, with correct ownership.

`simpleitk_from_image` read the ITK image with `itk.array_from_image` (a deep copy) purely to hand it to `sitk.GetImageFromArray`, which deep-copies again into the buffer the new `sitk.Image` owns. It now reads with `itk.array_view_from_image` instead, dropping the redundant first copy.

<details>
<summary>Why the ownership fix matters</summary>

`image_view_from_array` marks the itk::Image pixel container as not managing its own memory, since it imports a pointer into a numpy-owned buffer. Filters that graft their output onto a pre-existing image, or that reuse/reallocate a buffer in place, assume the container they write into owns its memory. `image_from_array` deep-copies into a container ITK allocates and owns, removing that hazard.

</details>

<details>
<summary>Testing</summary>

`black --target-version py310` and the project pre-commit hooks pass on the changed file. Not exercised against real SimpleITK locally (no SimpleITK/itk build environment available). The in-tree `simpleitk_protocol.py` test does not cover either function directly; per #6811 it stubs only the geometry accessors, by design (round-trip fidelity is owned by an out-of-tree suite).

</details>
