### PR TITLE
COMP: Fix itkVoxBoCUBImageIO: warning(4): ITK type not wrapped

### DIFF
--- a/Wrapping/Generators/SwigInterface/igenerator.py
+++ b/Wrapping/Generators/SwigInterface/igenerator.py
@@ -531,6 +531,7 @@ class SwigInputGenerator:
         r"itk::ObjectFactoryBasePrivate",
         r"itk::ThreadPoolGlobals",
         r"itk::MultiThreaderBaseGlobals",
+        r"itk::GenericCUBFileAdaptor",  # private implementation detail of VoxBoCUBImageIO
         ".+[(][*][)][(].+",  # functor functions
     ]
 


### PR DESCRIPTION
The full message was:
```log
[9972/10647] Run igenerator.py for ITKReview
itkVoxBoCUBImageIO: warning(4): ITK type not wrapped, or currently not known: itk::GenericCUBFileAdaptor
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
