### PR TITLE
Fix deprecation warning in itk.LabelGeometryImageFilter.hxx

### DIFF
--- a/Utilities/Maintenance/BuildHeaderTest.py
+++ b/Utilities/Maintenance/BuildHeaderTest.py
@@ -58,6 +58,7 @@ BANNED_HEADERS = {
     "QuickView.h",  # Depends on VTK_RENDERING_BACKEND
     "itkBSplineDeformableTransformInitializer.h",
     "VNLSparseLUSolverTraits.h",  # deprecated
+    "itkLabelGeometryImageFilter.h",  # deprecated, triggers MSVC C4996 in its own .hxx
 }
 
 HEADER = """/*=========================================================================


### PR DESCRIPTION
The full message was:
```log
C:\Misc\ITK-patches-dev\Modules\Nonunit\Review\include\itkLabelGeometryImageFilter.hxx(561,73): warning C4996: 'itk::LabelGeometryImageFilter<TLabelImage,TIntensityImage>::LabelPixelType': This class contains known computational bugs. See class documentation for details.
  (compiling source file '../../Nonunit/Review/test/ITKReviewHeaderTest1.cxx')
```

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
