### PR TITLE
COMP: Improve ITKVtkGlue build robustness on Windows and with unusable VTK

### DIFF
--- a/Modules/Bridge/VtkGlue/itk-module-init.cmake
+++ b/Modules/Bridge/VtkGlue/itk-module-init.cmake
@@ -54,4 +54,31 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
   )
 endif()
 
+if(ITK_WRAP_PYTHON)
+  if(NOT VTK_WRAP_PYTHON)
+    message(
+      FATAL_ERROR
+      "ITK_WRAP_PYTHON is ON and Module_ITKVtkGlue is enabled, but the VTK at\n"
+      "  ${VTK_DIR}\n"
+      "was built with VTK_WRAP_PYTHON=OFF. Rebuild VTK with VTK_WRAP_PYTHON=ON,\n"
+      "or set Module_ITKVtkGlue=OFF."
+    )
+  endif()
+  # VTK exports no shared/static variable, so ask an imported target directly.
+  if(TARGET VTK::CommonCore)
+    get_target_property(_vtk_common_core_type VTK::CommonCore TYPE)
+    if(_vtk_common_core_type STREQUAL "STATIC_LIBRARY")
+      message(
+        FATAL_ERROR
+        "ITK_WRAP_PYTHON is ON and Module_ITKVtkGlue is enabled, but the VTK at\n"
+        "  ${VTK_DIR}\n"
+        "is a static build. Its Python wrapping collapses into a single\n"
+        "_vtkmodules_static module that ITK's wrapping cannot import. Rebuild VTK\n"
+        "with BUILD_SHARED_LIBS=ON, or set Module_ITKVtkGlue=OFF."
+      )
+    endif()
+    unset(_vtk_common_core_type)
+  endif()
+endif()
+
 set(ITKVtkGlue_VTK_LIBRARIES ${_required_vtk_libraries})

--- a/Modules/Bridge/VtkGlue/test/CMakeLists.txt
+++ b/Modules/Bridge/VtkGlue/test/CMakeLists.txt
@@ -110,3 +110,19 @@ if(NOT VTK_RENDERING_BACKEND STREQUAL "None")
         REQUIRES_DISPLAY
   )
 endif()
+
+# Windows has no RPATH, so VTK's DLLs must be on PATH at test time.
+if(WIN32 AND TARGET VTK::CommonCore)
+  get_property(_vtkglue_tests DIRECTORY PROPERTY TESTS)
+  if(_vtkglue_tests)
+    set_property(
+      TEST
+        ${_vtkglue_tests}
+      APPEND
+      PROPERTY
+        ENVIRONMENT_MODIFICATION
+          "PATH=path_list_prepend:$<TARGET_FILE_DIR:VTK::CommonCore>"
+    )
+  endif()
+  unset(_vtkglue_tests)
+endif()


### PR DESCRIPTION
Two build-robustness fixes for `ITKVtkGlue`, both from independent Windows validation of #6715 (now merged). Each replaces a failure that surfaces late and cryptically with one that names its remedy.

- **Unusable VTK configurations now fail at configure time** instead of as an `ImportError` when the Python tests run.
- **Windows tests get VTK's DLL directory on `PATH`**, instead of aborting with `STATUS_DLL_NOT_FOUND` before reaching `main`.

<details>
<summary>1. Reject unusable VTK configurations at configure time</summary>

Two VTK shapes were only detected when the Python tests ran:

- **VTK without `VTK_WRAP_PYTHON`** — not caught until an import fails.
- **A static VTK.** Its Python wrapping collapses into a single
  `_vtkmodules_static` module, and the tests die with
  `ImportError: DLL load failed while importing _vtkmodules_static`.
  A shared VTK produces per-module extensions and works.

Both are now checked while configuring, with the remedy named in the message.

VTK exports no shared/static variable — `VTK_BUILD_SHARED_LIBS` is not part of its package — so the imported `VTK::CommonCore` target is queried for its `TYPE` instead. An earlier attempt using the variable produced a false positive on a perfectly good shared VTK, since the undefined variable read as false.

</details>

<details>
<summary>2. VTK's DLL directory on PATH for the Windows tests</summary>

Windows has no RPATH, so the VtkGlue C++ test executables abort with
`0xc0000135` (`STATUS_DLL_NOT_FOUND`) before reaching `main`. ctest reports
only an opaque exit code.

The failure is especially misleading because the *Python* tests pass in the
same run — `itkTestDriver` already sets their environment with
`--add-before-libpath`. So it presents as "C++ broken, Python fine", which
reads like a code defect rather than an environment gap.

`ENVIRONMENT_MODIFICATION` with `path_list_prepend` is applied to every test
registered in the directory, via `get_property(DIRECTORY PROPERTY TESTS)`, so
the conditional rendering tests are covered too. It is `WIN32`-guarded and a
no-op elsewhere. `ENVIRONMENT_MODIFICATION` requires CMake 3.22, and ITK's
`ITK_OLDEST_VALIDATED_POLICIES_VERSION` is 3.22.1, so no version gate is
needed.

</details>

<details>
<summary>Verification</summary>

macOS arm64 against a purpose-built VTK 9.6.2 (non-kit, rendering, Python
wrapped for the same interpreter as ITK):

- Configure succeeds with a valid VTK — the new checks do not false-positive.
- All 12 VtkGlue tests still register and pass, in both
  `ITK_USE_PYTHON_LIMITED_API=OFF` and `=ON`.
- `pre-commit run --all-files` exits 0.

The `VTK_WRAP_PYTHON` check is confirmed to read VTK's real exported value
rather than an empty one: it does not fire on a wrapped VTK, and an undefined
variable would have fired.

The Windows path is not exercised by this verification — the change is
`WIN32`-guarded and was authored from a Windows report, so it needs a Windows
CI run or a manual check to confirm.

</details>

<details>
<summary>Related findings, deliberately not in this PR</summary>

The same Windows validation surfaced three issues that are ITK-wide rather
than VtkGlue-specific, and belong in their own changes:

- **`Module_ITKTestKernel` fails silently without `:BOOL`.** With
  `ITK_BUILD_DEFAULT_MODULES=OFF`, `-DModule_ITKTestKernel=ON` leaves
  `INTERNAL=OFF`; the dependent C++ tests are never created and ctest reports
  100% pass on what remains.
- **Python tests carry the wrong module label.** Every Python test in a build
  here shows `Labels: ITKFFTImageFilterInit Python`. `itk_python_add_test`
  delegates to `itk_add_test`, which labels with `${itk-module}`, and that
  variable is stale in the `Wrapping/Modules/<Name>/test` scope. The effect is
  that `ctest -L ITKVtkGlue` and `ctest -R "VtkGlue|ImageToVTK|VTKImageTo"`
  select *different* sets that both happen to contain 8 tests, which hides the
  discrepancy.
- **The resolved `ITK_USE_PYTHON_LIMITED_API` value is never printed**, though
  it auto-enables by interpreter version.

Also related and already filed: #6846, ITKVtkGlue cannot configure against a
rendering-free VTK because the `VTK_RENDERING_BACKEND` guard tests a VTK 8
variable that VTK 9 never defines.

</details>

<!--
provenance: claude-code session 2026-09-06
origin: Windows 11 / MSVC 19.38 / Ninja validation of #6715 by the reporter
verified_on: macOS arm64, VTK 9.6.2 non-kit + rendering + py3.13.9, 12/12 tests both modes
static_check_impl: get_target_property(VTK::CommonCore TYPE) — VTK exports no shared/static var
windows_change_untested_locally: WIN32-guarded; needs Windows CI or manual confirmation
followups_not_here: Module_ITKTestKernel :BOOL silent failure; itk_python_add_test stale
  ${itk-module} label; print resolved ITK_USE_PYTHON_LIMITED_API
-->
