### PR TITLE
Wrap BSplineTransform for 2D-2D and 4D-4D case

### DIFF
--- a/Modules/Core/Transform/wrapping/itkBSplineBaseTransform.wrap
+++ b/Modules/Core/Transform/wrapping/itkBSplineBaseTransform.wrap
@@ -1,5 +1,8 @@
 itk_wrap_class("itk::BSplineBaseTransform" POINTER)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   itk_wrap_template("${ITKM_D}${d}3" "${ITKT_D},${d},3")
+  if (NOT ${d} EQUAL 3)
+    itk_wrap_template("${ITKM_D}${d}${d}" "${ITKT_D},${d},${d}")
+  endif()
 endforeach()
 itk_end_wrap_class()

--- a/Modules/Core/Transform/wrapping/itkBSplineTransform.wrap
+++ b/Modules/Core/Transform/wrapping/itkBSplineTransform.wrap
@@ -1,5 +1,8 @@
 itk_wrap_class("itk::BSplineTransform" POINTER)
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   itk_wrap_template("${ITKM_D}${d}3" "${ITKT_D},${d},3")
+  if (NOT ${d} EQUAL 3)
+    itk_wrap_template("${ITKM_D}${d}${d}" "${ITKT_D},${d},${d}")
+  endif()
 endforeach()
 itk_end_wrap_class()

--- a/Modules/Core/Transform/wrapping/test/CMakeLists.txt
+++ b/Modules/Core/Transform/wrapping/test/CMakeLists.txt
@@ -6,4 +6,17 @@ if(ITK_WRAP_PYTHON)
     ${CMAKE_CURRENT_SOURCE_DIR}/itkTransformSerializationTest.py
     DATA{Baseline/BSplineDeformationTransformDisplacements5.txt}
     ${ITK_EXAMPLE_DATA_ROOT}/DiagonalLines.png)
+
+  itk_python_expression_add_test(
+    NAME PythonInstantiateBSplineTransform2D2D
+    EXPRESSION "t = itk.BSplineTransform[itk.D, 2, 2].New()"
+  )
+
+  list(FIND ITK_WRAP_IMAGE_DIMS 4 wrap_4_index)
+  if(wrap_4_index GREATER -1)
+    itk_python_expression_add_test(
+      NAME PythonInstantiateBSplineTransform4D4D
+      EXPRESSION "t = itk.BSplineTransform[itk.D, 4, 4].New()"
+    )
+  endif()
 endif()

--- a/Wrapping/WrapITKTypes.cmake
+++ b/Wrapping/WrapITKTypes.cmake
@@ -135,8 +135,10 @@ wrap_type("itk::FixedArray" "FA" "itkFixedArray.h")
 set(dims ${ITK_WRAP_IMAGE_DIMS_INCREMENTED})
 foreach(d ${ITK_WRAP_IMAGE_DIMS})
   math(EXPR d2 "${d} * 2")
+
   # for itk::SymmetricSecondRankTensor
   math(EXPR d3 "${d} * (${d} + 1) / 2")
+
   list(
     APPEND
     dims
@@ -149,9 +151,9 @@ endforeach()
 # needs to have defined sizes for:
 # - ITK_WRAP_IMAGE_DIMS_INCREMENTED
 # - ITK_WRAP_VECTOR_COMPONENTS_INCREMENTED
-# Dimensions 1;2;3;4;6 should always be wrapped.
+# Dimensions 1;2;3;4;6;9 should always be wrapped.
 
-unique(array_sizes "${dims};1;2;3;4;6;${ITK_WRAP_VECTOR_COMPONENTS_INCREMENTED}")
+unique(array_sizes "${dims};1;2;3;4;6;9;${ITK_WRAP_VECTOR_COMPONENTS_INCREMENTED}")
 
 # 3-D FixedArrays are required as superclass of rgb pixels
 # TODO: Do we need fixed arrays for all of these types? For just the selected
@@ -178,8 +180,15 @@ foreach(d ${ITK_WRAP_IMAGE_DIMS})
   foreach(i RANGE 1 ${d})
     math(EXPR comp "${comp}*4")
   endforeach()
-  add_template("${ITKM_D}${comp}" "${ITKT_D},${comp}")
-  add_template("${ITKM_UL}${comp}" "${ITKT_UL},${comp}")
+
+  # Check if computed comp dimension has already wrapped above
+  list(FIND array_sizes ${comp} array_sizes_index)
+
+  if(array_sizes_index LESS 0)
+    # Not already in array_sizes
+    add_template("${ITKM_D}${comp}" "${ITKT_D},${comp}")
+    add_template("${ITKM_UL}${comp}" "${ITKT_UL},${comp}")
+  endif()
 endforeach()
 end_wrap_type()
 set(itk_Wrap_FixedArray ${WRAPPER_TEMPLATES})


### PR DESCRIPTION
This is a backport of #6396 to 5.4 release branch.

## PR Checklist
- [x] No [API changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#breaking-changes) were made (or the changes have been approved)
- [x] No [major design changes](https://github.com/InsightSoftwareConsortium/ITK/blob/main/CONTRIBUTING.md#design-changes) were made (or the changes have been approved)
- [x] Added test (or behavior not changed)
- [x] Added Python wrapping to new files (if any) as described in [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf) Section 9.5

