### PR TITLE
Replace Modified() call in itk::Object, remove Modified() call from BSplineDeformableTransform

### DIFF
--- a/Modules/Core/Common/src/itkObject.cxx
+++ b/Modules/Core/Common/src/itkObject.cxx
@@ -545,7 +545,7 @@ Object::Object()
   : LightObject()
   , m_ObjectName()
 {
-  this->Modified();
+  m_MTime.Modified();
 }
 
 Object::~Object() { itkDebugMacro("Destructing!"); }

--- a/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
+++ b/Modules/Core/Transform/include/itkBSplineDeformableTransform.hxx
@@ -69,8 +69,6 @@ BSplineDeformableTransform<TParametersValueType, VDimension, VSplineOrder>::BSpl
   this->SetFixedParametersGridOriginFromTransformDomainInformation();
   this->SetFixedParametersGridSpacingFromTransformDomainInformation();
   this->SetFixedParametersGridDirectionFromTransformDomainInformation();
-
-  this->Modified();
 }
 
 // Get the number of parameters


### PR DESCRIPTION
- Removed the Modified() call from the default-constructor of BSplineDeformableTransform, as follow-up to pull request #6854
- Replace the Modified() call with `m_MTime.Modified()` in the default-constructor of `itk::Object`. For an Object that is still "under construction", it appears _overdone_ to call `this->Modified()`, because it does not yet have any observer to listen to its `ModifiedEvent`. Moreover, it appears preferable to avoid calling virtual functions within a constructor: C++ Core Guidelines, [Don’t call virtual functions in constructors and destructors](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#rc-ctor-virtual).


----

For the record `Object::Modified()` is defined here: https://github.com/InsightSoftwareConsortium/ITK/blob/fd3b0b4ae9bdda33e878389b34364ad09ffeb1f2/Modules/Core/Common/src/itkObject.cxx#L345-L353

It appears to have overrides at:
```
Modules/Core/ImageAdaptors/include/itkImageAdaptor.h
Modules/Filtering/ImageIntensity/include/itkNormalizeImageFilter.h
Modules/Filtering/MathematicalMorphology/include/itkGrayscaleDilateImageFilter.h
Modules/Filtering/MathematicalMorphology/include/itkGrayscaleErodeImageFilter.h
Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalClosingImageFilter.h
Modules/Filtering/MathematicalMorphology/include/itkGrayscaleMorphologicalOpeningImageFilter.h
Modules/Filtering/MathematicalMorphology/include/itkMorphologicalGradientImageFilter.h
Modules/Filtering/ParabolicMorphology/include/itkBinaryDilateParabolicImageFilter.h
Modules/Filtering/ParabolicMorphology/include/itkBinaryErodeParabolicImageFilter.h
Modules/Filtering/ParabolicMorphology/include/itkMorphologicalDistanceTransformImageFilter.h
Modules/Filtering/ParabolicMorphology/include/itkParabolicOpenCloseSafeBorderImageFilter.h
Modules/Nonunit/Review/include/itkMiniPipelineSeparableImageFilter.h
```