### PR TITLE
COMP: Make SetCoefficientImageInformationFromFixedParameters() final

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -299,7 +299,7 @@ protected:
 private:
   /** Construct control point grid size from transform domain information in the fixed parameters. */
   void
-  SetCoefficientImageInformationFromFixedParameters() override;
+  SetCoefficientImageInformationFromFixedParameters() final;
 
   /** Methods have empty implementations */
   /** @ITKStartGrouping */


### PR DESCRIPTION
Declared the private virtual BSplineTransform member function `SetCoefficientImageInformationFromFixedParameters()` final, to fix a local clang-tidy LLVM 22.1.3 warning, saying:

    Call to virtual method 'BSplineTransform::SetCoefficientImageInformationFromFixedParameters'
    during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]