### PR TITLE
Remove `unsigned short` and IdentifierType arguments from aliases of VectorContainer

### DIFF
--- a/Modules/IO/IOMeshSWC/include/itkSWCMeshIO.h
+++ b/Modules/IO/IOMeshSWC/include/itkSWCMeshIO.h
@@ -153,10 +153,10 @@ public:
   // For Python wrapping
   using ParentIdentifierType = float;
 
-  using SampleIdentifierContainerType = VectorContainer<IdentifierType, SampleIdentifierType>;
-  using TypeIdentifierContainerType = VectorContainer<IdentifierType, TypeIdentifierType>;
-  using RadiusContainerType = VectorContainer<IdentifierType, RadiusType>;
-  using ParentIdentifierContainerType = VectorContainer<IdentifierType, ParentIdentifierType>;
+  using SampleIdentifierContainerType = VectorContainer<SampleIdentifierType>;
+  using TypeIdentifierContainerType = VectorContainer<TypeIdentifierType>;
+  using RadiusContainerType = VectorContainer<RadiusType>;
+  using ParentIdentifierContainerType = VectorContainer<ParentIdentifierType>;
 
   /** Set/Get the sample identifiers. */
   void
@@ -310,8 +310,8 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  using PointsBufferContainerType = VectorContainer<IdentifierType, float>;
-  using CellsBufferContainerType = VectorContainer<IdentifierType, uint32_t>;
+  using PointsBufferContainerType = VectorContainer<float>;
+  using CellsBufferContainerType = VectorContainer<uint32_t>;
   using SampleIdentifierToPointIndexType = std::unordered_map<SampleIdentifierType, IdentifierType>;
   using PointIndexToParentPointIndexType = std::unordered_map<IdentifierType, IdentifierType>;
   using PointIndexToSampleIdentifierType = std::unordered_map<IdentifierType, SampleIdentifierType>;

--- a/Modules/Registration/RANSAC/include/itkLandmarkRegistrationEstimator.h
+++ b/Modules/Registration/RANSAC/include/itkLandmarkRegistrationEstimator.h
@@ -47,8 +47,8 @@ public:
 
   using KdTreeT = KDTreeVectorOfVectorsAdaptor<VectorofVectorsT, double>;
 
-  using PointsLocatorType = itk::PointsLocator<itk::VectorContainer<IdentifierType, itk::Point<double, 3>>>;
-  using PointsContainer = itk::VectorContainer<IdentifierType, itk::Point<double, 3>>;
+  using PointsLocatorType = itk::PointsLocator<itk::VectorContainer<itk::Point<double, 3>>>;
+  using PointsContainer = itk::VectorContainer<itk::Point<double, 3>>;
 
   itkOverrideGetNameOfClassMacro(LandmarkRegistrationEstimator);
   /** New method for creating an object using a factory. */

--- a/Modules/Registration/RANSAC/include/itkRANSAC.hxx
+++ b/Modules/Registration/RANSAC/include/itkRANSAC.hxx
@@ -199,10 +199,10 @@ RANSAC<T, SType, TTransform>::Compute(std::vector<SType> & parameters, double de
 
 
   // STEP3: least squares estimate using largest consensus set and cleanup
-  using PointsLocatorType = itk::PointsLocator<itk::VectorContainer<IdentifierType, itk::Point<double, 3>>>;
+  using PointsLocatorType = itk::PointsLocator<itk::VectorContainer<itk::Point<double, 3>>>;
   auto pointsLocator = PointsLocatorType::New();
 
-  using PointsContainer = itk::VectorContainer<IdentifierType, itk::Point<double, 3>>;
+  using PointsContainer = itk::VectorContainer<itk::Point<double, 3>>;
   auto                  points = PointsContainer::New();
   itk::Point<double, 3> testPoint;
   itk::Point<double, 6> inlierPoint;

--- a/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
+++ b/Modules/Segmentation/Classifiers/include/itkBayesianClassifierInitializationImageFilter.hxx
@@ -78,10 +78,9 @@ BayesianClassifierInitializationImageFilter<TInputImage, TProbabilityPrecisionTy
   using ClassCountArrayType = Array<double>;
 
   using GaussianMembershipFunctionType = Statistics::GaussianMembershipFunction<MeasurementVectorType>;
-  using MeanEstimatorsContainerType =
-    VectorContainer<unsigned short, typename GaussianMembershipFunctionType::MeanVectorType *>;
+  using MeanEstimatorsContainerType = VectorContainer<typename GaussianMembershipFunctionType::MeanVectorType *>;
   using CovarianceEstimatorsContainerType =
-    VectorContainer<unsigned short, typename GaussianMembershipFunctionType::CovarianceMatrixType *>;
+    VectorContainer<typename GaussianMembershipFunctionType::CovarianceMatrixType *>;
 
   // Run k means to get the means from the input image
   auto kmeansFilter = KMeansFilterType::New();


### PR DESCRIPTION
Removed the `unsigned short` template argument from type aliases of VectorContainer in
`BayesianClassifierInitializationImageFilter::InitializeMembershipFunctions()`. The default (`IdentifierType` = `SizeValueType`) is  preferred, and does not need to be specified, explicitly.

Removed the `IdentifierType` template argument from other aliases of VectorContainer, as it is already the default, and it does not need to be specified, explicitly.
