### PR TITLE
STYLE: Remove SetFixedParameters... functions from BSplineBaseTransform

### DIFF
--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.h
@@ -353,26 +353,6 @@ protected:
   WrapAsImages();
 
 protected:
-  /** Construct control point grid from transform domain information */
-  void
-  SetFixedParametersFromTransformDomainInformation() const;
-
-  /** Construct control point grid size from transform domain information */
-  virtual void
-  SetFixedParametersGridSizeFromTransformDomainInformation() const = 0;
-
-  /** Construct control point grid origin from transform domain information */
-  virtual void
-  SetFixedParametersGridOriginFromTransformDomainInformation() const = 0;
-
-  /** Construct control point grid spacing from transform domain information */
-  virtual void
-  SetFixedParametersGridSpacingFromTransformDomainInformation() const = 0;
-
-  /** Construct control point grid direction from transform domain information */
-  virtual void
-  SetFixedParametersGridDirectionFromTransformDomainInformation() const = 0;
-
   /** Construct control point grid size from transform domain information */
   virtual void
   SetCoefficientImageInformationFromFixedParameters() = 0;

--- a/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineBaseTransform.hxx
@@ -89,28 +89,6 @@ BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::SetParamet
 }
 
 
-template <typename TParametersValueType, unsigned int VDimension, unsigned int VSplineOrder>
-void
-BSplineBaseTransform<TParametersValueType, VDimension, VSplineOrder>::SetFixedParametersFromTransformDomainInformation()
-  const
-{
-  //  Fixed Parameters store the following information:
-  //  Grid Size
-  //  Grid Origin
-  //  Grid Spacing
-  //  Grid Direction
-  //  The size of each of these is equal to VDimension
-
-  this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
-
-  this->SetFixedParametersGridSizeFromTransformDomainInformation();
-  this->SetFixedParametersGridOriginFromTransformDomainInformation();
-  this->SetFixedParametersGridSpacingFromTransformDomainInformation();
-  this->SetFixedParametersGridDirectionFromTransformDomainInformation();
-
-  this->Modified();
-}
-
 /**
  * UpdateTransformParameters
  */

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.h
@@ -324,19 +324,19 @@ protected:
 private:
   /** Construct control point grid size from transform domain information */
   void
-  SetFixedParametersGridSizeFromTransformDomainInformation() const override;
+  SetFixedParametersGridSizeFromTransformDomainInformation() const;
 
   /** Construct control point grid origin from transform domain information */
   void
-  SetFixedParametersGridOriginFromTransformDomainInformation() const override;
+  SetFixedParametersGridOriginFromTransformDomainInformation() const;
 
   /** Construct control point grid spacing from transform domain information */
   void
-  SetFixedParametersGridSpacingFromTransformDomainInformation() const override;
+  SetFixedParametersGridSpacingFromTransformDomainInformation() const;
 
   /** Construct control point grid direction from transform domain information */
   void
-  SetFixedParametersGridDirectionFromTransformDomainInformation() const override;
+  SetFixedParametersGridDirectionFromTransformDomainInformation() const;
 
   /** Construct control point grid size from transform domain information */
   void

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -48,13 +48,13 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::BSpl
   this->m_ValidRegionFirst.Fill(0);
   this->m_ValidRegionLast.Fill(1);
 
-  /** Fixed Parameters store the following information:
-   *     Grid Size
-   *     Grid Origin
-   *     Grid Spacing
-   *     Grid Direction
-   *  The size of these is equal to the  NInputDimensions
-   */
+  //  Fixed Parameters store the following information:
+  //  Grid Size
+  //  Grid Origin
+  //  Grid Spacing
+  //  Grid Direction
+  //  The size of each of these is equal to VDimension
+  //
   // For example 3D image has FixedParameters of:
   // [size[0],size[1],size[2],
   // origin[0],origin[1],origin[2],
@@ -63,7 +63,14 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::BSpl
   // dir[0][1],dir[1][1],dir[2][1],
   // dir[0][2],dir[1][2],dir[2][2]]
 
-  this->SetFixedParametersFromTransformDomainInformation();
+  this->m_FixedParameters.SetSize(VDimension * (VDimension + 3));
+
+  this->SetFixedParametersGridSizeFromTransformDomainInformation();
+  this->SetFixedParametersGridOriginFromTransformDomainInformation();
+  this->SetFixedParametersGridSpacingFromTransformDomainInformation();
+  this->SetFixedParametersGridDirectionFromTransformDomainInformation();
+
+  this->Modified();
 }
 
 // Get the number of parameters

--- a/Modules/Core/Transform/include/itkBSplineTransform.h
+++ b/Modules/Core/Transform/include/itkBSplineTransform.h
@@ -301,21 +301,6 @@ private:
   void
   SetCoefficientImageInformationFromFixedParameters() final;
 
-  /** Methods have empty implementations */
-  /** @ITKStartGrouping */
-  void
-  SetFixedParametersGridSizeFromTransformDomainInformation() const override
-  {}
-  void
-  SetFixedParametersGridOriginFromTransformDomainInformation() const override
-  {}
-  void
-  SetFixedParametersGridSpacingFromTransformDomainInformation() const override
-  {}
-  void
-  SetFixedParametersGridDirectionFromTransformDomainInformation() const override
-  {}
-  /** @ITKEndGrouping */
   /** Check if a continuous index is inside the valid region. */
   bool
   InsideValidRegion(ContinuousIndexType &) const override;


### PR DESCRIPTION
Removed the protected `SetFixedParametersFromTransformDomainInformation()` from BSplineBaseTransform, and moved the code of its implementation into the default-constructor of BSplineDeformableTransform, which was the only place where the function was called.

Removed four protected pure virtual member functions from BSplineBaseTransform:

    SetFixedParametersGridSizeFromTransformDomainInformation()
    SetFixedParametersGridOriginFromTransformDomainInformation()
    SetFixedParametersGridSpacingFromTransformDomainInformation()
    SetFixedParametersGridDirectionFromTransformDomainInformation()

- Left them implemented by BSplineDeformableTransform, but removed their dummy (empty) implementations from BSplineTransform. They were already made empty by pull request #297 commit 794c82d16ebc4b4035f37e0675176e7677f9bd68, Bradley Lowekamp (@blowekamp), 2018.