### PR TITLE
BUG: Release ImageIOFactory mutex before probing candidate IOs

### DIFF
--- a/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
+++ b/Modules/IO/ImageBase/src/itkImageIOFactory.cxx
@@ -34,20 +34,26 @@ ImageIOFactory::CreateImageIO(const char * path, IOFileModeEnum mode)
 {
   std::list<ImageIOBase::Pointer> possibleImageIO;
 
-  const std::lock_guard<std::mutex> lockGuard(createImageIOMutex);
-
-  for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkImageIOBase"))
   {
-    auto * io = dynamic_cast<ImageIOBase *>(allobject.GetPointer());
-    if (io)
+    // Lock the mutex while creating all instances of ImageIOBase, to
+    // ensure thread safety during intialization of third-party libraries.
+    const std::lock_guard<std::mutex> lockGuard(createImageIOMutex);
+
+    for (auto & allobject : ObjectFactoryBase::CreateAllInstance("itkImageIOBase"))
     {
-      possibleImageIO.emplace_back(io);
-    }
-    else
-    {
-      std::cerr << "Error ImageIO factory did not return an ImageIOBase: " << allobject->GetNameOfClass() << std::endl;
+      auto * io = dynamic_cast<ImageIOBase *>(allobject.GetPointer());
+      if (io)
+      {
+        possibleImageIO.emplace_back(io);
+      }
+      else
+      {
+        std::cerr << "Error ImageIO factory did not return an ImageIOBase: " << allobject->GetNameOfClass()
+                  << std::endl;
+      }
     }
   }
+
   for (auto & k : possibleImageIO)
   {
     if (mode == IOFileModeEnum::ReadMode)


### PR DESCRIPTION
## Summary

`ImageIOFactory::CreateImageIO()` holds `createImageIOMutex` for its entire body, including the `CanReadFile()`/`CanWriteFile()` probing loop over every registered `ImageIOBase`. Several IO `CanReadFile`/`CanWriteFile` implementations (e.g. `GDCMImageIO`) open and parse the file, so this serializes **every** `ReadImage`/`WriteImage` call in the process — across all images, not just concurrent access to the same file.

Under concurrent reads of many distinct files from many threads, this collapses effective throughput. It can look indistinguishable from a hang once concurrent demand is high enough, since a large number of threads all queue up on this single mutex while only one thread makes progress at a time, each turn potentially doing blocking disk I/O.

This is the same underlying issue behind the intermittent hang in SimpleITK's `Wrapping/Python/tests/ConcurrentImageRead.py` (labeled `UNSTABLE` on macOS). Confirmed with `lldb`: at the moment of the "hang," 70 of 72 worker threads were blocked in `std::mutex::lock()` inside this function, while the lock holder was inside `GDCMImageIO::CanReadFile()`'s `fopen()`.

## Fix

Narrow the lock to only the `ObjectFactoryBase::CreateAllInstance` call that builds the candidate IO list; release it before probing files, so independent reads/writes on different files no longer serialize.

This mirrors the concurrency portion of b5def871167aa14d9886ba63e2315c237524d715 ("ENH: Two-phase ImageIOFactory dispatch via extension check", `main`), backported here as a minimal, behavior-preserving fix for the `release-5.4` branch — without the extension-dispatch API changes from that commit, which aren't appropriate for a stable release branch.

## Test plan

- [ ] Confirm this applies cleanly to `release-5.4` and existing `itkImageIOFactory`/related tests still pass
- [ ] Optionally add a targeted concurrency regression test (a `std::thread`-based stress test reading many distinct files concurrently), mirroring SimpleITK's `ConcurrentImageRead.py`