### PR TITLE
BUG: Remove unnecessary global fflush(nullptr) causing MetaIO read deadlocks

### DIFF
--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaForm.cxx
@@ -591,8 +591,6 @@ MetaForm::ReadStream(METAIO_STREAM::ifstream * _stream)
 
   MetaForm::M_Destroy();
 
-  fflush(nullptr);
-
   Clear();
 
   M_SetupReadFields();

--- a/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.cxx
+++ b/Modules/ThirdParty/MetaIO/src/MetaIO/src/metaObject.cxx
@@ -357,8 +357,6 @@ MetaObject::ReadStream(int _nDims, METAIO_STREAM::ifstream * _stream)
 
   MetaObject::M_Destroy();
 
-  fflush(nullptr);
-
   Clear();
 
   M_SetupReadFields();


### PR DESCRIPTION
## Summary

MetaObject::ReadStream() and MetaForm::ReadStream() unconditionally call fflush(nullptr) before parsing header fields. This line dates back to MetaIOs very first file-IO commit, long before multithreading was a design concern for this library.

fflush(NULL) flushes every open FILE* stream in the entire process, not just the one being read. On platforms such as macOS, this requires walking the process-wide list of all open FILE* streams and locking each one in turn (_fwalk -> sflush_locked -> flockfile).

Under heavy concurrent MetaImage/.mha reads (many threads, each opening/reading/closing its own file), this global flush-all creates severe lock contention: every threads fflush(nullptr) call competes to lock every other threads in-flight FILE* handle. In practice this can grind concurrent reads to a halt indefinitely (observed via a native C++ gtest reproducer with 70+ threads reading distinct .mha files concurrently; lldb backtraces showed the large majority of threads parked in flockfile/sflush_locked/_fwalk called from MetaObject::ReadStream).

Reading a file does not require flushing any previously written data (nothing was just written), so this call serves no purpose and can simply be removed.

## Test plan

- [x] Added a native C++ gtest reproducer (ConcurrentImageRead.*, in the companion SimpleITK repo) that spins up ~70 threads each repeatedly reading distinct .mha/.mhd files via itk::simple::ReadImage.
- [x] Confirmed the test reliably hangs/times out on main before this change.
- [x] Confirmed the test passes reliably after removing the two fflush(nullptr) calls, including repeated runs with 2x the stress (more iterations per thread).
- [x] Ruled out several other hypotheses along the way (MetaIOs std::ifstream usage, itk::ImageFileReader::TestFileExistanceAndReadability()s own ifstream probe) via direct experimentation before finding this root cause.
