### PR TITLE
COMP: Label wrapped tests correctly and report the limited-API setting

### DIFF
--- a/CMake/ITKSetPython3Vars.cmake
+++ b/CMake/ITKSetPython3Vars.cmake
@@ -111,6 +111,14 @@ else()
     "SABIModule"
     _SKBUILD_SABI_COMPONENT_REQUIRED
   )
+  # A reconfigure sees the cached value, so remember how it was first set.
+  if(NOT DEFINED ITK_USE_PYTHON_LIMITED_API_WAS_AUTO)
+    if(NOT DEFINED ITK_USE_PYTHON_LIMITED_API)
+      set(ITK_USE_PYTHON_LIMITED_API_WAS_AUTO 1 CACHE INTERNAL "")
+    else()
+      set(ITK_USE_PYTHON_LIMITED_API_WAS_AUTO 0 CACHE INTERNAL "")
+    endif()
+  endif()
   if(NOT DEFINED ITK_USE_PYTHON_LIMITED_API)
     if(
       (
@@ -139,7 +147,28 @@ else()
     endif()
     mark_as_advanced(ITK_USE_PYTHON_LIMITED_API)
   endif()
+  if(ITK_USE_PYTHON_LIMITED_API_WAS_AUTO)
+    set(
+      _itk_limited_api_origin
+      "auto-selected from Python ${ITK_WRAP_PYTHON_VERSION}"
+    )
+  else()
+    set(_itk_limited_api_origin "requested")
+  endif()
   unset(_SKBUILD_SABI_COMPONENT_REQUIRED)
+  # The value auto-enables by interpreter version, so report what was chosen.
+  if(ITK_USE_PYTHON_LIMITED_API)
+    message(
+      STATUS
+      "Python wrapping: limited API (abi3) ON [${_itk_limited_api_origin}]"
+    )
+  else()
+    message(
+      STATUS
+      "Python wrapping: limited API (abi3) OFF [${_itk_limited_api_origin}]"
+    )
+  endif()
+  unset(_itk_limited_api_origin)
   if(ITK_USE_PYTHON_LIMITED_API)
     if(CMAKE_VERSION VERSION_LESS "3.26")
       message(

--- a/Wrapping/macro_files/itk_end_wrap_module.cmake
+++ b/Wrapping/macro_files/itk_end_wrap_module.cmake
@@ -646,6 +646,8 @@ ${DO_NOT_WAIT_FOR_THREADS_CALLS}
   # Add testing
   set(wrapping_test_directory ${CMAKE_CURRENT_SOURCE_DIR}/test)
   if(BUILD_TESTING AND EXISTS ${wrapping_test_directory}/CMakeLists.txt)
+    # itk_add_test labels with ${itk-module}, which is unset in this scope.
+    set(itk-module ${WRAPPER_LIBRARY_NAME})
     add_subdirectory(${wrapping_test_directory})
   endif()
   unset(wrapping_test_directory)


### PR DESCRIPTION
Two build-UX fixes that apply to every wrapped module, split out of the ITKVtkGlue-specific work in #6848. Both come from independent Windows validation of #6715.

- **Wrapped tests now carry their own module's label.** `ctest -L ITKVtkGlue` went from 8 tests to 11 here.
- **The resolved `ITK_USE_PYTHON_LIMITED_API` value is printed**, since it auto-enables by interpreter version.

<details>
<summary>1. Wrapped tests were labelled with the wrong module</summary>

`itk_python_add_test` delegates to `itk_add_test`, which labels a test with `${itk-module}`. That variable is not set in the `Wrapping/Modules/<Name>/test` scope, so every Python test inherited whichever module happened to be configured last — in this build, `ITKFFTImageFilterInit`:

```
Labels: ITKFFTImageFilterInit Python
```

That was true of *every* Python test in the build, not just one module's.

The visible symptom is that the two obvious selectors disagree while both returning the same count, which hides the problem:

```
ctest -L ITKVtkGlue                        -> 8 tests
ctest -R "VtkGlue|ImageToVTK|VTKImageTo"   -> 8 tests   (a different 8)
```

Union is 11. Fixed by setting `itk-module` before the wrapping test directory is added, so `itk_add_test` labels correctly for all modules.

Measured before and after, same configuration:

| | `ctest -L ITKVtkGlue` |
|---|---|
| before | 8 |
| after | **11** |

</details>

<details>
<summary>2. Print the resolved limited-API setting</summary>

`ITK_USE_PYTHON_LIMITED_API` auto-enables from the interpreter version in `ITKSetPython3Vars.cmake`, so "I did not pass it" does not mean OFF. Nothing reported the resolved value, which made it easy to believe a build was testing the opposite mode from the one it was in.

```
-- Python wrapping: limited API (abi3) ON [auto-selected from Python 3.13.9]
-- Python wrapping: limited API (abi3) ON [requested]
```

</details>

<details>
<summary>What was dropped from this PR, and why</summary>

The same Windows report described a third issue: with `ITK_BUILD_DEFAULT_MODULES=OFF`, `-DModule_ITKTestKernel=ON` without the `:BOOL` type leaves the entry `INTERNAL=OFF`, the dependent C++ tests are never created, and ctest reports 100% pass on what remains.

I wrote a configure-time warning for it and then removed it, because **I could not reproduce the underlying condition on current `main`**. In a build with `ITK_BUILD_DEFAULT_MODULES=OFF` and `Module_ITKVtkGlue=ON`, the C++ tests register whether or not `Module_ITKTestKernel:BOOL=ON` is passed. A first attempt at the warning also fired on every dependency-pulled module, which legitimately builds no tests.

Rather than ship a diagnostic for a state I cannot demonstrate, it is left out. If someone can produce a configuration where the tests silently vanish, that belongs in its own issue with the exact flags.

</details>

<details>
<summary>Verification</summary>

macOS arm64, VTK 9.6.2, Python 3.13.9:

- Configure succeeds; `pre-commit run --all-files` exits 0.
- Label change measured against an unpatched build of the same source as a control: 8 before, 11 after.
- Status line verified in both branches of the auto-selection logic.

</details>

<!--
provenance: claude-code session 2026-09-06
origin: Windows 11 / MSVC 19.38 validation of #6715; ITKVtkGlue-specific half is #6848
label_fix: set itk-module before add_subdirectory in itk_end_wrap_module.cmake
control: unpatched build-cv-ON -L ITKVtkGlue = 8; patched = 11
dropped: Module_ITKTestKernel :BOOL warning — condition did not reproduce on current main
-->
